### PR TITLE
README.md: invite reaching out

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ The maintainers of this project are reachable via:
 - [filing an issue] against this repo
 - The Kubernetes [SIG-Testing Mailing List]
 
-Current maintainers (approvers) are [@BenTheElder] and [@munnerz].
+Current maintainers (approvers) are [@BenTheElder] and [@munnerz] - feel free to
+reach out if you have any questions!
 
 Pull Requests are very welcome!  
 See the [issue tracker] if you're unsure where to start, or feel free to reach out to discuss.


### PR DESCRIPTION
... to the maintainers

I read back through the readme tonight, and this jumped out ... I think this is a bit more inviting, which is really what I wanted out of this line. not sure how it got left in the previous state

/cc @munnerz 
