### PR TITLE
Add cli flags for multinode

### DIFF
--- a/pkg/cluster/config/encoding/scheme.go
+++ b/pkg/cluster/config/encoding/scheme.go
@@ -48,30 +48,56 @@ func AddToScheme(scheme *runtime.Scheme) {
 	utilruntime.Must(scheme.SetVersionPriority(v1alpha2.SchemeGroupVersion))
 }
 
-// Load reads the file at path and attempts to convert into a `kind` Config; the file
-// can be one of the different API versions defined in scheme.
-// If path == "" then the default config is returned
-func Load(path string) (*config.Config, error) {
+// NewConfig returns the default config according to requested number of control-plane
+// and worker nodes
+func NewConfig(controlPlanes, workers int32) (*config.Config, error) {
 	var latestPublicConfig = &v1alpha2.Config{}
 
-	if path != "" {
-		// read in file
-		contents, err := ioutil.ReadFile(path)
-		if err != nil {
-			return nil, err
-		}
-
-		// decode data into a internal api Config object because
-		// to leverage on conversion functions for all the api versions
-		var cfg = &config.Config{}
-		err = runtime.DecodeInto(Codecs.UniversalDecoder(), contents, cfg)
-		if err != nil {
-			return nil, errors.Wrap(err, "decoding failure")
-		}
-
-		// converts back to the latest API version to apply defaults
-		Scheme.Convert(cfg, latestPublicConfig, nil)
+	// create default config according to requested number of control-plane and worker nodes
+	// adds the control-plane node(s)
+	latestPublicConfig.Nodes = append(latestPublicConfig.Nodes, v1alpha2.Node{Role: v1alpha2.ControlPlaneRole, Replicas: &controlPlanes})
+	// if more than one control-plane node(s), automatically add an external load balancer
+	if controlPlanes > 1 {
+		latestPublicConfig.Nodes = append(latestPublicConfig.Nodes, v1alpha2.Node{Role: v1alpha2.ExternalLoadBalancerRole})
 	}
+
+	// adds the worker node(s), if any
+	if workers > 0 {
+		latestPublicConfig.Nodes = append(latestPublicConfig.Nodes, v1alpha2.Node{Role: v1alpha2.WorkerRole, Replicas: &workers})
+	}
+
+	// apply defaults
+	Scheme.Default(latestPublicConfig)
+
+	// converts to internal config
+	var cfg = &config.Config{}
+	Scheme.Convert(latestPublicConfig, cfg, nil)
+
+	// unmarshal the file content into a `kind` Config
+	return cfg, nil
+}
+
+// Load reads the file at path and attempts to convert into a `kind` Config; the file
+// can be one of the different API versions defined in scheme.
+func Load(path string) (*config.Config, error) {
+	// override default config by reading a file
+	latestPublicConfig := &v1alpha2.Config{}
+
+	contents, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// decode data into a internal api Config object because
+	// to leverage on conversion functions for all the api versions
+	var filecfg = &config.Config{}
+	err = runtime.DecodeInto(Codecs.UniversalDecoder(), contents, filecfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "decoding failure")
+	}
+
+	// converts back to the latest API version to apply defaults
+	Scheme.Convert(filecfg, latestPublicConfig, nil)
 
 	// apply defaults
 	Scheme.Default(latestPublicConfig)

--- a/pkg/cluster/config/encoding/scheme_test.go
+++ b/pkg/cluster/config/encoding/scheme_test.go
@@ -18,50 +18,110 @@ package encoding
 
 import (
 	"testing"
+
+	"sigs.k8s.io/kind/pkg/cluster/config"
 )
+
+func TestNewConfig(t *testing.T) {
+	cases := []struct {
+		TestName                 string
+		Path                     string
+		ControlPlaneNodes        int32
+		WorkerNodes              int32
+		ExternaloadBalancerNodes int32
+		ExpectError              bool
+	}{
+		{
+			TestName:          "Defaults",
+			Path:              "",
+			ControlPlaneNodes: 1,
+			ExpectError:       false,
+		},
+		{
+			TestName:          "1 ControlPlaneNodes + n WorkerNodes",
+			Path:              "",
+			ControlPlaneNodes: 1,
+			WorkerNodes:       2,
+			ExpectError:       false,
+		},
+		{
+			TestName:                 "n ControlPlaneNodes",
+			Path:                     "",
+			ControlPlaneNodes:        2,
+			ExternaloadBalancerNodes: 1,
+			ExpectError:              false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.TestName, func(t *testing.T) {
+			cfg, err := NewConfig(c.ControlPlaneNodes, c.WorkerNodes)
+
+			// the error can be:
+			// - nil, in which case we should expect no errors or fail
+			if err != nil {
+				if !c.ExpectError {
+					t.Fatalf("unexpected error while Loading config: %v", err)
+				}
+				return
+			}
+			// - not nil, in which case we should expect errors or fail
+			if err == nil {
+				if c.ExpectError {
+					t.Fatalf("unexpected lack or error while Loading config")
+				}
+			}
+
+			// check the expected nodes are there
+			assertConfigHasNodes(t, cfg, config.ControlPlaneRole, c.ControlPlaneNodes)
+			assertConfigHasNodes(t, cfg, config.ExternalLoadBalancerRole, c.ExternaloadBalancerNodes)
+			assertConfigHasNodes(t, cfg, config.WorkerRole, c.WorkerNodes)
+		})
+	}
+}
 
 func TestLoadCurrent(t *testing.T) {
 	cases := []struct {
-		TestName       string
-		Path           string
-		ExpectReplicas []string
-		ExpectError    bool
+		TestName                       string
+		Path                           string
+		ExpectControlPlaneNodes        int32
+		ExpectWorkerNodes              int32
+		ExpectExternaloadBalancerNodes int32
+		ExpectExternaEtcdNodes         int32
+		ExpectError                    bool
 	}{
 		{
-			TestName:       "no config",
-			Path:           "",
-			ExpectReplicas: []string{"control-plane"}, // no config (empty config path) should return a single node cluster
-			ExpectError:    false,
+			TestName:                "v1alpha1 minimal",
+			Path:                    "./testdata/v1alpha1/valid-minimal.yaml",
+			ExpectControlPlaneNodes: 1,
+			ExpectError:             false,
 		},
 		{
-			TestName:       "v1alpha1 minimal",
-			Path:           "./testdata/v1alpha1/valid-minimal.yaml",
-			ExpectReplicas: []string{"control-plane"},
-			ExpectError:    false,
+			TestName:                "v1alpha1 with lifecyclehooks",
+			Path:                    "./testdata/v1alpha1/valid-with-lifecyclehooks.yaml",
+			ExpectControlPlaneNodes: 1,
+			ExpectError:             false,
 		},
 		{
-			TestName:       "v1alpha1 with lifecyclehooks",
-			Path:           "./testdata/v1alpha1/valid-with-lifecyclehooks.yaml",
-			ExpectReplicas: []string{"control-plane"},
-			ExpectError:    false,
+			TestName:                "v1alpha2 minimal",
+			Path:                    "./testdata/v1alpha2/valid-minimal.yaml",
+			ExpectControlPlaneNodes: 1,
+			ExpectError:             false,
 		},
 		{
-			TestName:       "v1alpha2 minimal",
-			Path:           "./testdata/v1alpha2/valid-minimal.yaml",
-			ExpectReplicas: []string{"control-plane"},
-			ExpectError:    false,
+			TestName:                "v1alpha2 config with 2 nodes",
+			Path:                    "./testdata/v1alpha2/valid-minimal-two-nodes.yaml",
+			ExpectControlPlaneNodes: 1,
+			ExpectWorkerNodes:       1,
+			ExpectError:             false,
 		},
 		{
-			TestName:       "v1alpha2 config with 2 nodes",
-			Path:           "./testdata/v1alpha2/valid-minimal-two-nodes.yaml",
-			ExpectReplicas: []string{"control-plane", "worker"},
-			ExpectError:    false,
-		},
-		{
-			TestName:       "v1alpha2 full HA",
-			Path:           "./testdata/v1alpha2/valid-full-ha.yaml",
-			ExpectReplicas: []string{"etcd", "lb", "control-plane1", "control-plane2", "control-plane3", "worker1", "worker2"},
-			ExpectError:    false,
+			TestName:                       "v1alpha2 full HA",
+			Path:                           "./testdata/v1alpha2/valid-full-ha.yaml",
+			ExpectExternaEtcdNodes:         1,
+			ExpectExternaloadBalancerNodes: 1,
+			ExpectControlPlaneNodes:        3,
+			ExpectWorkerNodes:              2,
+			ExpectError:                    false,
 		},
 		{
 			TestName:    "invalid path",
@@ -86,7 +146,7 @@ func TestLoadCurrent(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.TestName, func(t *testing.T) {
-			_, err := Load(c.Path)
+			cfg, err := Load(c.Path)
 
 			// the error can be:
 			// - nil, in which case we should expect no errors or fail
@@ -102,6 +162,34 @@ func TestLoadCurrent(t *testing.T) {
 					t.Fatalf("unexpected lack or error while Loading config")
 				}
 			}
+
+			assertConfigHasNodes(t, cfg, config.ExternalLoadBalancerRole, c.ExpectExternaloadBalancerNodes)
+			assertConfigHasNodes(t, cfg, config.ExternalEtcdRole, c.ExpectExternaEtcdNodes)
+			assertConfigHasNodes(t, cfg, config.ControlPlaneRole, c.ExpectControlPlaneNodes)
+			assertConfigHasNodes(t, cfg, config.WorkerRole, c.ExpectWorkerNodes)
 		})
+	}
+}
+
+func assertConfigHasNodes(t *testing.T, cfg *config.Config, role config.NodeRole, expectedReplicas int32) {
+	for _, n := range cfg.Nodes {
+		if n.Role != role {
+			continue
+		}
+
+		var actualReplicas int32 = 1
+		if n.Replicas != nil {
+			actualReplicas = *n.Replicas
+		}
+
+		if actualReplicas == expectedReplicas {
+			return
+		}
+
+		t.Fatalf("expected %d replicas with role %s, saw %d", expectedReplicas, role, actualReplicas)
+	}
+
+	if expectedReplicas != 0 {
+		t.Fatalf("config does not have nodes with role %s", role)
 	}
 }


### PR DESCRIPTION
This PR adds CLI flags to change the number of nodes without being forced to use the config files

Fixes: https://github.com/kubernetes-sigs/kind/issues/133