### PR TITLE
eliminate test-infra from docker labels and hack scripts

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -37,7 +37,7 @@ cleanup() {
     fi
 }
 
-# install kind to a tempdir GOPATH from this script's test-infra checkout
+# install kind to a tempdir GOPATH from this script's kind checkout
 install_kind() {
     # install `kind` to tempdir
     TMP_DIR=$(mktemp -d)

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -160,7 +160,7 @@ func (c *BuildContext) populateBits(buildDir string) error {
 }
 
 // BuildContainerLabelKey is applied to each build container
-const BuildContainerLabelKey = "io.k8s.test-infra.kind-build"
+const BuildContainerLabelKey = "io.k8s.sigs.kind.build"
 
 // private kube.InstallContext implementation, local to the image build
 type installContext struct {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -33,7 +33,7 @@ import (
 )
 
 // ClusterLabelKey is applied to each "node" docker container for identification
-const ClusterLabelKey = "io.k8s.test-infra.kind-cluster"
+const ClusterLabelKey = "io.k8s.sigs.kind.cluster"
 
 // Context is used to create / manipulate kubernetes-in-docker clusters
 type Context struct {


### PR DESCRIPTION
we still had a few `test-infra`'s in here that aren't related to intentionally linking to test-infra (EG kubetest), this PR fixes those