### PR TITLE
Pass NO_PROXY environment variable to nodes

### DIFF
--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -141,6 +141,11 @@ func createNode(name, image, clusterLabel string, role config.NodeRole, extraArg
 		runArgs = append(runArgs, "-e", "HTTPS_PROXY="+httpsProxy)
 	}
 
+	noProxy := os.Getenv("NO_PROXY")
+	if noProxy != "" {
+		runArgs = append(runArgs, "-e", "NO_PROXY="+noProxy)
+	}
+
 	// adds node specific args
 	runArgs = append(runArgs, extraArgs...)
 


### PR DESCRIPTION
Pass the environment variable NO_PROXY from the host
environment to the nodes, so that the docker running on the node
could undertand which hosts not to use proxy for.

(see issue #306 for further details)

Fixes #306

Signed-off-by: Ed Bartosh <eduard.bartosh@intel.com>