### PR TITLE
Remove dependency constraints on master branches

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,16 +43,3 @@ required = [
 [[constraint]]
   name = "github.com/spf13/cobra"
   version = "0.0.3"
-
-[[constraint]]
-  branch = "master"
-  name = "k8s.io/apimachinery"
-
-[[constraint]]
- name = "k8s.io/code-generator"
- branch = "master"
-
-
-[[constraint]]
-  branch = "master"
-  name = "k8s.io/utils"


### PR DESCRIPTION
This pull request removes the `master` branch constraints specified in the `Gopkg.toml` file. The goal is to simplify dependency management for projects that import `kind` libraries and the constrained dependencies (e.g. the `k8s.io/apimachinery` package). By removing the constraints, users don't have to update their dependencies to satisfy the constraints or provide package overrides.