### PR TITLE
fix node build with prebuilt base image

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -55,10 +55,6 @@ install_kind() {
 
 # build kubernetes / node image, e2e binaries
 build() {
-    # build the base image
-    # TODO(bentheelder): eliminate this once we publish this image
-    kind build base
-
     # possibly enable bazel build caching before building kubernetes
     BAZEL_REMOTE_CACHE_ENABLED=${BAZEL_REMOTE_CACHE_ENABLED:-false}
     if [[ "${BAZEL_REMOTE_CACHE_ENABLED}" == "true" ]]; then

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -307,8 +307,8 @@ func (c *BuildContext) createBuildContainer(buildDir string) (id string, err err
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create build container")
 	}
-	if len(lines) != 1 {
-		return "", fmt.Errorf("invalid container creation output: %v", lines)
+	if len(lines) < 1 {
+		return "", fmt.Errorf("invalid container creation output, must print at least one line")
 	}
-	return lines[0], nil
+	return lines[len(lines)-1], nil
 }


### PR DESCRIPTION
d'oh, the output validation was a little too tight on docker run, this fixes `kind build node`
additionally, stop building the base image when doing conformance e2es