### PR TITLE
drop --tag flags

### DIFF
--- a/cmd/kind/build/base/base.go
+++ b/cmd/kind/build/base/base.go
@@ -26,7 +26,6 @@ import (
 type flags struct {
 	Source string
 	Image  string
-	Tag    string
 }
 
 // NewCommand returns a new cobra.Command for building the base image
@@ -41,16 +40,15 @@ func NewCommand() *cobra.Command {
 			run(flags, cmd, args)
 		},
 	}
-	cmd.Flags().StringVar(&flags.Source, "source", "", "path to the base image sources")
 	cmd.Flags().StringVar(
-		&flags.Image, "image",
-		base.DefaultImageName,
-		"name of the resulting image to be built",
+		&flags.Source, "source",
+		"",
+		"path to the base image sources",
 	)
 	cmd.Flags().StringVar(
-		&flags.Tag, "tag",
-		base.DefaultImageTag,
-		"tag of the resulting image to be built",
+		&flags.Image, "image",
+		base.DefaultImage,
+		"name:tag of the resulting image to be built",
 	)
 	return cmd
 }
@@ -58,8 +56,7 @@ func NewCommand() *cobra.Command {
 func run(flags *flags, cmd *cobra.Command, args []string) {
 	// TODO(bentheelder): make this more configurable
 	ctx := base.NewBuildContext(
-		base.WithImageName(flags.Image),
-		base.WithImageTag(flags.Tag),
+		base.WithImage(flags.Image),
 		base.WithSourceDir(flags.Source),
 	)
 	err := ctx.Build()

--- a/cmd/kind/build/node/node.go
+++ b/cmd/kind/build/node/node.go
@@ -24,12 +24,10 @@ import (
 )
 
 type flags struct {
-	Source        string
-	BuildType     string
-	ImageName     string
-	ImageTag      string
-	BaseImageName string
-	BaseImageTag  string
+	Source    string
+	BuildType string
+	Image     string
+	BaseImage string
 }
 
 // NewCommand returns a new cobra.Command for building the node image
@@ -49,24 +47,14 @@ func NewCommand() *cobra.Command {
 		"docker", "build type, one of [bazel, docker, apt]",
 	)
 	cmd.Flags().StringVar(
-		&flags.ImageName, "image",
-		node.DefaultImageName,
-		"name of the resulting image to be built",
+		&flags.Image, "image",
+		node.DefaultImage,
+		"name:tag of the resulting image to be built",
 	)
 	cmd.Flags().StringVar(
-		&flags.ImageTag, "tag",
-		node.DefaultImageTag,
-		"tag of the resulting image to be built",
-	)
-	cmd.Flags().StringVar(
-		&flags.BaseImageName, "base-image",
-		node.DefaultBaseImageName,
-		"name of the base image to use for the build",
-	)
-	cmd.Flags().StringVar(
-		&flags.BaseImageTag, "base-tag",
-		node.DefaultBaseImageTag,
-		"tag of the base image to use for the build",
+		&flags.BaseImage, "base-image",
+		node.DefaultBaseImage,
+		"name:tag of the base image to use for the build",
 	)
 	return cmd
 }
@@ -75,10 +63,8 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 	// TODO(bentheelder): make this more configurable
 	ctx, err := node.NewBuildContext(
 		node.WithMode(flags.BuildType),
-		node.WithImageName(flags.ImageName),
-		node.WithImageTag(flags.ImageTag),
-		node.WithBaseImageName(flags.BaseImageName),
-		node.WithBaseImageTag(flags.BaseImageTag),
+		node.WithImage(flags.Image),
+		node.WithBaseImage(flags.BaseImage),
 	)
 	if err != nil {
 		log.Fatalf("Error creating build context: %v", err)

--- a/hack/build/push-base.sh
+++ b/hack/build/push-base.sh
@@ -37,10 +37,11 @@ KIND="${KIND:-$(get_kind)}"
 # generate tag
 DATE="$(date +v%Y%m%d)"
 TAG="${DATE}-$(git describe --tags --always --dirty)"
+IMAGE="kindest/base:${TAG}"
 
 # build
-(set -x; "${KIND}" build base --tag="${TAG}")
+(set -x; "${KIND}" build base --image="${IMAGE}")
 
 # push
-docker push kindest/base:"${TAG}"
+docker push "${IMAGE}"
 

--- a/hack/build/push-node.sh
+++ b/hack/build/push-node.sh
@@ -40,7 +40,7 @@ TAG="${DATE}-$(git describe --tags --always --dirty)"
 
 # build
 set -x
-"${KIND}" build node --tag="${TAG}" --base-tag="${TAG}"
+"${KIND}" build node --image="kindest/node:${TAG}" --base-image="kindest/base:${TAG}"
 
 # re-tag with kubernetes version
 IMG="kindest/node:${TAG}"

--- a/pkg/build/base/base.go
+++ b/pkg/build/base/base.go
@@ -24,26 +24,20 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kind/pkg/build/base/sources"
-	"sigs.k8s.io/kind/pkg/docker"
 	"sigs.k8s.io/kind/pkg/exec"
 	"sigs.k8s.io/kind/pkg/fs"
 )
 
-// DefaultImageName is the default name of the built base image
-const DefaultImageName = "kindest/base"
-
-// DefaultImageTag is the default tag of the built base image
-const DefaultImageTag = "latest"
+// DefaultImage is the default name:tag of the built base image
+const DefaultImage = "kindest/base:latest"
 
 // BuildContext is used to build the kind node base image, and contains
 // build configuration
 type BuildContext struct {
 	// option fields
 	sourceDir string
-	imageName string
-	imageTag  string
+	image     string
 	// non option fields
-	image string
 	goCmd string // TODO(bentheelder): should be an option possibly
 	arch  string // TODO(bentheelder): should be an option
 }
@@ -58,17 +52,10 @@ func WithSourceDir(sourceDir string) Option {
 	}
 }
 
-// WithImageName configures a NewBuildContext to tag the built image with `name`
-func WithImageName(name string) Option {
+// WithImage configures a NewBuildContext to tag the built image with `name`
+func WithImage(image string) Option {
 	return func(b *BuildContext) {
-		b.imageName = name
-	}
-}
-
-// WithImageTag configures a NewBuildContext to tag the built image with `tag`
-func WithImageTag(tag string) Option {
-	return func(b *BuildContext) {
-		b.imageTag = tag
+		b.image = image
 	}
 }
 
@@ -76,16 +63,13 @@ func WithImageTag(tag string) Option {
 // default configuration
 func NewBuildContext(options ...Option) *BuildContext {
 	ctx := &BuildContext{
-		imageName: DefaultImageName,
-		imageTag:  DefaultImageTag,
-		goCmd:     "go",
-		arch:      "amd64",
+		image: DefaultImage,
+		goCmd: "go",
+		arch:  "amd64",
 	}
 	for _, option := range options {
 		option(ctx)
 	}
-	// normalize name and tag into an image reference
-	ctx.image = docker.JoinNameAndTag(ctx.imageName, ctx.imageTag)
 	return ctx
 }
 

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -18,23 +18,8 @@ limitations under the License.
 package docker
 
 import (
-	"strings"
-
 	"sigs.k8s.io/kind/pkg/exec"
 )
-
-// JoinNameAndTag combines a docker image name and tag
-// The tag may be empty, a tag as in name:tag, or a a sha as in `@sha256:asdf`
-func JoinNameAndTag(name, tag string) string {
-	// Join the name and tag with a colon IFF the tag is not any of:
-	// - empty, in which case we can just the name
-	// - starts with @, this is either a digest, or an invalid value
-	// - starts with :, we can gracefully not double up the :
-	if tag != "" && !strings.HasPrefix(tag, "@") && !strings.HasPrefix(tag, ":") {
-		return name + ":" + tag
-	}
-	return name + tag
-}
 
 // PullIfNotPresent will pull an image if it is not present locally
 // it returns true if it attempted to pull, and any errors from pulling


### PR DESCRIPTION
I think these are just more confusing than having `--image` and `--base-image` tags. normalizing all commands to take `--image` (and `--base-image` for building the node image).