### PR TITLE
add a flag to configure docker network

### DIFF
--- a/cmd/kind/create/cluster/createcluster.go
+++ b/cmd/kind/create/cluster/createcluster.go
@@ -32,6 +32,7 @@ import (
 
 type flagpole struct {
 	Name      string
+	Network   string
 	Config    string
 	ImageName string
 	Retain    bool
@@ -51,6 +52,7 @@ func NewCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flags.Name, "name", cluster.DefaultName, "cluster context name")
+	cmd.Flags().StringVar(&flags.Network, "network", "", "network to use for cluster")
 	cmd.Flags().StringVar(&flags.Config, "config", "", "path to a kind config file")
 	cmd.Flags().StringVar(&flags.ImageName, "image", "", "node docker image to use for booting the cluster")
 	cmd.Flags().BoolVar(&flags.Retain, "retain", false, "retain nodes for debugging when cluster creation fails")
@@ -87,6 +89,9 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 
 	// create a cluster context and create the cluster
 	ctx := cluster.NewContext(flags.Name)
+	if flags.Network != "" {
+		ctx.SetNetwork(flags.Network)
+	}
 	if flags.ImageName != "" {
 		// Apply image override to all the Nodes defined in Config
 		// TODO(fabrizio pandini): this should be reconsidered when implementing

--- a/cmd/kind/create/cluster/createcluster.go
+++ b/cmd/kind/create/cluster/createcluster.go
@@ -52,7 +52,7 @@ func NewCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flags.Name, "name", cluster.DefaultName, "cluster context name")
-	cmd.Flags().StringVar(&flags.Network, "network", "", "network to use for cluster")
+	cmd.Flags().StringVar(&flags.Network, "network", "", "container network to use for cluster")
 	cmd.Flags().StringVar(&flags.Config, "config", "", "path to a kind config file")
 	cmd.Flags().StringVar(&flags.ImageName, "image", "", "node docker image to use for booting the cluster")
 	cmd.Flags().BoolVar(&flags.Retain, "retain", false, "retain nodes for debugging when cluster creation fails")
@@ -88,10 +88,7 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	}
 
 	// create a cluster context and create the cluster
-	ctx := cluster.NewContext(flags.Name)
-	if flags.Network != "" {
-		ctx.SetNetwork(flags.Network)
-	}
+	ctx := cluster.NewContext(flags.Name, cluster.WithNetwork(flags.Network))
 	if flags.ImageName != "" {
 		// Apply image override to all the Nodes defined in Config
 		// TODO(fabrizio pandini): this should be reconsidered when implementing

--- a/pkg/cluster/context.go
+++ b/pkg/cluster/context.go
@@ -54,12 +54,16 @@ const DefaultName = "kind"
 
 // NewContext returns a new cluster management context
 // if name is "" the default name will be used
-func NewContext(name string) *Context {
+func NewContext(name string, options ...Option) *Context {
 	if name == "" {
 		name = DefaultName
 	}
+	var c contextConfig
+	for _, opt := range options {
+		opt(&c)
+	}
 	return &Context{
-		ClusterMeta: meta.NewClusterMeta(name),
+		ClusterMeta: meta.NewClusterMeta(name, c.network),
 	}
 }
 
@@ -206,4 +210,18 @@ func (c *Context) CollectLogs(dir string) error {
 		return err
 	}
 	return logs.Collect(nodes, dir)
+}
+
+type contextConfig struct {
+	network string
+}
+
+// Option allows optional configuration of the cluster context.
+type Option func(*contextConfig)
+
+// WithNetwork sets the container network to be used when creating a cluster.
+func WithNetwork(network string) func(*contextConfig) {
+	return func(c *contextConfig) {
+		c.network = network
+	}
 }

--- a/pkg/cluster/internal/create/createcontext.go
+++ b/pkg/cluster/internal/create/createcontext.go
@@ -126,11 +126,11 @@ func (cc *Context) ProvisionNodes() (nodeList map[string]*nodes.Node, err error)
 
 		switch configNode.Role {
 		case config.ExternalLoadBalancerRole:
-			node, err = nodes.CreateExternalLoadBalancerNode(name, configNode.Image, cc.ClusterLabel())
+			node, err = nodes.CreateExternalLoadBalancerNode(name, configNode.Image, cc.Network(), cc.ClusterLabel())
 		case config.ControlPlaneRole:
-			node, err = nodes.CreateControlPlaneNode(name, configNode.Image, cc.ClusterLabel())
+			node, err = nodes.CreateControlPlaneNode(name, configNode.Image, cc.Network(), cc.ClusterLabel())
 		case config.WorkerRole:
-			node, err = nodes.CreateWorkerNode(name, configNode.Image, cc.ClusterLabel())
+			node, err = nodes.CreateWorkerNode(name, configNode.Image, cc.Network(), cc.ClusterLabel())
 		}
 		if err != nil {
 			return nodeList, err

--- a/pkg/cluster/internal/meta/meta.go
+++ b/pkg/cluster/internal/meta/meta.go
@@ -29,7 +29,8 @@ import (
 // cluster metadata
 // See: NewClusterMeta
 type ClusterMeta struct {
-	name string
+	name    string
+	network string
 }
 
 // NewClusterMeta returns a new cluster meta
@@ -42,6 +43,14 @@ func NewClusterMeta(name string) *ClusterMeta {
 // Name returns the cluster's name
 func (c *ClusterMeta) Name() string {
 	return c.name
+}
+
+func (c *ClusterMeta) Network() string {
+	return c.network
+}
+
+func (c *ClusterMeta) SetNetwork(network string) {
+	c.network = network
 }
 
 // KubeConfigPath returns the path to where the Kubeconfig would be placed

--- a/pkg/cluster/internal/meta/meta.go
+++ b/pkg/cluster/internal/meta/meta.go
@@ -34,9 +34,10 @@ type ClusterMeta struct {
 }
 
 // NewClusterMeta returns a new cluster meta
-func NewClusterMeta(name string) *ClusterMeta {
+func NewClusterMeta(name, network string) *ClusterMeta {
 	return &ClusterMeta{
-		name: name,
+		name:    name,
+		network: network,
 	}
 }
 
@@ -45,12 +46,9 @@ func (c *ClusterMeta) Name() string {
 	return c.name
 }
 
+// Network returns the cluster's container network
 func (c *ClusterMeta) Network() string {
 	return c.network
-}
-
-func (c *ClusterMeta) SetNetwork(network string) {
-	c.network = network
 }
 
 // KubeConfigPath returns the path to where the Kubeconfig would be placed

--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -63,7 +63,6 @@ func CreateControlPlaneNode(name, image, network, clusterLabel string) (node *No
 	if network != "" {
 		extraArgs = append(extraArgs, "--network", network)
 	}
-
 	node, err = createNode(name, image, clusterLabel, config.ControlPlaneRole, extraArgs...)
 	if err != nil {
 		return node, err
@@ -92,7 +91,6 @@ func CreateExternalLoadBalancerNode(name, image, network, clusterLabel string) (
 	if network != "" {
 		extraArgs = append(extraArgs, "--network", network)
 	}
-
 	node, err = createNode(name, image, clusterLabel, config.ExternalLoadBalancerRole, extraArgs...)
 	if err != nil {
 		return node, err


### PR DESCRIPTION
I've implemented a minimal solution for adding a docker network.
This adds a flag `--network` to the create cluster command.

It will error if the network doesn't exist.
If the network flag is not passed it uses the default bridge network.

We can work from here on design and implementation.

resolves #273