### PR TITLE
library - Refactor create options

### DIFF
--- a/cmd/kind/create/cluster/createcluster.go
+++ b/cmd/kind/create/cluster/createcluster.go
@@ -102,7 +102,10 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 		}
 	}
 	fmt.Printf("Creating cluster %q ...\n", flags.Name)
-	if err = ctx.Create(cfg, flags.Retain, flags.Wait); err != nil {
+	if err = ctx.Create(cfg,
+		cluster.Retain(flags.Retain),
+		cluster.WaitForReady(flags.Wait),
+	); err != nil {
 		return errors.Wrap(err, "failed to create cluster")
 	}
 


### PR DESCRIPTION
As discussed in last kind office hours (and in the kind slack channel), the current `library.Create` method expose options in a way that cannot be supported in the long term, because each new option will introduce a breaking change

This PR propose an alternative approach, based on a pattern already used in kind and described [here](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) 