### PR TITLE
Add default storage class

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -257,7 +257,7 @@ func (c *Context) provisionControlPlane(
 	// TODO(bentheelder): support other overlay networks
 	if err = node.Run(
 		"/bin/sh", "-c",
-		`kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"`,
+		`kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version --kubeconfig=/etc/kubernetes/admin.conf | base64 | tr -d '\n')"`,
 	); err != nil {
 		return kubeadmConfig, errors.Wrap(err, "failed to apply overlay network")
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -270,6 +271,14 @@ func (c *Context) provisionControlPlane(
 		); err != nil {
 			return kubeadmConfig, errors.Wrap(err, "failed to remove master taint")
 		}
+	}
+
+	// add the default storage class
+	if err := node.RunWithInput(
+		strings.NewReader(defaultStorageClassManifest),
+		"kubectl", "--kubeconfig=/etc/kubernetes/admin.conf", "apply", "-f", "-",
+	); err != nil {
+		return kubeadmConfig, errors.Wrap(err, "failed to add default storage class")
 	}
 
 	// run any post-overlay hooks

--- a/pkg/cluster/const.go
+++ b/pkg/cluster/const.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+// a default storage class
+// we need this for e2es (StatefulSet)
+const defaultStorageClassManifest = `# host-path based default storage class
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  namespace: kube-system
+  name: standard
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+provisioner: kubernetes.io/host-path`

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -108,6 +109,23 @@ func (nh *nodeHandle) Run(command string, args ...string) error {
 	cmd.Args = append(cmd.Args,
 		args..., // finally, with the args specified
 	)
+	cmd.InheritOutput = true
+	return cmd.Run()
+}
+
+// RunWithInput execs command, args... on the node, hooking input to stdin
+func (nh *nodeHandle) RunWithInput(input io.Reader, command string, args ...string) error {
+	cmd := exec.Command("docker", "exec")
+	cmd.Args = append(cmd.Args,
+		"-i",           // interactive so we can supply input
+		"--privileged", // run with priliges so we can remount etc..
+		nh.nameOrID,    // ... against the "node" container
+		command,        // with the command specified
+	)
+	cmd.Args = append(cmd.Args,
+		args..., // finally, with the args specified
+	)
+	cmd.Stdin = input
 	cmd.InheritOutput = true
 	return cmd.Run()
 }


### PR DESCRIPTION
This should fix https://github.com/kubernetes-sigs/kind/issues/26, and in turn improve the ability to run e2e tests.

TODO: it might be reasonable to allow overriding this. OTOH this can be overridden _after_ the cluster is up anyhow.

I also found and fixed the `The connection to the server localhost:8080 was refused - did you specify the right host or port?` error during bootup, we just needed to supply the kubeconfig to `kubectl version` when installing weave.