### PR TITLE
pkg/cluster: trim the sha digest when showing status

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -110,7 +110,11 @@ func (c *Context) Create(cfg *config.Config) error {
 	c.status.MaybeWrapLogrus(log.StandardLogger())
 
 	defer c.status.End(false)
-	c.status.Start(fmt.Sprintf("Ensuring node image (%s) 🖼", cfg.Image))
+	image := cfg.Image
+	if strings.Contains(image, "@sha256:") {
+		image = strings.Split(image, "@sha256:")[0]
+	}
+	c.status.Start(fmt.Sprintf("Ensuring node image (%s) 🖼", image))
 
 	// attempt to explicitly pull the image if it doesn't exist locally
 	// we don't care if this errors, we'll still try to run which also pulls


### PR DESCRIPTION
If the whole image + tag + sha is printing as status (i.e.
a long line > 80 characters) the status handler will
print each animation frame on new line.

Trim the sha digest to attempt to always fit this status
on a single line.

AFAIK `\r` only works for single lines.

/kind bug
/priority backlog
