### PR TITLE
disable building the conformance test image

### DIFF
--- a/pkg/build/kube/dockerbuildbits.go
+++ b/pkg/build/kube/dockerbuildbits.go
@@ -108,7 +108,12 @@ func (b *DockerBuildBits) build() error {
 	}
 
 	// build images
-	cmd = exec.Command("make", "quick-release-images", "KUBE_BUILD_HYPERKUBE=n")
+	cmd = exec.Command(
+		"make", "quick-release-images",
+		// we don't want to build these images as we don't use them...
+		"KUBE_BUILD_HYPERKUBE=n",
+		"KUBE_BUILD_CONFORMANCE=n",
+	)
 	cmd.Env = append(cmd.Env, os.Environ()...)
 	cmd.Debug = true
 	cmd.InheritOutput = true


### PR DESCRIPTION
this was recently added upstream, we should explicitly disable it as we don't need it