### PR TITLE
add `kind export logs`

### DIFF
--- a/cmd/kind/create/cluster/createcluster.go
+++ b/cmd/kind/create/cluster/createcluster.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/kind/pkg/util"
 )
 
-type flags struct {
+type flagpole struct {
 	Name      string
 	Config    string
 	ImageName string
@@ -34,7 +34,7 @@ type flags struct {
 
 // NewCommand returns a new cobra.Command for cluster creation
 func NewCommand() *cobra.Command {
-	flags := &flags{}
+	flags := &flagpole{}
 	cmd := &cobra.Command{
 		// TODO(bentheelder): more detailed usage
 		Use:   "cluster",
@@ -50,7 +50,7 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func run(flags *flags, cmd *cobra.Command, args []string) {
+func run(flags *flagpole, cmd *cobra.Command, args []string) {
 	// TODO(bentheelder): make this more configurable
 	// load the config
 	cfg, err := encoding.Load(flags.Config)

--- a/cmd/kind/export/export.go
+++ b/cmd/kind/export/export.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package export implements the `export` command
+package export
+
+import (
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kind/cmd/kind/export/logs"
+)
+
+// NewCommand returns a new cobra.Command for export
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		// TODO(bentheelder): more detailed usage
+		Use:   "export",
+		Short: "exports one of [logs]",
+		Long:  "exports one of [logs]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	// add subcommands
+	cmd.AddCommand(logs.NewCommand())
+	return cmd
+}

--- a/cmd/kind/export/logs/logs.go
+++ b/cmd/kind/export/logs/logs.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package logs implements the `logs` command
+package logs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kind/pkg/cluster"
+	"sigs.k8s.io/kind/pkg/fs"
+)
+
+type flagpole struct {
+	Name string
+}
+
+// NewCommand returns a new cobra.Command for getting the cluster logs
+func NewCommand() *cobra.Command {
+	flags := &flagpole{}
+	cmd := &cobra.Command{
+		// TODO(bentheelder): more detailed usage
+		Use:   "logs [output-dir]",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "exports logs to to a tempdir or [output-dir] if specified",
+		Long:  "exports logs to to a tempdir or [output-dir] if specified",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags, cmd, args)
+		},
+	}
+	// TODO(bentheelder): this default should be a constant somewhere
+	cmd.Flags().StringVar(&flags.Name, "name", "1", "the cluster context name")
+	return cmd
+}
+
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	// get the optional directory argument, or create a tempdir
+	var dir string
+	if len(args) == 0 {
+		t, err := fs.TempDir("", "")
+		if err != nil {
+			return err
+		}
+		dir = t
+	} else {
+		dir = args[0]
+	}
+	// TODO(bentheelder): NewContext should not return error
+	context, err := cluster.NewContext(flags.Name)
+	if err != nil {
+		return err
+	}
+	err = context.CollectLogs(dir)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Exported logs to: " + dir)
+	return nil
+}

--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/kind/cmd/kind/build"
 	"sigs.k8s.io/kind/cmd/kind/create"
 	"sigs.k8s.io/kind/cmd/kind/delete"
+	"sigs.k8s.io/kind/cmd/kind/export"
 	"sigs.k8s.io/kind/cmd/kind/get"
 	logutil "sigs.k8s.io/kind/pkg/log"
 )
@@ -63,6 +64,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(build.NewCommand())
 	cmd.AddCommand(create.NewCommand())
 	cmd.AddCommand(delete.NewCommand())
+	cmd.AddCommand(export.NewCommand())
 	cmd.AddCommand(get.NewCommand())
 	return cmd
 }

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -4,8 +4,8 @@ A non-exhaustive list of tasks (in no-particular order) includes:
 - [x] basic single "node" clusters
 - [x] multiple clusters per host / named clusters
 - [x] user guide(s)
-  - [ ] more detailed user guides for common usage
-  - [ ] more detailed user guides for more advanced usage
+  - [x] more detailed user guides for common usage
+  - [x] more detailed user guides for more advanced usage
 - [ ] preflight checks [WIP]
 - [ ] multi-node clusters
 - [x] cli command to list clusters
@@ -31,7 +31,7 @@ A non-exhaustive list of tasks (in no-particular order) includes:
 - [ ] support for other CRI within the "node" containers (containerd, cri-o)
 - [ ] move all docker functionality into a common package (`pkg/docker`) [WIP]
  - [ ] potentially move this to using the docker client library
-- [ ] log dumping functionality / cli commands [WIP]
+- [x] log dumping functionality / cli commands
   - [ ] support audit logging
 - [ ] fake out all internals and unit test [WIP]
 - [ ] support for local registries

--- a/pkg/cluster/logs/doc.go
+++ b/pkg/cluster/logs/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package logs contains tooling for obtaining cluster logs
+package logs

--- a/pkg/cluster/logs/logs.go
+++ b/pkg/cluster/logs/logs.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"sigs.k8s.io/kind/pkg/cluster/nodes"
+	"sigs.k8s.io/kind/pkg/exec"
+	"sigs.k8s.io/kind/pkg/util"
+)
+
+type errFn func() error
+
+// Collect collects logs related to / from the cluster nodes and the host
+// system to the specified directory
+func Collect(nodes []nodes.Node, dir string) error {
+	prefixedPath := func(path string) string {
+		return filepath.Join(dir, path)
+	}
+	// helper to run a cmd and write the output to path
+	execToPath := func(cmd exec.Cmd, path string) error {
+		realPath := prefixedPath(path)
+		os.MkdirAll(filepath.Dir(realPath), os.ModePerm)
+		f, err := os.Create(realPath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		cmd.SetStdout(f)
+		cmd.SetStderr(f)
+		return cmd.Run()
+	}
+	execToPathFn := func(cmd exec.Cmd, path string) func() error {
+		return func() error {
+			return execToPath(cmd, path)
+		}
+	}
+	// construct a slice of methods to collect logs
+	fns := []errFn{
+		// TODO(bentheelder): record the kind version here as well
+		// record info about the host docker
+		execToPathFn(
+			exec.Command("docker", "info"),
+			"docker-info.txt",
+		),
+	}
+	// add a log collection method for each node
+	for _, n := range nodes {
+		node := n // https://golang.org/doc/faq#closures_and_goroutines
+		fns = append(fns, func() error {
+			name := node.String()
+			return coalesce(
+				// record info about the node container
+				execToPathFn(
+					exec.Command("docker", "inspect", name),
+					filepath.Join(name, "inspect.json"),
+				),
+				// grab all of the node logs
+				execToPathFn(
+					node.Command("cat", "/kind/version"),
+					filepath.Join(name, "kubernetes-version.txt"),
+				),
+				execToPathFn(
+					node.Command("journalctl", "--no-pager"),
+					filepath.Join(name, "journal.log"),
+				),
+				execToPathFn(
+					node.Command("journalctl", "--no-pager", "-u", "kubelet.service"),
+					filepath.Join(name, "kubelet.log"),
+				),
+				execToPathFn(
+					node.Command("journalctl", "--no-pager", "-u", "docker.service"),
+					filepath.Join(name, "docker.log"),
+				),
+				// grab all container / pod logs
+				// NOTE: we cannot just docker cp this directory because
+				// it is mostly symlinks, so we must list and resolve the symlinks
+				func() error {
+					// collect up file names
+					files, err := exec.CombinedOutputLines(
+						node.Command("find", "-L", "/var/log", "-type", "f"),
+					)
+					if err != nil {
+						return err
+					}
+					// for each file, we want to copy it out at the path
+					// we find it (symlink or not), so we pipe cat in the container
+					// to a file in our logs dir on the host
+					copyFns := []errFn{}
+					for _, f := range files {
+						file := f // https://golang.org/doc/faq#closures_and_goroutines
+						targetPath := strings.TrimPrefix(file, "/var/log/")
+						copyFns = append(copyFns, func() error {
+							return execToPath(
+								node.Command("cat", file),
+								filepath.Join(name, targetPath),
+							)
+						})
+					}
+					return coalesce(copyFns...)
+				},
+			)
+		})
+	}
+	// run and collect up all errors
+	return coalesce(fns...)
+}
+
+// colaese runs fns concurrently, returning an Errors if there are > 1 errors
+func coalesce(fns ...errFn) error {
+	// run all fns concurrently
+	ch := make(chan error, len(fns))
+	var wg sync.WaitGroup
+	for _, fn := range fns {
+		wg.Add(1)
+		go func(f errFn) {
+			defer wg.Done()
+			ch <- f()
+		}(fn)
+	}
+	wg.Wait()
+	close(ch)
+	// collect up and return errors
+	errs := []error{}
+	for err := range ch {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 1 {
+		return util.Flatten(errs)
+	} else if len(errs) == 1 {
+		return errs[0]
+	}
+	return nil
+}

--- a/pkg/docker/cp.go
+++ b/pkg/docker/cp.go
@@ -29,3 +29,13 @@ func CopyTo(hostPath, containerNameOrID, destPath string) error {
 	)
 	return cmd.Run()
 }
+
+// CopyFrom copies the file or dir in the container at srcPath to the host at hostPath
+func CopyFrom(containerNameOrID, srcPath, hostPath string) error {
+	cmd := exec.Command(
+		"docker", "cp",
+		containerNameOrID+":"+srcPath, // from the node, at src
+		hostPath,                      // to the host
+	)
+	return cmd.Run()
+}

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -20,22 +20,20 @@ import "bytes"
 
 // Errors implements error and contains all config errors
 // This is returned by Config.Validate
-type Errors struct {
-	errors []error
-}
+type Errors []error
 
 // NewErrors returns a new Errors from a slice of error
-func NewErrors(errors []error) *Errors {
-	return &Errors{errors}
+func NewErrors(errors []error) Errors {
+	return errors
 }
 
 // assert Errors implements error
-var _ error = &Errors{}
+var _ error = Errors{}
 
 // Error implements the error interface
-func (e *Errors) Error() string {
+func (e Errors) Error() string {
 	var buff bytes.Buffer
-	for _, err := range e.errors {
+	for _, err := range e {
 		buff.WriteString(err.Error())
 		buff.WriteRune('\n')
 	}
@@ -43,6 +41,19 @@ func (e *Errors) Error() string {
 }
 
 // Errors returns the slice of errors contained by Errors
-func (e *Errors) Errors() []error {
-	return e.errors
+func (e Errors) Errors() []error {
+	return e
+}
+
+// Flatten recursively flattens any Errors to a single top level Errors
+func Flatten(errors Errors) Errors {
+	flat := []error{}
+	for _, err := range errors {
+		if v, ok := err.(Errors); ok {
+			flat = append(flat, Flatten(v))
+		} else {
+			flat = append(flat, err)
+		}
+	}
+	return flat
 }


### PR DESCRIPTION
adds snappily fast native log dumping functionality. we should dump more logs later on, but this should be a decent start. fixes #5 

/kind enhancement