### PR TITLE
implicitly handle load balancers

### DIFF
--- a/pkg/cluster/config/v1alpha2/types.go
+++ b/pkg/cluster/config/v1alpha2/types.go
@@ -28,7 +28,7 @@ type Config struct {
 	// TypeMeta representing the type of the object and its API schema version.
 	metav1.TypeMeta `json:",inline"`
 
-	// nodes constains the list of nodes defined in the `kind` Config
+	// Nodes constains the list of nodes defined in the `kind` Config
 	Nodes []Node `json:"nodes"`
 }
 
@@ -39,7 +39,7 @@ type Node struct {
 	// Replicas is the number of desired node replicas.
 	// Defaults to 1
 	Replicas *int32 `json:"replicas,omitempty"`
-	// Role defines the role of the nodw in the in the Kubernetes cluster managed by `kind`
+	// Role defines the role of the node in the in the Kubernetes cluster managed by `kind`
 	// Defaults to "control-plane"
 	Role NodeRole `json:"role,omitempty"`
 	// Image is the node image to use when running the cluster
@@ -70,7 +70,7 @@ const (
 	ExternalEtcdRole NodeRole = "external-etcd"
 	// ExternalLoadBalancerRole identifies a node that hosts an external load balancer for API server
 	// in HA configurations.
-	// WARNING: this node type is not yet implemented!
-	// Please note that `kind` nodes hosting external load balancer are not kubernetes nodes
+	// If multiple control-plane nodes exists, a node with this role will be added automatically if missing.
+	// Please note that `kind` nodes hosting external load balancer are not Kubernetes nodes.
 	ExternalLoadBalancerRole NodeRole = "external-load-balancer"
 )

--- a/pkg/cluster/config/validate.go
+++ b/pkg/cluster/config/validate.go
@@ -30,7 +30,7 @@ func (c *Config) Validate() error {
 	// All nodes in the config should be valid
 	for i, n := range c.Nodes {
 		if err := n.Validate(); err != nil {
-			errs = append(errs, errors.Errorf("invalid configuration for node %d", i))
+			errs = append(errs, errors.Errorf("invalid configuration for node %d: %v", i, err))
 		}
 	}
 


### PR DESCRIPTION
This preserves load balancers as being part of the node lists,
but makes it possible to handle the case where the user
did not provide a LB in the config.

In such a case the function populateLoadBalancer() adds this "kind node"
automatically.

Includes minor cleanup in types.go and validate.go.

/assign @fabriziopandini @BenTheElder 
/priority important-soon
/kind feature

i'm not particularly happy about this change as is, yet it's not config breaking at this point.

my goal was to get this to unblock my other PR:
https://github.com/kubernetes-sigs/kind/pull/267
related to: #269

so consider this a temporary solution and we can iterate on config changes later.
