### PR TITLE
configure Docker daemon to use proxy

### DIFF
--- a/pkg/cluster/internal/create/createcontext.go
+++ b/pkg/cluster/internal/create/createcontext.go
@@ -146,6 +146,12 @@ func (cc *Context) ProvisionNodes() (nodeList map[string]*nodes.Node, err error)
 			return nodeList, err
 		}
 
+		cc.Status.Start(fmt.Sprintf("[%s] Configuring proxy 🐋", configNode.Name))
+		if err := node.SetProxy(); err != nil {
+			// TODO: logging here
+			return nodeList, errors.Wrapf(err, "failed to set proxy for %s", configNode.Name)
+		}
+
 		cc.Status.Start(fmt.Sprintf("[%s] Starting systemd 🖥", configNode.Name))
 		// signal the node container entrypoint to continue booting into systemd
 		if err := node.SignalStart(); err != nil {


### PR DESCRIPTION
This is a second fix for the proxy issues (see #306 for details)

Docker fails to pull images if running behind the proxy.
It causes weave-net pods to stuck in ImagePullBackOff state.

Configured proxy as explained in docker documentation:
https://docs.docker.com/config/daemon/systemd/#http-proxy
This should solve the issue.

Fixes: #306