### PR TITLE
Pass PROXY environment variables to nodes

### DIFF
--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -19,6 +19,7 @@ package nodes
 import (
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kind/pkg/cluster/config"
@@ -128,6 +129,16 @@ func createNode(name, image, clusterLabel string, role config.NodeRole, extraArg
 		"--label", fmt.Sprintf("%s=%s", constants.ClusterRoleKey, role),
 		// explicitly set the entrypoint
 		"--entrypoint=/usr/local/bin/entrypoint",
+	}
+
+	// pass proxy environment variables to be used by node's docker deamon
+	httpProxy := os.Getenv("HTTP_PROXY")
+	if httpProxy != "" {
+		runArgs = append(runArgs, "-e", "HTTP_PROXY="+httpProxy)
+	}
+	httpsProxy := os.Getenv("HTTPS_PROXY")
+	if httpsProxy != "" {
+		runArgs = append(runArgs, "-e", "HTTPS_PROXY="+httpsProxy)
 	}
 
 	// adds node specific args


### PR DESCRIPTION
Fixes #270 

Pass the environment variables HTTP_PROXY/HTTPS_PROXY from the host environment to the nodes, so that the docker running on the node could download images when running behind a proxy (see issue #136)

Signed-off-by: Pablo Chacin <pchacin@suse.com>