### PR TITLE
fixes command for building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To delete your cluster use `kind delete cluster`
 <!--TODO(bentheelder): improve this part of the guide-->
 To create a cluster from Kubernetes source:
 - ensure that Kubernetes is cloned in `$(go env GOPATH)/src/k8s.io/kubernetes`
-- build a node image and create a cluster with `kind build node-image && kind create cluster`  
+- build a node image and create a cluster with `kind build node-image && kind create cluster --image kindest/node:latest`
 
 For more usage see [the docs][user guide] or run `kind [command] --help`
 


### PR DESCRIPTION
Building without an image flag defaults to a different image (not the one you just built with `kind build node-image`).

This PR adds an image flag so the image built from source is used.