### PR TITLE
Upgrade images

### DIFF
--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -42,7 +42,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20181203-d055041"
+const DefaultBaseImage = "kindest/base:v20190211-a8c9fc8"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits

--- a/pkg/cluster/config/defaults/image.go
+++ b/pkg/cluster/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.13.2@sha256:e14edfa4950e009fe560499c9db6e89daae8bd18bcb372caca6d321a86c52cda"
+const Image = "kindest/node:v1.13.3@sha256:d1af504f20f3450ccb7aed63b67ec61c156f9ed3e8b0d973b3dee3c95991753c"


### PR DESCRIPTION
ref: #263 
This also picks up docker 18.06.2 regarding the runc escape. I am similarly pushing new images to previous default Kubernetes versions kind has shipped.

We should consider reversing course and unpinning the default from the image tag. CI could always explicitly select an exact image. For this PR though I am simply upgrading the images, as upgrading the base image it the most important change

/assign @neolit123 