### PR TITLE
Support for CNCF containernetworking plugins

### DIFF
--- a/docs/user/kind-bridge-ipv4-config.yaml
+++ b/docs/user/kind-bridge-ipv4-config.yaml
@@ -1,0 +1,41 @@
+# this config file contains all config fields with comments
+kind: Config
+apiVersion: kind.sigs.k8s.io/v1alpha2
+# 1 control plane node and 3 workers
+nodes:
+# the control plane node config
+- role: control-plane
+  cni: cncf-containernetworking-plugin
+  cniConfigFileName: 100-bridge.conf
+  cniConfig:
+  - |
+    {
+        "cniVersion": "0.3.0",
+        "name": "mynet",
+        "type": "bridge",
+        "bridge": "cni0",
+        "isDefaultGateway": true,
+        "ipMasq": true,
+        "ipam": {
+            "type": "host-local",
+            "subnet": "10.0.0.0/16"
+        }
+    }
+  # patch the generated kubeadm config with some extra settings
+  kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta1
+    kind: ClusterConfiguration
+    networking:
+      serviceSubnet: 192.168.0.0/16
+      podSubnet: 10.0.0.0/10
+  # patch it further using a JSON 6902 patch
+  kubeadmConfigPatchesJson6902:
+  - group: kubeadm.k8s.io
+    version: v1beta1
+    kind: ClusterConfiguration
+    patch: |
+      - op: add
+        path: /apiServer/certSANs/-
+        value: my-hostname
+

--- a/pkg/cluster/config/types.go
+++ b/pkg/cluster/config/types.go
@@ -43,6 +43,12 @@ type Node struct {
 	// Role defines the role of the nodw in the in the Kubernetes cluster managed by `kind`
 	// Defaults to "control-plane"
 	Role NodeRole
+	// CNI is the name of the desired network plugin
+	CNI string
+	// CNIConfigFIleName is the name of the config file that will be placed in /etc/cni/net.d
+	CNIConfigFileName string
+	// CNIConfig is the actual content inside the cni config file.
+	CNIConfig []string
 	// Image is the node image to use when running the cluster
 	// TODO(bentheelder): split this into image and tag?
 	Image string
@@ -74,4 +80,6 @@ const (
 	// WARNING: this node type is not yet implemented!
 	// Please note that `kind` nodes hosting external load balancer are not kubernetes nodes
 	ExternalLoadBalancerRole NodeRole = "external-load-balancer"
+	// Default path where the CNI configuration(s) are placed.
+	CNIConfigPath = "/etc/cni/net.d/"
 )

--- a/pkg/cluster/config/v1alpha2/types.go
+++ b/pkg/cluster/config/v1alpha2/types.go
@@ -42,6 +42,12 @@ type Node struct {
 	// Role defines the role of the nodw in the in the Kubernetes cluster managed by `kind`
 	// Defaults to "control-plane"
 	Role NodeRole `json:"role,omitempty"`
+	// CNI is the name of the desired network plugin
+	CNI string `json:"cni,omitempty"`
+	// CNIConfigFIleName is the name of the config file that will be placed in /etc/cni/net.d
+	CNIConfigFileName string `json:"cniConfigFileName,omitempty"`
+	// CNIConfig is the actual content inside the cni config file.
+	CNIConfig []string `json:"cniConfig,omitempty"`
 	// Image is the node image to use when running the cluster
 	// TODO(bentheelder): split this into image and tag?
 	Image string `json:"image,omitempty"`

--- a/pkg/cluster/nodes/node.go
+++ b/pkg/cluster/nodes/node.go
@@ -96,6 +96,10 @@ func (n *Node) CopyFrom(source, dest string) error {
 	return docker.CopyFrom(n.nameOrID, source, dest)
 }
 
+func (n *Node) MkDirPath(dirPath string) error {
+	return docker.MkDirPath(dirPath, n.nameOrID)
+}
+
 // WaitForDocker waits for Docker to be ready on the node
 // it returns true on success, and false on a timeout
 func (n *Node) WaitForDocker(until time.Time) bool {

--- a/pkg/docker/mkdir.go
+++ b/pkg/docker/mkdir.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+// MkDirPath makes the directory path in the container
+func MkDirPath(dirPath, containerNameOrID string) error {
+	cmd := exec.Command(
+		"docker", "exec",
+		containerNameOrID,
+		"mkdir", "-p",
+		dirPath,
+	)
+	return cmd.Run()
+}


### PR DESCRIPTION
Add support for CNCF containernetworking plugins; in particular, bridge and host-local ipam.
This approach extends KinD's Config with 3 additional fields: CNI, Config File Name and Config File Body.
If these fields are specified then KinD will copy the config file to the /etc/cni/net.d directory under the desired name.
In theory, this approach should work with other plugins that only require a configuration file and their binaries have already been placed in the /opt/cni/bin directory.
** WIP **

Addresses the following issue: https://github.com/kubernetes-sigs/kind/issues/280