### PR TITLE
Add parameters for node container

### DIFF
--- a/cmd/kind/create/cluster/createcluster.go
+++ b/cmd/kind/create/cluster/createcluster.go
@@ -35,6 +35,7 @@ type flagpole struct {
 	ImageName string
 	Retain    bool
 	Wait      time.Duration
+	Args      string
 }
 
 // NewCommand returns a new cobra.Command for cluster creation
@@ -51,6 +52,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&flags.Name, "name", "1", "cluster context name")
 	cmd.Flags().StringVar(&flags.Config, "config", "", "path to a kind config file")
 	cmd.Flags().StringVar(&flags.ImageName, "image", "", "node docker image to use for booting the cluster")
+	cmd.Flags().StringVar(&flags.Args, "args", "", "additional parameters for launching node container")
 	cmd.Flags().BoolVar(&flags.Retain, "retain", false, "retain nodes for debugging when cluster creation fails")
 	cmd.Flags().DurationVar(&flags.Wait, "wait", time.Duration(0), "Wait for control plane node to be ready (default 0s)")
 	return cmd
@@ -84,7 +86,7 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("aborting due to invalid configuration")
 		}
 	}
-	if err = ctx.Create(cfg, flags.Retain, flags.Wait); err != nil {
+	if err = ctx.Create(cfg, flags.Retain, flags.Wait, flags.Args); err != nil {
 		return fmt.Errorf("failed to create cluster: %v", err)
 	}
 

--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -45,7 +45,7 @@ func getPort() (int, error) {
 // CreateControlPlaneNode `docker run`s the node image, note that due to
 // images/node/entrypoint being the entrypoint, this container will
 // effectively be paused until we call actuallyStartNode(...)
-func CreateControlPlaneNode(name, image, clusterLabel string) (handle *Node, port int, err error) {
+func CreateControlPlaneNode(name, image, clusterLabel string, args []string) (handle *Node, port int, err error) {
 	port, err = getPort()
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "failed to get port for API server")
@@ -79,6 +79,9 @@ func CreateControlPlaneNode(name, image, clusterLabel string) (handle *Node, por
 		// in systems that have userns-remap enabled on the docker daemon
 		runArgs = append(runArgs, "--userns=host")
 	}
+
+	runArgs = append(runArgs, args...)
+
 
 	id, err := docker.Run(
 		image,


### PR DESCRIPTION
What this PR does
---------------------------
Add a parameter to create cluster command for specifying
arguments to be passed to the node container run command.

This allows for example, exposing additional ports, or attaching
additional volumes. This is necessary to complement the ability
to create custom node images.

The 'args' parameter receives a string with the parameters
which are appended to the docker run command used for
launching the node container.

For example the command bellow allows mapping port 8000 
exposed by a custom node image.

`kind create cluster --args "-p 8000:8000`

How to test feature
---------------------------

Create cluster exposing port 2379 (etcd)
`>kind create cluster --args "--expose 2379 -p 2379:2379`

After the cluster has been create, check the port is actually exposed:
`> docker inspect kind-1-control-plane | jq '.[].HostConfig.PortBindings[][].HostPort' | grep -o 2379`
2379

Signed-off-by: Pablo Chacin <pchacin@suse.com>