### PR TITLE
docker: Remove unneeded quotes from the inspect format string

### DIFF
--- a/pkg/cluster/nodes/node.go
+++ b/pkg/cluster/nodes/node.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -228,7 +227,7 @@ func (n *Node) IP() (ip string, err error) {
 	if len(lines) != 1 {
 		return "", errors.Errorf("file should only be one line, got %d lines", len(lines))
 	}
-	n.nodeCache.ip = strings.Trim(lines[0], "'")
+	n.nodeCache.ip = lines[0]
 	return n.nodeCache.ip, nil
 }
 
@@ -253,7 +252,7 @@ func (n *Node) Ports(containerPort int) (hostPort int, err error) {
 		n.nodeCache.ports = map[int]int{}
 	}
 
-	n.nodeCache.ports[containerPort], err = strconv.Atoi(strings.Trim(lines[0], "'"))
+	n.nodeCache.ports[containerPort], err = strconv.Atoi(lines[0])
 	if err != nil {
 		return -1, errors.Wrap(err, "failed to get file")
 	}

--- a/pkg/docker/inspect.go
+++ b/pkg/docker/inspect.go
@@ -17,16 +17,13 @@ limitations under the License.
 package docker
 
 import (
-	"fmt"
-
 	"sigs.k8s.io/kind/pkg/exec"
 )
 
 // Inspect return low-level information on containers
 func Inspect(containerNameOrID, format string) ([]string, error) {
 	cmd := exec.Command("docker", "inspect",
-		"-f", // format
-		fmt.Sprintf("'%s'", format),
+		"-f", format,
 		containerNameOrID, // ... against the "node" container
 	)
 


### PR DESCRIPTION
I'm guessing those quotes come from the command line examples where you have to
quote the go template:

  $ docker inspect --format='{{.LogPath}}' $INSTANCE_ID

However, we directly give the array of strings for the exec call so we don't
need to use the shell quotes here.

This removes the need to trim the quotes at the caller sites.