### PR TITLE
cmd/kind: add new line after stderr errors

### DIFF
--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -99,7 +99,7 @@ func Main() {
 		ForceColors: logutil.IsTerminal(log.StandardLogger().Out),
 	})
 	if err := Run(); err != nil {
-		os.Stderr.WriteString(err.Error())
+		os.Stderr.WriteString(err.Error() + "\n")
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
with the change:
```
~/go/src/sigs.k8s.io/kind$ go build && ./kind abcdef
Error: unknown command "abcdef" for "kind"
Run 'kind --help' for usage.
unknown command "abcdef" for "kind"
```

without:
```
~/go/src/sigs.k8s.io/kind$ go build && ./kind abcdef
Error: unknown command "abcdef" for "kind"
Run 'kind --help' for usage.
unknown command "abcdef" for "kind"~/go/src/sigs.k8s.io/kind$
```

/priority backlog
/kind bug
