### PR TITLE
image pull fixes

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -94,7 +94,7 @@ create_cluster() {
     # mark the cluster as up for cleanup
     # even if kind create fails, kind delete can clean up after it
     KIND_IS_UP=true
-    kind create
+    kind create --image="kindest/node:latest"
 }
 
 # run e2es with kubetest

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -19,6 +19,8 @@ package docker
 
 import (
 	"strings"
+
+	"sigs.k8s.io/kind/pkg/exec"
 )
 
 // JoinNameAndTag combines a docker image name and tag
@@ -32,4 +34,16 @@ func JoinNameAndTag(name, tag string) string {
 		return name + ":" + tag
 	}
 	return name + tag
+}
+
+// PullIfNotPresent will pull an image if it is not present locally
+// it returns true if it attempted to pull, and any errors from pulling
+func PullIfNotPresent(image string) (pulled bool, err error) {
+	// if this did not return an error, then the image exists locally
+	cmd := exec.Command("docker", "inspect", "--type=image", image)
+	if err := cmd.Run(); err == nil {
+		return false, nil
+	}
+	// otherwise try to pull it
+	return true, exec.Command("docker", "pull", image).Run()
 }

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -73,7 +73,7 @@ func (cmd *Cmd) runLoggingOutputOnFail() error {
 	cmd.Stdout = &buff
 	cmd.Stderr = &buff
 	err := cmd.Cmd.Run()
-	if cmd.LogOutputOnFail {
+	if err != nil && cmd.LogOutputOnFail {
 		log.Error("failed with:")
 		scanner := bufio.NewScanner(&buff)
 		for scanner.Scan() {
@@ -95,12 +95,9 @@ func (cmd *Cmd) CombinedOutputLines() (lines []string, err error) {
 	cmd.Stdout = &buff
 	cmd.Stderr = &buff
 	err = cmd.Cmd.Run()
-	if err != nil {
-		return nil, err
-	}
 	scanner := bufio.NewScanner(&buff)
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}
-	return lines, nil
+	return lines, err
 }


### PR DESCRIPTION
- try to explicitly pre-pull images as these are large
- make sure exec.CombinedOutputLines will return the lines even if the command errors so we can debug stdout / stderr
- make sure image creation failures include the lines
- also ensure the CI e2es are using the locally built image ...

/kind bug