### PR TITLE
fix symlink handling

### DIFF
--- a/pkg/build/base/base.go
+++ b/pkg/build/base/base.go
@@ -93,7 +93,7 @@ func (c *BuildContext) Build() (err error) {
 		buildDir = filepath.Join(buildDir, "images", "base")
 
 	} else {
-		err = fs.CopyDir(c.sourceDir, buildDir)
+		err = fs.Copy(c.sourceDir, buildDir)
 		if err != nil {
 			log.Errorf("failed to copy sources to build dir %v", err)
 			return err

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -149,7 +149,7 @@ func (nh *nodeHandle) CombinedOutputLines(command string, args ...string) ([]str
 func (nh *nodeHandle) CopyTo(source, dest string) error {
 	cmd := exec.Command("docker", "cp")
 	cmd.Args = append(cmd.Args,
-		source, // from the source file
+		source,               // from the source file
 		nh.nameOrID+":"+dest, // to the node, at dest
 	)
 	cmd.InheritOutput = true


### PR DESCRIPTION
 we need to resolve symlinks when staging bits to the docker image builds, this updates the golang filesystem helpers to do that properly 

Fixes flakes when building the node image with bazel-built kubernetes bits
/kind bug
/priority critical-urgent
