### PR TITLE
Add flag to Wait for node to reach ready state

### DIFF
--- a/cmd/kind/create/cluster/createcluster.go
+++ b/cmd/kind/create/cluster/createcluster.go
@@ -19,6 +19,7 @@ package cluster
 
 import (
 	"fmt"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -33,6 +34,7 @@ type flagpole struct {
 	Config    string
 	ImageName string
 	Retain    bool
+	Wait      time.Duration
 }
 
 // NewCommand returns a new cobra.Command for cluster creation
@@ -50,6 +52,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&flags.Config, "config", "", "path to a kind config file")
 	cmd.Flags().StringVar(&flags.ImageName, "image", "", "node docker image to use for booting the cluster")
 	cmd.Flags().BoolVar(&flags.Retain, "retain", false, "retain nodes for debugging when cluster creation fails")
+	cmd.Flags().DurationVar(&flags.Wait, "wait", time.Duration(0), "Wait for control plane node to be ready (default 0s)")
 	return cmd
 }
 
@@ -81,7 +84,7 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("aborting due to invalid configuration")
 		}
 	}
-	if err = ctx.Create(cfg, flags.Retain); err != nil {
+	if err = ctx.Create(cfg, flags.Retain, flags.Wait); err != nil {
 		return fmt.Errorf("failed to create cluster: %v", err)
 	}
 

--- a/docs/user/user-guide.md
+++ b/docs/user/user-guide.md
@@ -35,6 +35,11 @@ For a sample kind configuration file see
 To use a kind configuration file use the `--config` flag and pass the path to
 the file.
 
+If you want the `create cluster` command to block until the control plane
+reaches a ready status, you can use the `--wait` flag and specify a timeout.
+To use `--wait` you must specify the units of the time to wait. For example, to
+wait for 30 seconds, do `--wait 30s`, for 5 minutes do `--wait 5m`, etc.
+
 
 ## Building Images
 


### PR DESCRIPTION
Add --wait flag which will make kind block until the master node of the
cluster reaches a ready state.

Resolves #42

/kind feature

Signed-off-by: Jorge Alarcon Ochoa <alarcj137@gmail.com>