### PR TITLE
ensure consistent ownership of the image tarballs

### DIFF
--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -409,6 +409,12 @@ func (c *BuildContext) prePullImages(dir, containerID string) error {
 	if err := execInBuild(movePulled...); err != nil {
 		return err
 	}
+	// make sure we own the tarballs
+	// TODO(bentheelder): someday we might need a different user ...
+	if err = execInBuild("chown", "-R", "root", DockerImageArchives); err != nil {
+		log.Errorf("Image build Failed! %v", err)
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
IE chown them to root when building the node image. related to #124