### PR TITLE
cleanup: use `pkg/errors` instead of `fmt.Errorf()` in `/pkg/build` and `/pkg/docker`

### DIFF
--- a/pkg/build/kube/aptbits.go
+++ b/pkg/build/kube/aptbits.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -78,7 +79,7 @@ EOF`
 	// the output should be one line of the form `Kubernetes ${VERSION}`
 	if len(lines) != 1 {
 		log.Errorf("Failed to parse Kubernetes version with unexpected output: %v", lines)
-		return fmt.Errorf("failed to parse Kubernetes version")
+		return errors.New("failed to parse Kubernetes version")
 	}
 	// write version file
 	version := strings.SplitN(lines[0], " ", 2)[1]

--- a/pkg/build/kube/bits.go
+++ b/pkg/build/kube/bits.go
@@ -17,8 +17,9 @@ limitations under the License.
 package kube
 
 import (
-	"fmt"
 	"sync"
+
+	"github.com/pkg/errors"
 )
 
 // Bits provides the locations of Kubernetes Binaries / Images
@@ -61,7 +62,7 @@ func NewNamedBits(name string, kubeRoot string) (bits Bits, err error) {
 	fn, ok := bitsImpls.impls[name]
 	bitsImpls.Unlock()
 	if !ok {
-		return nil, fmt.Errorf("no Bits implementation with name: %s", name)
+		return nil, errors.Errorf("no Bits implementation with name: %s", name)
 	}
 	return fn(kubeRoot)
 }

--- a/pkg/build/kube/source.go
+++ b/pkg/build/kube/source.go
@@ -17,8 +17,9 @@ limitations under the License.
 package kube
 
 import (
-	"fmt"
 	"go/build"
+
+	"github.com/pkg/errors"
 )
 
 // ImportPath is the canonical import path for the kubernetes root package
@@ -32,7 +33,7 @@ func FindSource() (root string, err error) {
 	if err == nil && maybeKubeDir(pkg.Dir) {
 		return pkg.Dir, nil
 	}
-	return "", fmt.Errorf("could not find kubernetes source")
+	return "", errors.New("could not find kubernetes source")
 }
 
 // maybeKubeDir returns true if the dir looks plausibly like a kubernetes

--- a/pkg/build/kube/version.go
+++ b/pkg/build/kube/version.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kube
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -62,7 +61,7 @@ func buildVersionFile(kubeRoot string) error {
 		parts := strings.SplitN(line, " ", 2)
 		if len(parts) != 2 {
 			log.Errorf("Could not parse kubernetes version, output: %s", strings.Join(output, "\n"))
-			return fmt.Errorf("could not parse kubernetes version")
+			return errors.New("could not parse kubernetes version")
 		}
 		if parts[0] == "gitVersion" {
 			if err := ioutil.WriteFile(
@@ -77,7 +76,7 @@ func buildVersionFile(kubeRoot string) error {
 	}
 	if !wroteVersion {
 		log.Errorf("Could not obtain kubernetes version, output: %s", strings.Join(output, "\n"))
-		return fmt.Errorf("could not obtain kubernetes version")
+		return errors.New("could not obtain kubernetes version")
 	}
 	return nil
 }

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -113,7 +113,7 @@ func NewBuildContext(options ...Option) (ctx *BuildContext, err error) {
 		if ctx.mode != "apt" {
 			kubeRoot, err = kube.FindSource()
 			if err != nil {
-				return nil, fmt.Errorf("error finding kuberoot: %v", err)
+				return nil, errors.Wrap(err, "error finding kuberoot")
 			}
 		}
 		ctx.kubeRoot = kubeRoot
@@ -356,7 +356,7 @@ func (c *BuildContext) prePullImages(dir, containerID string) error {
 	}
 	if len(rawVersion) != 1 {
 		log.Errorf("Image build Failed! %v", err)
-		return fmt.Errorf("invalid kubernetes version file")
+		return errors.New("invalid kubernetes version file")
 	}
 
 	// before Kubernetes v1.12.0 kubeadm requires arch specific images, instead

--- a/pkg/docker/archive.go
+++ b/pkg/docker/archive.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+
+	"github.com/pkg/errors"
 )
 
 // GetArchiveTags obtains a list of "repo:tag" docker image tags from a
@@ -45,7 +47,7 @@ func GetArchiveTags(path string) ([]string, error) {
 	for {
 		hdr, err = tr.Next()
 		if err == io.EOF {
-			return nil, fmt.Errorf("could not find image metadata")
+			return nil, errors.New("could not find image metadata")
 		}
 		if err != nil {
 			return nil, err

--- a/pkg/docker/run.go
+++ b/pkg/docker/run.go
@@ -17,9 +17,9 @@ limitations under the License.
 package docker
 
 import (
-	"fmt"
 	"regexp"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kind/pkg/exec"
@@ -47,10 +47,10 @@ func Run(image string, runArgs []string, containerArgs []string) (id string, err
 	// if docker created a container the id will be the first line and match
 	// validate the output and get the id
 	if len(output) < 1 {
-		return "", fmt.Errorf("failed to get container id, received no output from docker run")
+		return "", errors.New("failed to get container id, received no output from docker run")
 	}
 	if !containerIDRegex.MatchString(output[0]) {
-		return "", fmt.Errorf("failed to get container id, output did not match: %v", output)
+		return "", errors.Errorf("failed to get container id, output did not match: %v", output)
 	}
 	return output[0], nil
 }


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/kind/issues/234

/cc @neolit123 