### PR TITLE
print kubeadm init and join combined output for loglevel 'debug'

### DIFF
--- a/pkg/cluster/internal/create/const.go
+++ b/pkg/cluster/internal/create/const.go
@@ -29,3 +29,5 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 provisioner: kubernetes.io/host-path`
+
+const kubeadmVerbosityFlag = "--v=6"

--- a/pkg/cluster/internal/create/kubeadm-init.go
+++ b/pkg/cluster/internal/create/kubeadm-init.go
@@ -17,6 +17,7 @@ limitations under the License.
 package create
 
 import (
+	"sigs.k8s.io/kind/pkg/exec"
 	"strings"
 	"time"
 
@@ -64,7 +65,7 @@ func runKubeadmInit(ec *execContext, configNode *NodeReplica) error {
 	}
 
 	// run kubeadm
-	if err := node.Command(
+	cmd := node.Command(
 		// init because this is the control plane node
 		"kubeadm", "init",
 		// preflight errors are expected, in particular for swap being enabled
@@ -72,7 +73,12 @@ func runKubeadmInit(ec *execContext, configNode *NodeReplica) error {
 		"--ignore-preflight-errors=all",
 		// specify our generated config file
 		"--config=/kind/kubeadm.conf",
-	).Run(); err != nil {
+		"--skip-token-print",
+		kubeadmVerbosityFlag,
+	)
+	lines, err := exec.CombinedOutputLines(cmd)
+	log.Debug(strings.Join(lines, "\n"))
+	if err != nil {
 		return errors.Wrap(err, "failed to init node with kubeadm")
 	}
 

--- a/pkg/cluster/internal/create/kubeadm-join.go
+++ b/pkg/cluster/internal/create/kubeadm-join.go
@@ -20,10 +20,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kind/pkg/cluster/internal/kubeadm"
+	"sigs.k8s.io/kind/pkg/exec"
 	"sigs.k8s.io/kind/pkg/fs"
 )
 
@@ -126,7 +129,7 @@ func runKubeadmJoinControlPlane(ec *execContext, configNode *NodeReplica) error 
 	}
 
 	// run kubeadm join --control-plane
-	if err := node.Command(
+	cmd := node.Command(
 		"kubeadm", "join",
 		// the join command uses the docker ip and a well know port that
 		// are accessible only inside the docker network
@@ -139,7 +142,11 @@ func runKubeadmJoinControlPlane(ec *execContext, configNode *NodeReplica) error 
 		// preflight errors are expected, in particular for swap being enabled
 		// TODO(bentheelder): limit the set of acceptable errors
 		"--ignore-preflight-errors=all",
-	).Run(); err != nil {
+		kubeadmVerbosityFlag,
+	)
+	lines, err := exec.CombinedOutputLines(cmd)
+	log.Debug(strings.Join(lines, "\n"))
+	if err != nil {
 		return errors.Wrap(err, "failed to join a control plane node with kubeadm")
 	}
 
@@ -162,7 +169,7 @@ func runKubeadmJoin(ec *execContext, configNode *NodeReplica) error {
 	}
 
 	// run kubeadm join
-	if err := node.Command(
+	cmd := node.Command(
 		"kubeadm", "join",
 		// the join command uses the docker ip and a well know port that
 		// are accessible only inside the docker network
@@ -173,7 +180,11 @@ func runKubeadmJoin(ec *execContext, configNode *NodeReplica) error {
 		// preflight errors are expected, in particular for swap being enabled
 		// TODO(bentheelder): limit the set of acceptable errors
 		"--ignore-preflight-errors=all",
-	).Run(); err != nil {
+		kubeadmVerbosityFlag,
+	)
+	lines, err := exec.CombinedOutputLines(cmd)
+	log.Debug(strings.Join(lines, "\n"))
+	if err != nil {
 		return errors.Wrap(err, "failed to join node with kubeadm")
 	}
 


### PR DESCRIPTION
- Use --v=6 and print the combined output from 'init' and 'join'
if the user sets --loglevel=info.
- Skip printing the kubeadm joint token from init.

https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-all#kubeadm-kind-master
https://k8s-testgrid.appspot.com/sig-testing-kind#conformance,%20master%20(dev)%20%5Bnon-serial%5D

^ seeing some errors.

i think this is quite needed because without it, the actual error from kubeadm init or join is not printed to the kind user host terminal. also with level=info i'm adding a pretty high klog debug level =6.
i'm ok with reducing the level 6 to something lower?

/kind feature
/important soon
/assign @BenTheElder 
cc @fabriziopandini 
