### PR TITLE
Fix typo in controlPlane JSON tag

### DIFF
--- a/pkg/cluster/config/v1alpha1/types.go
+++ b/pkg/cluster/config/v1alpha1/types.go
@@ -40,7 +40,7 @@ type Config struct {
 	// as patchesJson6902 to `kustomize build`
 	KubeadmConfigPatchesJSON6902 []kustomize.PatchJSON6902 `json:"kubeadmConfigPatchesJson6902,omitempty"`
 	// ControlPlane holds config for the control plane node
-	ControlPlane *ControlPlane `json:"ControlPlane,omitempty"`
+	ControlPlane *ControlPlane `json:"controlPlane,omitempty"`
 }
 
 // ControlPlane holds configurations specific to the control plane nodes


### PR DESCRIPTION
Fix a typo in the Config structure's `controlPlane` field.

I'm not 100% sure how this effects existing users - investigating further...