### PR TITLE
Change ownership of tarballs

### DIFF
--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -420,7 +420,7 @@ func (c *BuildContext) prePullImages(dir, containerID string) error {
 	}
 	// make sure we own the tarballs
 	// TODO(bentheelder): someday we might need a different user ...
-	if err = execInBuild("chown", "-R", "root", DockerImageArchives); err != nil {
+	if err = execInBuild("chown", "-R", "root:root", DockerImageArchives); err != nil {
 		log.Errorf("Image build Failed! %v", err)
 		return err
 	}


### PR DESCRIPTION
This is required in order to let hosts which have userns remap feature
enabled in dockerd to pull the node image.

Currently I get the following output whenever I'm trying to pull the image:

```
$ docker pull kindest/node:v1.13.2
v1.13.2: Pulling from kindest/node
473ede7ed136: Pull complete
c46b5fa4d940: Pull complete
93ae3df89c92: Pull complete
6b1eed27cade: Pull complete
fe9f28e8f84f: Pull complete
9c2e410c2835: Pull complete
333f0a67efb7: Pull complete
b95071799aaf: Pull complete
82e5ba2c4d20: Pull complete
bf7d176ae5bd: Pull complete
2f53f10ec78d: Extracting [==================================================>]  278.1MB/278.1MB
failed to register layer: Error processing tar file(exit status 1): Container ID 89939 cannot be mapped to a host ID
```

On the right you can see that the group is matching the `Container ID` in the above log.

![screen shot 2019-01-17 at 17 18 14](https://user-images.githubusercontent.com/8529459/51332980-1827b380-1a7d-11e9-9b64-c6813ce87d5f.png)

After rebuilding the image using this branch we get the following.

![screen shot 2019-01-17 at 17 30 47](https://user-images.githubusercontent.com/8529459/51333272-ab60e900-1a7d-11e9-8cb0-209cf1cdc28e.png)
