### PR TITLE
Remove existing packages

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -52,8 +52,8 @@ RUN chmod +x /usr/local/bin/clean-install
 RUN clean-install \
       apt-transport-https ca-certificates curl software-properties-common gnupg2 lsb-release \
       systemd systemd-sysv libsystemd0 \
-      iptables iproute2 ethtool socat util-linux mount ebtables udev kmod aufs-tools \
-      bash rsync \
+      iptables iproute2 ethtool socat util-linux ebtables udev kmod aufs-tools \
+      rsync \
     && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-tmpfiles-setup.service" -delete \
     && rm -f /lib/systemd/system/multi-user.target.wants/* \
     && rm -f /etc/systemd/system/*.wants/* \


### PR DESCRIPTION
Because we have changed the base image to `Ubuntu:18.04`, the `bash` and `mount` packages are already existed.

xref:
https://github.com/kubernetes-sigs/kind/pull/89

Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>