### PR TITLE
clean up context, flag structs, and runE

### DIFF
--- a/cmd/kind/build/baseimage/baseimage.go
+++ b/cmd/kind/build/baseimage/baseimage.go
@@ -17,7 +17,8 @@ limitations under the License.
 package baseimage
 
 import (
-	log "github.com/sirupsen/logrus"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/build/base"
@@ -36,8 +37,8 @@ func NewCommand() *cobra.Command {
 		Use:   "base-image",
 		Short: "build the base node image",
 		Long:  `build the base node image for running nested containers, systemd, and kubernetes components.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			run(flags, cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags, cmd, args)
 		},
 	}
 	cmd.Flags().StringVar(
@@ -59,8 +60,8 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 		base.WithImage(flags.Image),
 		base.WithSourceDir(flags.Source),
 	)
-	err := ctx.Build()
-	if err != nil {
-		log.Fatalf("Build failed! %v", err)
+	if err := ctx.Build(); err != nil {
+		return fmt.Errorf("build failed: %v", err)
 	}
+	return nil
 }

--- a/cmd/kind/build/baseimage/baseimage.go
+++ b/cmd/kind/build/baseimage/baseimage.go
@@ -23,14 +23,14 @@ import (
 	"sigs.k8s.io/kind/pkg/build/base"
 )
 
-type flags struct {
+type flagpole struct {
 	Source string
 	Image  string
 }
 
 // NewCommand returns a new cobra.Command for building the base image
 func NewCommand() *cobra.Command {
-	flags := &flags{}
+	flags := &flagpole{}
 	cmd := &cobra.Command{
 		// TODO(bentheelder): more detailed usage
 		Use:   "base-image",
@@ -53,7 +53,7 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func run(flags *flags, cmd *cobra.Command, args []string) {
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	// TODO(bentheelder): make this more configurable
 	ctx := base.NewBuildContext(
 		base.WithImage(flags.Image),

--- a/cmd/kind/build/nodeimage/nodeimage.go
+++ b/cmd/kind/build/nodeimage/nodeimage.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/kind/pkg/build/node"
 )
 
-type flags struct {
+type flagpole struct {
 	Source    string
 	BuildType string
 	Image     string
@@ -32,7 +32,7 @@ type flags struct {
 
 // NewCommand returns a new cobra.Command for building the node image
 func NewCommand() *cobra.Command {
-	flags := &flags{}
+	flags := &flagpole{}
 	cmd := &cobra.Command{
 		// TODO(bentheelder): more detailed usage
 		Use:   "node-image",
@@ -59,7 +59,7 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func run(flags *flags, cmd *cobra.Command, args []string) {
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	// TODO(bentheelder): make this more configurable
 	ctx, err := node.NewBuildContext(
 		node.WithMode(flags.BuildType),

--- a/cmd/kind/build/nodeimage/nodeimage.go
+++ b/cmd/kind/build/nodeimage/nodeimage.go
@@ -17,7 +17,8 @@ limitations under the License.
 package nodeimage
 
 import (
-	log "github.com/sirupsen/logrus"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/build/node"
@@ -38,8 +39,8 @@ func NewCommand() *cobra.Command {
 		Use:   "node-image",
 		Short: "build the node image",
 		Long:  "build the node image which contains kubernetes build artifacts and other kind requirements",
-		Run: func(cmd *cobra.Command, args []string) {
-			run(flags, cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags, cmd, args)
 		},
 	}
 	cmd.Flags().StringVar(
@@ -67,10 +68,10 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 		node.WithBaseImage(flags.BaseImage),
 	)
 	if err != nil {
-		log.Fatalf("Error creating build context: %v", err)
+		return fmt.Errorf("error creating build context: %v", err)
 	}
-	err = ctx.Build()
-	if err != nil {
-		log.Fatalf("Error building node image: %v", err)
+	if err := ctx.Build(); err != nil {
+		return fmt.Errorf("error building node image: %v", err)
 	}
+	return nil
 }

--- a/cmd/kind/delete/cluster/deletecluster.go
+++ b/cmd/kind/delete/cluster/deletecluster.go
@@ -18,7 +18,8 @@ limitations under the License.
 package cluster
 
 import (
-	log "github.com/sirupsen/logrus"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cluster"
@@ -37,22 +38,18 @@ func NewCommand() *cobra.Command {
 		Use:   "cluster",
 		Short: "Deletes a cluster",
 		Long:  "Deletes a resource",
-		Run: func(cmd *cobra.Command, args []string) {
-			run(flags, cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags, cmd, args)
 		},
 	}
 	cmd.Flags().StringVar(&flags.Name, "name", "1", "the cluster name")
 	return cmd
 }
 
-func run(flags *flags, cmd *cobra.Command, args []string) {
-	// TODO(bentheelder): make this more configurable
-	ctx, err := cluster.NewContext(flags.Name, false)
-	if err != nil {
-		log.Fatalf("Failed to create cluster context! %v", err)
+func runE(flags *flags, cmd *cobra.Command, args []string) error {
+	ctx := cluster.NewContext(flags.Name)
+	if err := ctx.Delete(); err != nil {
+		return fmt.Errorf("Failed to delete cluster: %v", err)
 	}
-	err = ctx.Delete()
-	if err != nil {
-		log.Fatalf("Failed to delete cluster: %v", err)
-	}
+	return nil
 }

--- a/cmd/kind/delete/cluster/deletecluster.go
+++ b/cmd/kind/delete/cluster/deletecluster.go
@@ -25,14 +25,14 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster"
 )
 
-type flags struct {
+type flagpole struct {
 	Name   string
 	Retain bool
 }
 
 // NewCommand returns a new cobra.Command for cluster creation
 func NewCommand() *cobra.Command {
-	flags := &flags{}
+	flags := &flagpole{}
 	cmd := &cobra.Command{
 		// TODO(bentheelder): more detailed usage
 		Use:   "cluster",
@@ -46,7 +46,7 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func runE(flags *flags, cmd *cobra.Command, args []string) error {
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	ctx := cluster.NewContext(flags.Name)
 	if err := ctx.Delete(); err != nil {
 		return fmt.Errorf("Failed to delete cluster: %v", err)

--- a/cmd/kind/delete/cluster/deletecluster.go
+++ b/cmd/kind/delete/cluster/deletecluster.go
@@ -49,7 +49,7 @@ func NewCommand() *cobra.Command {
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	ctx := cluster.NewContext(flags.Name)
 	if err := ctx.Delete(); err != nil {
-		return fmt.Errorf("Failed to delete cluster: %v", err)
+		return fmt.Errorf("failed to delete cluster: %v", err)
 	}
 	return nil
 }

--- a/cmd/kind/export/logs/logs.go
+++ b/cmd/kind/export/logs/logs.go
@@ -60,13 +60,8 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	} else {
 		dir = args[0]
 	}
-	// TODO(bentheelder): NewContext should not return error
-	context, err := cluster.NewContext(flags.Name, false)
-	if err != nil {
-		return err
-	}
-	err = context.CollectLogs(dir)
-	if err != nil {
+	context := cluster.NewContext(flags.Name)
+	if err := context.CollectLogs(dir); err != nil {
 		return err
 	}
 	fmt.Println("Exported logs to: " + dir)

--- a/cmd/kind/get/kubeconfigpath/kubeconfigpath.go
+++ b/cmd/kind/get/kubeconfigpath/kubeconfigpath.go
@@ -51,10 +51,7 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flags, cmd *cobra.Command, args []string) error {
-	ctx, err := cluster.NewContext(flags.Name, false)
-	if err != nil {
-		return fmt.Errorf("failed to create cluster context! %v", err)
-	}
+	ctx := cluster.NewContext(flags.Name)
 	fmt.Println(ctx.KubeConfigPath())
 	return nil
 }

--- a/cmd/kind/get/kubeconfigpath/kubeconfigpath.go
+++ b/cmd/kind/get/kubeconfigpath/kubeconfigpath.go
@@ -25,13 +25,13 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster"
 )
 
-type flags struct {
+type flagpole struct {
 	Name string
 }
 
 // NewCommand returns a new cobra.Command for getting the kubeconfig path
 func NewCommand() *cobra.Command {
-	flags := &flags{}
+	flags := &flagpole{}
 	cmd := &cobra.Command{
 		// TODO(bentheelder): more detailed usage
 		Use:   "kubeconfig-path",
@@ -50,7 +50,7 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func runE(flags *flags, cmd *cobra.Command, args []string) error {
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	ctx := cluster.NewContext(flags.Name)
 	fmt.Println(ctx.KubeConfigPath())
 	return nil

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -96,7 +96,7 @@ create_cluster() {
     # mark the cluster as up for cleanup
     # even if kind create fails, kind delete can clean up after it
     KIND_IS_UP=true
-    kind create cluster --image="kindest/node:latest"
+    kind create cluster --image="kindest/node:latest" --retain
 }
 
 # run e2es with kubetest

--- a/pkg/cluster/clusters.go
+++ b/pkg/cluster/clusters.go
@@ -30,7 +30,7 @@ func List() ([]Context, error) {
 	}
 	clusters := []Context{}
 	for name := range n {
-		clusters = append(clusters, *newContextNoValidation(name, false))
+		clusters = append(clusters, *NewContext(name))
 	}
 	return clusters, nil
 }

--- a/pkg/cluster/context_test.go
+++ b/pkg/cluster/context_test.go
@@ -18,7 +18,7 @@ package cluster
 
 import "testing"
 
-func TestNewContext(t *testing.T) {
+func TestContextValidate(t *testing.T) {
 	cases := []struct {
 		TestName    string
 		Name        string
@@ -57,7 +57,8 @@ func TestNewContext(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, err := NewContext(tc.Name, false)
+		ctx := NewContext(tc.Name)
+		err := ctx.Validate()
 		// the error can be:
 		// - nil, in which case we should expect no errors or fail
 		if err == nil && tc.ExpectError {


### PR DESCRIPTION
some general code base cleanup:
- all cobra commands should use runE (and return an error) instead of just `run`. this will be helpful later for testing etc.
- all flags structs are `flagpole` (where else would you put flags :stuck_out_tongue:), so as not to have `flags := &flags{}` and other slightly confusing code, this was previously changed in a few places but not all
- cluster.Context validation now only occurs during Create, this allows eg `kind delete`ing a cluster with a previously valid but now invalid context name, or at least attempting to, should we change the validation. it will not allow creating new things with currently invalid names
- the helper functions for `cluster.Context.Create` now use a wrapper type with some extra fields, including the recently added `retain` field, which was moved to there. Context no longer takes a `retain`