### PR TITLE
add `kind get kubeconfig-path`

### DIFF
--- a/cmd/kind/get/get.go
+++ b/cmd/kind/get/get.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package get implements the `get` command
+package get
+
+import (
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kind/cmd/kind/get/kubeconfigpath"
+)
+
+// NewCommand returns a new cobra.Command for get
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		// TODO(bentheelder): more detailed usage
+		Use:   "get",
+		Short: "Gets one of [kubeconfig-path]",
+		Long:  "Gets one of [kubeconfig-path]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	// add subcommands
+	cmd.AddCommand(kubeconfigpath.NewCommand())
+	return cmd
+}

--- a/cmd/kind/get/kubeconfigpath/kubeconfigpath.go
+++ b/cmd/kind/get/kubeconfigpath/kubeconfigpath.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubeconfigpath implements the `kubeconfig-path` command
+package kubeconfigpath
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kind/pkg/cluster"
+)
+
+type flags struct {
+	Name string
+}
+
+// NewCommand returns a new cobra.Command for getting the kubeconfig path
+func NewCommand() *cobra.Command {
+	flags := &flags{}
+	cmd := &cobra.Command{
+		// TODO(bentheelder): more detailed usage
+		Use:   "kubeconfig-path",
+		Short: "prints the default kubeconfig path for the kind cluster by --name",
+		Long:  "prints the default kubeconfig path for the kind cluster by --name",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags, cmd, args)
+		},
+	}
+	cmd.Flags().StringVar(
+		&flags.Name,
+		"name",
+		"1",
+		"the cluster context name",
+	)
+	return cmd
+}
+
+func runE(flags *flags, cmd *cobra.Command, args []string) error {
+	ctx, err := cluster.NewContext(flags.Name)
+	if err != nil {
+		return fmt.Errorf("failed to create cluster context! %v", err)
+	}
+	fmt.Println(ctx.KubeConfigPath())
+	return nil
+}

--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/kind/cmd/kind/build"
 	"sigs.k8s.io/kind/cmd/kind/create"
 	"sigs.k8s.io/kind/cmd/kind/delete"
+	"sigs.k8s.io/kind/cmd/kind/get"
 	logutil "sigs.k8s.io/kind/pkg/log"
 )
 
@@ -62,6 +63,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(build.NewCommand())
 	cmd.AddCommand(create.NewCommand())
 	cmd.AddCommand(delete.NewCommand())
+	cmd.AddCommand(get.NewCommand())
 	return cmd
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -133,8 +133,7 @@ func (c *Context) Create(cfg *config.Config) error {
 
 	c.status.End(true)
 	fmt.Printf(
-		"Cluster creation complete. You can now use the cluster with:\n\nexport KUBECONFIG=\"%s\"\nkubectl cluster-info\n",
-		c.KubeConfigPath(),
+		"Cluster creation complete. You can now use the cluster with:\n\nexport KUBECONFIG=\"$(kind get kubeconfig-path)\"\nkubectl cluster-info\n",
 	)
 	return nil
 }


### PR DESCRIPTION
... so users can stop hard-coding the KUBECONFIG path. cc @munnerz @liztio @Katharine