### PR TITLE
New 'zypper' build type

### DIFF
--- a/cmd/kind/build/nodeimage/nodeimage.go
+++ b/cmd/kind/build/nodeimage/nodeimage.go
@@ -18,10 +18,12 @@ package nodeimage
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/build/node"
+	"sigs.k8s.io/kind/pkg/build/kube"
 )
 
 type flagpole struct {
@@ -35,6 +37,7 @@ type flagpole struct {
 // NewCommand returns a new cobra.Command for building the node image
 func NewCommand() *cobra.Command {
 	flags := &flagpole{}
+	builds := fmt.Sprintf("[%s]", strings.Join(kube.GetRegisteredNamedBits(), ","))
 	cmd := &cobra.Command{
 		// TODO(bentheelder): more detailed usage
 		Use:   "node-image",
@@ -46,7 +49,7 @@ func NewCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(
 		&flags.BuildType, "type",
-		"docker", "build type, one of [bazel, docker, apt]",
+		"docker", fmt.Sprintf("build type, one of %s", builds),
 	)
 	cmd.Flags().StringVar(
 		&flags.Image, "image",

--- a/pkg/build/kube/bits.go
+++ b/pkg/build/kube/bits.go
@@ -56,6 +56,7 @@ type InstallContext interface {
 // "apt" -> NewAptBits(kubeRoot)
 // "bazel" -> NewBazelBuildBits(kubeRoot)
 // "docker" or "make" -> NewDockerBuildBits(kubeRoot)
+// "zypper" -> NewZypperBits(kubeRoot)
 func NewNamedBits(name string, kubeRoot string) (bits Bits, err error) {
 	bitsImpls.Lock()
 	fn, ok := bitsImpls.impls[name]
@@ -72,6 +73,17 @@ func RegisterNamedBits(name string, fn func(string) (Bits, error)) {
 	bitsImpls.Lock()
 	bitsImpls.impls[name] = fn
 	bitsImpls.Unlock()
+}
+
+// GetRegisteredNamedBits gets the list of Bits
+func GetRegisteredNamedBits() []string {
+	res := []string{}
+	bitsImpls.Lock()
+	defer bitsImpls.Unlock()
+	for name := range bitsImpls.impls {
+		res = append(res, name)
+	}
+	return res
 }
 
 // NamedBitsRegistered returns true if name is in the registry backing

--- a/pkg/build/kube/zypperbits.go
+++ b/pkg/build/kube/zypperbits.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// the packages repo
+	repo = "https://download.opensuse.org/tumbleweed/repo/oss/"
+
+	// packages necessary to install
+	packages = "kubernetes-kubelet kubernetes-kubeadm kubernetes-client"
+)
+
+// ZypperBits implements Bits for the official upstream openSUSE packages
+type ZypperBits struct {
+}
+
+var _ Bits = &ZypperBits{}
+
+func init() {
+	RegisterNamedBits("zypper", NewZypperBits)
+}
+
+// NewZypperBits returns a new Bits backed by the upstream debian packages
+func NewZypperBits(kubeRoot string) (bits Bits, err error) {
+	return &ZypperBits{}, nil
+}
+
+// Build implements Bits.Build
+// for ZypperBits this does nothing
+func (b *ZypperBits) Build() error {
+	return nil
+}
+
+// Paths implements Bits.Paths
+func (b *ZypperBits) Paths() map[string]string {
+	return map[string]string{}
+}
+
+// Install implements Bits.Install
+func (b *ZypperBits) Install(install InstallContext) error {
+	addRepo := fmt.Sprintf("zypper --non-interactive --gpg-auto-import-keys addrepo %s repo-opensuse", repo)
+	if err := install.Run("/bin/sh", "-c", addRepo); err != nil {
+		log.Errorf("Adding Kubernetes apt repository failed! %v", err)
+		return err
+	}
+	// install packages
+	if err := install.Run("/bin/sh", "-c", fmt.Sprintf("zypper in -y %s", packages)); err != nil {
+		log.Errorf("Installing Kubernetes packages failed! %v", err)
+		return err
+	}
+	// get version for version file
+	lines, err := install.CombinedOutputLines("/bin/sh", "-c", `kubelet --version`)
+	if err != nil {
+		log.Errorf("Failed to get Kubernetes version! %v", err)
+		return err
+	}
+	// the output should be one line of the form `Kubernetes ${VERSION}`
+	if len(lines) != 1 {
+		log.Errorf("Failed to parse Kubernetes version with unexpected output: %v", lines)
+		return fmt.Errorf("failed to parse Kubernetes version")
+	}
+	// write version file
+	version := strings.SplitN(lines[0], " ", 2)[1]
+	if err := install.Run("/bin/sh", "-c", fmt.Sprintf(`echo "%s" >> /kind/version`, version)); err != nil {
+		log.Errorf("Failed to get Kubernetes version! %v", err)
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
New `zypper` build type, for installing packages in openSUSE-based base images with the [`zypper`](https://en.opensuse.org/SDB:Zypper_usage) installer.

This can be used in conjunction with [a Dockerfile for building a openSUSE base image](https://github.com/kubic-project/kubic-init/blob/master/build/kind/base/Dockerfile).