### PR TITLE
Implements a new command "load" which allows images to be loaded 

### DIFF
--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/kind/cmd/kind/delete"
 	"sigs.k8s.io/kind/cmd/kind/export"
 	"sigs.k8s.io/kind/cmd/kind/get"
+	"sigs.k8s.io/kind/cmd/kind/load"
 	"sigs.k8s.io/kind/cmd/kind/version"
 	logutil "sigs.k8s.io/kind/pkg/log"
 )
@@ -68,6 +69,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(export.NewCommand())
 	cmd.AddCommand(get.NewCommand())
 	cmd.AddCommand(version.NewCommand())
+	cmd.AddCommand(load.NewCommand())
 	return cmd
 }
 

--- a/cmd/kind/load/docker-image/docker-image.go
+++ b/cmd/kind/load/docker-image/docker-image.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package load implements the `load` command
+package load
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kind/pkg/cluster"
+	clusternodes "sigs.k8s.io/kind/pkg/cluster/nodes"
+	"sigs.k8s.io/kind/pkg/docker"
+)
+
+type flagpole struct {
+	Name  string
+	Nodes []string
+}
+
+// NewCommand returns a new cobra.Command for loading an image into a cluster
+func NewCommand() *cobra.Command {
+	flags := &flagpole{}
+	cmd := &cobra.Command{
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("name of image is required")
+			}
+			return nil
+		},
+		Use:   "docker-image",
+		Short: "loads docker image from host into nodes",
+		Long:  "loads docker image from host into all or specified nodes by name",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags, cmd, args)
+		},
+	}
+	cmd.Flags().StringVar(
+		&flags.Name,
+		"name",
+		cluster.DefaultName,
+		"the cluster context name",
+	)
+	cmd.Flags().StringSliceVar(
+		&flags.Nodes,
+		"nodes",
+		nil,
+		"comma seperated list of nodes to load images into",
+	)
+	return cmd
+}
+
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	imageTarName := "image.tar"
+	destinationImageTar := fmt.Sprintf("/%s", imageTarName)
+
+	// Get the image into a tar
+	err := docker.Save(args[0], imageTarName)
+	if err != nil {
+		return err
+	}
+
+	// List nodes by cluster context name
+	n, err := clusternodes.ListByCluster()
+	if err != nil {
+		return err
+	}
+	nodes, known := n[flags.Name]
+	if !known {
+		return errors.Errorf("unknown cluster %q", flags.Name)
+	}
+
+	for _, node := range nodes {
+		// Copy image tar to each node
+		if err := node.CopyTo(imageTarName, destinationImageTar); err != nil {
+			return errors.Wrap(err, "failed to copy image to node")
+		}
+
+		// Load image into each node
+		if err := node.Command(
+			"docker", "load", "--input", destinationImageTar,
+		).Run(); err != nil {
+			return errors.Wrap(err, "failed to load image")
+		}
+	}
+	return nil
+}

--- a/cmd/kind/load/image-archive/image-archive.go
+++ b/cmd/kind/load/image-archive/image-archive.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package load implements the `load` command
+package load
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kind/pkg/cluster"
+	clusternodes "sigs.k8s.io/kind/pkg/cluster/nodes"
+)
+
+type flagpole struct {
+	Name  string
+	Nodes []string
+}
+
+// NewCommand returns a new cobra.Command for loading an image into a cluster
+func NewCommand() *cobra.Command {
+	flags := &flagpole{}
+	cmd := &cobra.Command{
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("name of image archive is required")
+			}
+			return nil
+		},
+		Use:   "image-archive",
+		Short: "loads docker image from archive into nodes",
+		Long:  "loads docker image from archive into all or specified nodes by name",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags, cmd, args)
+		},
+	}
+	cmd.Flags().StringVar(
+		&flags.Name,
+		"name",
+		cluster.DefaultName,
+		"the cluster context name",
+	)
+	cmd.Flags().StringSliceVar(
+		&flags.Nodes,
+		"nodes",
+		nil,
+		"comma seperated list of nodes to load images into",
+	)
+	return cmd
+}
+
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	destinationImageTar := fmt.Sprintf("/%s", args[0])
+
+	// List nodes by cluster context name
+	n, err := clusternodes.ListByCluster()
+	if err != nil {
+		return err
+	}
+	nodes, known := n[flags.Name]
+	if !known {
+		return errors.Errorf("unknown cluster %q", flags.Name)
+	}
+
+	for _, node := range nodes {
+		// Copy image tar to each node
+		if err := node.CopyTo(args[0], destinationImageTar); err != nil {
+			return errors.Wrap(err, "failed to copy image to node")
+		}
+
+		// Load image into each node
+		if err := node.Command(
+			"docker", "load", "--input", destinationImageTar,
+		).Run(); err != nil {
+			return errors.Wrap(err, "failed to load image")
+		}
+	}
+	return nil
+}

--- a/cmd/kind/load/load.go
+++ b/cmd/kind/load/load.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package load implements the `load` command
+package load
+
+import (
+	"github.com/spf13/cobra"
+
+	dockerimage "sigs.k8s.io/kind/cmd/kind/load/docker-image"
+	imagearchive "sigs.k8s.io/kind/cmd/kind/load/image-archive"
+)
+
+// NewCommand returns a new cobra.Command for get
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "load",
+		Short: "Loads images into nodes",
+		Long:  "Loads images into node from an archive or image on host",
+	}
+	// add subcommands
+	cmd.AddCommand(dockerimage.NewCommand())
+	cmd.AddCommand(imagearchive.NewCommand())
+	return cmd
+}


### PR DESCRIPTION
Fixes #28 by implementing a new `load` command which allows docker images to be loaded via an archive or by referencing an image on the host.

Example:
```
# Loads an image from an archive to cluster named `1`
$ kind load image-archive --name=1 sonoimg.tar 

# Loads an image from one that exists on the host into cluster named `1`
$ kind load docker-image --name=1 gcr.io/heptio-images/sonobuoy:kindCI 
```

It's also possible to pass a `--nodes` flag to specificy which nodes to deploy the image to, if not specified, it defaults to all nodes. 

Signed-off-by: Steve Sloka <slokas@vmware.com>