### PR TITLE
refactoring: convert exec.Cmd to an interface, break node logic into …

### DIFF
--- a/pkg/build/base/base.go
+++ b/pkg/build/base/base.go
@@ -121,12 +121,11 @@ func (c *BuildContext) buildEntrypoint(dir string) error {
 
 	cmd := exec.Command(c.goCmd, "build", "-o", entrypointDest, entrypointSrc)
 	// TODO(bentheelder): we may need to map between docker image arch and GOARCH
-	cmd.Env = []string{"GOOS=linux", "GOARCH=" + c.arch}
+	cmd.SetEnv("GOOS=linux", "GOARCH="+c.arch)
 
 	// actually build
 	log.Info("Building entrypoint binary ...")
-	cmd.Debug = true
-	cmd.InheritOutput = true
+	exec.InheritOutput(cmd)
 	if err := cmd.Run(); err != nil {
 		log.Errorf("Entrypoint build Failed! %v", err)
 		return err
@@ -138,10 +137,8 @@ func (c *BuildContext) buildEntrypoint(dir string) error {
 func (c *BuildContext) buildImage(dir string) error {
 	// build the image, tagged as tagImageAs, using the our tempdir as the context
 	cmd := exec.Command("docker", "build", "-t", c.image, dir)
-	cmd.Debug = true
-	cmd.InheritOutput = true
-
 	log.Info("Starting Docker build ...")
+	exec.InheritOutput(cmd)
 	err := cmd.Run()
 	if err != nil {
 		log.Errorf("Docker build Failed! %v", err)

--- a/pkg/build/kube/bazelbuildbits.go
+++ b/pkg/build/kube/bazelbuildbits.go
@@ -57,8 +57,8 @@ func (b *BazelBuildBits) Build() error {
 	defer os.Chdir(cwd)
 
 	// build artifacts
-	cmd := exec.Command("bazel", "build")
-	cmd.Args = append(cmd.Args,
+	cmd := exec.Command(
+		"bazel", "build",
 		// TODO(bentheelder): we assume linux amd64, but we could select
 		// this based on Arch etc. throughout, this flag supports GOOS/GOARCH
 		"--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64",
@@ -68,8 +68,7 @@ func (b *BazelBuildBits) Build() error {
 		//"//cluster/images/hyperkube:hyperkube.tar",
 		"//build:docker-artifacts",
 	)
-	cmd.Debug = true
-	cmd.InheritOutput = true
+	exec.InheritOutput(cmd)
 	if err := cmd.Run(); err != nil {
 		return err
 	}

--- a/pkg/build/kube/version.go
+++ b/pkg/build/kube/version.go
@@ -43,8 +43,7 @@ func buildVersionFile(kubeRoot string) error {
 
 	// get the version output
 	cmd := exec.Command("hack/print-workspace-status.sh")
-	cmd.Debug = true
-	output, err := cmd.CombinedOutputLines()
+	output, err := exec.CombinedOutputLines(cmd)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -201,18 +201,26 @@ func (ic *installContext) BasePath() string {
 }
 
 func (ic *installContext) Run(command string, args ...string) error {
-	cmd := exec.Command("docker", "exec", ic.containerID, command)
-	cmd.Args = append(cmd.Args, args...)
-	cmd.Debug = true
-	cmd.InheritOutput = true
+	cmd := exec.Command(
+		"docker",
+		append(
+			[]string{"exec", ic.containerID, command},
+			args...,
+		)...,
+	)
+	exec.InheritOutput(cmd)
 	return cmd.Run()
 }
 
 func (ic *installContext) CombinedOutputLines(command string, args ...string) ([]string, error) {
-	cmd := exec.Command("docker", "exec", ic.containerID, command)
-	cmd.Args = append(cmd.Args, args...)
-	cmd.Debug = true
-	return cmd.CombinedOutputLines()
+	cmd := exec.Command(
+		"docker",
+		append(
+			[]string{"exec", ic.containerID, command},
+			args...,
+		)...,
+	)
+	return exec.CombinedOutputLines(cmd)
 }
 
 func (c *BuildContext) buildImage(dir string) error {
@@ -238,10 +246,13 @@ func (c *BuildContext) buildImage(dir string) error {
 
 	// helper we will use to run "build steps"
 	execInBuild := func(command ...string) error {
-		cmd := exec.Command("docker", "exec", containerID)
-		cmd.Args = append(cmd.Args, command...)
-		cmd.Debug = true
-		cmd.InheritOutput = true
+		cmd := exec.Command("docker",
+			append(
+				[]string{"exec", containerID},
+				command...,
+			)...,
+		)
+		exec.InheritOutput(cmd)
 		return cmd.Run()
 	}
 
@@ -283,8 +294,7 @@ func (c *BuildContext) buildImage(dir string) error {
 
 	// Save the image changes to a new image
 	cmd := exec.Command("docker", "commit", containerID, c.image)
-	cmd.Debug = true
-	cmd.InheritOutput = true
+	exec.InheritOutput(cmd)
 	if err = cmd.Run(); err != nil {
 		log.Errorf("Image build Failed! %v", err)
 		return err
@@ -305,17 +315,23 @@ func (c *BuildContext) prePullImages(dir, containerID string) error {
 
 	// helpers to run things in the build container
 	execInBuild := func(command ...string) error {
-		cmd := exec.Command("docker", "exec", containerID)
-		cmd.Args = append(cmd.Args, command...)
-		cmd.Debug = true
-		cmd.InheritOutput = true
+		cmd := exec.Command("docker",
+			append(
+				[]string{"exec", containerID},
+				command...,
+			)...,
+		)
+		exec.InheritOutput(cmd)
 		return cmd.Run()
 	}
 	combinedOutputLinesInBuild := func(command ...string) ([]string, error) {
-		cmd := exec.Command("docker", "exec", containerID)
-		cmd.Args = append(cmd.Args, command...)
-		cmd.Debug = true
-		return cmd.CombinedOutputLines()
+		cmd := exec.Command("docker",
+			append(
+				[]string{"exec", containerID},
+				command...,
+			)...,
+		)
+		return exec.CombinedOutputLines(cmd)
 	}
 
 	// get the Kubernetes version we installed on the node

--- a/pkg/cluster/consts/consts.go
+++ b/pkg/cluster/consts/consts.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package consts contains well known constants for kind clusters
+package consts
+
+// ClusterLabelKey is applied to each "node" docker container for identification
+const ClusterLabelKey = "io.k8s.sigs.kind.cluster"

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -75,12 +75,12 @@ var containerIDRegex = regexp.MustCompile("^[a-f0-9]+$")
 // Run creates a container with "docker run", with some error handling
 // it will return the ID of the created container if any, even on error
 func Run(image string, runArgs []string, containerArgs []string) (id string, err error) {
-	cmd := exec.Command("docker", "run")
-	cmd.Args = append(cmd.Args, runArgs...)
-	cmd.Args = append(cmd.Args, image)
-	cmd.Args = append(cmd.Args, containerArgs...)
-	cmd.Debug = true
-	output, err := cmd.CombinedOutputLines()
+	args := []string{"run"}
+	args = append(args, runArgs...)
+	args = append(args, image)
+	args = append(args, containerArgs...)
+	cmd := exec.Command("docker", args...)
+	output, err := exec.CombinedOutputLines(cmd)
 	if err != nil {
 		// log error output if there was any
 		for _, line := range output {

--- a/pkg/exec/local.go
+++ b/pkg/exec/local.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"io"
+	osexec "os/exec"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// LocalCmd wraps os/exec.Cmd, implementing the kind/pkg/exec.Cmd interface
+type LocalCmd struct {
+	*osexec.Cmd
+}
+
+var _ Cmd = &LocalCmd{}
+
+// LocalCmder is a factory for LocalCmd, implementing Cmder
+type LocalCmder struct{}
+
+var _ Cmder = &LocalCmder{}
+
+// Command returns a new exec.Cmd backed by Cmd
+func (c *LocalCmder) Command(name string, arg ...string) Cmd {
+	return &LocalCmd{
+		Cmd: osexec.Command(name, arg...),
+	}
+}
+
+// SetEnv sets env
+func (cmd *LocalCmd) SetEnv(env ...string) {
+	cmd.Env = env
+}
+
+// SetStdin sets stdin
+func (cmd *LocalCmd) SetStdin(r io.Reader) {
+	cmd.Stdin = r
+}
+
+// SetStdout set stdout
+func (cmd *LocalCmd) SetStdout(w io.Writer) {
+	cmd.Stdout = w
+}
+
+// SetStderr sets stderr
+func (cmd *LocalCmd) SetStderr(w io.Writer) {
+	cmd.Stderr = w
+}
+
+// Run runs
+func (cmd *LocalCmd) Run() error {
+	log.Debugf("Running: %v %v", cmd.Path, cmd.Args)
+	return cmd.Cmd.Run()
+}

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -57,6 +57,7 @@ var _ io.Writer = &StatusFriendlyWriter{}
 
 func (ww *StatusFriendlyWriter) Write(p []byte) (n int, err error) {
 	ww.status.spinner.Stop()
+	ww.inner.Write([]byte("\r"))
 	n, err = ww.inner.Write(p)
 	ww.status.spinner.Start()
 	return n, err


### PR DESCRIPTION
…another package

This is the first part of major code cleanup. This will make it possible to test with fake exec later (even if we say, switch to the docker API, we still need to execute some actual commands on the nodes etc.). 

The other plan is to eventually have nodes implement the exec.Cmder and minimize the exposed surface of that logic so we generally have less direct calls to `os/exec.Command` left and right, which should further help with future cleanup ...