### PR TITLE
spelling: add a new hack/verify-spelling script

### DIFF
--- a/cmd/kind/load/docker-image/docker-image.go
+++ b/cmd/kind/load/docker-image/docker-image.go
@@ -62,7 +62,7 @@ func NewCommand() *cobra.Command {
 		&flags.Nodes,
 		"nodes",
 		nil,
-		"comma seperated list of nodes to load images into",
+		"comma separated list of nodes to load images into",
 	)
 	return cmd
 }

--- a/cmd/kind/load/image-archive/image-archive.go
+++ b/cmd/kind/load/image-archive/image-archive.go
@@ -59,7 +59,7 @@ func NewCommand() *cobra.Command {
 		&flags.Nodes,
 		"nodes",
 		nil,
-		"comma seperated list of nodes to load images into",
+		"comma separated list of nodes to load images into",
 	)
 	return cmd
 }

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -25,8 +25,8 @@ cd "${REPO_ROOT}"
 res=0
 
 # run all verify scripts
-echo "verifying govet ..."
-hack/verify-govet.sh || res=1
+echo "verifying spelling ..."
+hack/verify-spelling.sh || res=1
 cd "${REPO_ROOT}"
 
 echo "verifying gofmt ..."
@@ -35,6 +35,10 @@ cd "${REPO_ROOT}"
 
 echo "verifying golint ..."
 hack/verify-golint.sh || res=1
+cd "${REPO_ROOT}"
+
+echo "verifying govet ..."
+hack/verify-govet.sh || res=1
 cd "${REPO_ROOT}"
 
 echo "verifying generated ..."

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# cd to the repo root
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "${REPO_ROOT}"
+
+# create a temporary directory
+TMP_DIR=$(mktemp -d)
+
+# cleanup
+exitHandler() (
+  echo "Cleaning up ..."
+  rm -rf "${TMP_DIR}"
+)
+trap exitHandler EXIT
+
+# pull misspell
+export GO111MODULE=on
+URL="https://github.com/client9/misspell"
+echo "Cloning ${URL} in ${TMP_DIR}..."
+git clone --quiet --depth=1 "${URL}" "${TMP_DIR}"
+pushd "${TMP_DIR}" > /dev/null
+go mod init
+popd > /dev/null
+
+# build misspell
+BIN_PATH="${TMP_DIR}/cmd/misspell"
+pushd "${BIN_PATH}" > /dev/null
+echo "Building misspell ..."
+go build > /dev/null
+popd > /dev/null
+
+# check spelling
+RES=0
+ERROR_LOG="${TMP_DIR}/errors.log"
+echo "Checking spelling ..."
+git ls-files | grep -v -e vendor | xargs "${BIN_PATH}/misspell" > "${ERROR_LOG}"
+if [[ -s "${ERROR_LOG}" ]]; then
+  sed 's/^/error: /' "${ERROR_LOG}" # add 'error' to each line to highlight in e2e status
+  echo "Found spelling errors!"
+  RES=1
+else
+  echo "Done!"
+fi
+exit "${RES}"

--- a/pkg/cluster/config/v1alpha1/conversion.go
+++ b/pkg/cluster/config/v1alpha1/conversion.go
@@ -48,7 +48,7 @@ func Convert_config_Config_To_v1alpha1_Config(in *config.Config, out *Config, s 
 		return err
 	}
 
-	// convertion from internal config to v1alpha1 Config is used only by the fuzzer roundtrip test;
+	// conversion from internal config to v1alpha1 Config is used only by the fuzzer roundtrip test;
 	// the fuzzer is configured in order to enforce the number and type of nodes to get always the
 	// following condition pass
 

--- a/pkg/cluster/context.go
+++ b/pkg/cluster/context.go
@@ -88,7 +88,7 @@ type ControlPlaneMeta struct {
 	APIServerPort int
 }
 
-// GetControlPlaneMeta attempts to retreive / compute metadata about
+// GetControlPlaneMeta attempts to retrieve / compute metadata about
 // the control plane for the context's cluster
 // NOTE: due to refactoring this is currently non-functional (!)
 // TODO(bentheelder): fix this

--- a/pkg/cluster/internal/create/kubeadm-join.go
+++ b/pkg/cluster/internal/create/kubeadm-join.go
@@ -64,7 +64,7 @@ func (b *kubeadmJoinAction) Tasks() []Task {
 // runKubeadmJoinControlPlane executes kubadm join --control-plane command
 func runKubeadmJoinControlPlane(ec *execContext, configNode *NodeReplica) error {
 
-	// get the join addres
+	// get the join address
 	joinAddress, err := getJoinAddress(ec)
 	if err != nil {
 		// TODO(bentheelder): logging here
@@ -155,7 +155,7 @@ func runKubeadmJoinControlPlane(ec *execContext, configNode *NodeReplica) error 
 
 // runKubeadmJoin executes kubadm join command
 func runKubeadmJoin(ec *execContext, configNode *NodeReplica) error {
-	// get the join addres
+	// get the join address
 	joinAddress, err := getJoinAddress(ec)
 	if err != nil {
 		// TODO(bentheelder): logging here
@@ -191,7 +191,7 @@ func runKubeadmJoin(ec *execContext, configNode *NodeReplica) error {
 	return nil
 }
 
-// getJoinAddress return the join addres thas is the control plane endpoint in case the cluster has
+// getJoinAddress return the join address thas is the control plane endpoint in case the cluster has
 // an external load balancer in front of the control-plane nodes, otherwise the address of the
 // boostrap control plane node.
 func getJoinAddress(ec *execContext) (string, error) {

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -141,7 +141,7 @@ bootstrapTokens:
 apiEndpoint:
   bindPort: {{.APIBindPort}}
 ---
-# no-op entry that exists soley so it can be patched
+# no-op entry that exists solely so it can be patched
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: JoinConfiguration
 metadata:
@@ -160,7 +160,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 ---
-# no-op entry that exists soley so it can be patched
+# no-op entry that exists solely so it can be patched
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 metadata:
@@ -196,7 +196,7 @@ bootstrapTokens:
 localAPIEndpoint:
   bindPort: {{.APIBindPort}}
 ---
-# no-op entry that exists soley so it can be patched
+# no-op entry that exists solely so it can be patched
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: JoinConfiguration
 metadata:
@@ -215,7 +215,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 ---
-# no-op entry that exists soley so it can be patched
+# no-op entry that exists solely so it can be patched
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 metadata:

--- a/pkg/cluster/nodes/node.go
+++ b/pkg/cluster/nodes/node.go
@@ -65,7 +65,7 @@ func (n *Node) Command(command string, args ...string) exec.Cmd {
 	return n.Cmder().Command(command, args...)
 }
 
-// this is a seperate struct so we can clearly the whole thing at once
+// this is a separate struct so we can clearly the whole thing at once
 // it contains lazily initialized fields
 // like node.nodeCache = nodeCache{}
 type nodeCache struct {
@@ -136,7 +136,7 @@ func (n *Node) LoadImages() {
 		return
 	}
 
-	// if this fails, we don't care yet, but try to get the kubernetes verison
+	// if this fails, we don't care yet, but try to get the kubernetes version
 	// and see if we can skip retagging for amd64
 	// if this fails, we can just assume some unknown version and re-tag
 	// in a future release of kind, we can probably drop v1.11 support

--- a/pkg/container/cri/json.go
+++ b/pkg/container/cri/json.go
@@ -31,7 +31,7 @@ func (m *Mount) MarshalJSON() ([]byte, error) {
 	type Alias Mount
 	name, ok := MountPropagationValueToName[m.Propagation]
 	if !ok {
-		return nil, fmt.Errorf("unknown propogation value: %v", m.Propagation)
+		return nil, fmt.Errorf("unknown propagation value: %v", m.Propagation)
 	}
 	return json.Marshal(&struct {
 		Propagation string `json:"propagation"`
@@ -59,7 +59,7 @@ func (m *Mount) UnmarshalJSON(data []byte) error {
 	if aux.Propagation != "" {
 		val, ok := MountPropagationNameToValue[aux.Propagation]
 		if !ok {
-			return fmt.Errorf("unknown propogation value: %s", aux.Propagation)
+			return fmt.Errorf("unknown propagation value: %s", aux.Propagation)
 		}
 		m.Propagation = MountPropagation(val)
 	}

--- a/pkg/container/cri/types.go
+++ b/pkg/container/cri/types.go
@@ -24,7 +24,7 @@ https://github.com/kubernetes/kubernetes/blob/063e7ff358fdc8b0916e6f39beedc0d025
 // Mount specifies a host volume to mount into a container.
 // This is a close copy of the upstream cri Mount type
 // see: k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2
-// It additionally serializes the "propogation" field with the string enum
+// It additionally serializes the "propagation" field with the string enum
 // names on disk as opposed to the int32 values, and the serlialzed field names
 // have been made closer to core/v1 VolumeMount field names
 // In yaml this looks like:
@@ -33,7 +33,7 @@ https://github.com/kubernetes/kubernetes/blob/063e7ff358fdc8b0916e6f39beedc0d025
 //  readOnly: true
 //  selinuxRelabel: false
 //  propagation: None
-// Propogation may be one of: None, HostToContainer, Bidirectional
+// Propagation may be one of: None, HostToContainer, Bidirectional
 type Mount struct {
 	// Path of the mount within the container.
 	ContainerPath string `protobuf:"bytes,1,opt,name=container_path,json=containerPath,proto3" json:"containerPath,omitempty"`

--- a/pkg/container/docker/exec.go
+++ b/pkg/container/docker/exec.go
@@ -56,7 +56,7 @@ type containerCmd struct {
 func (c *containerCmd) Run() error {
 	args := []string{
 		"exec",
-		// run with priviliges so we can remount etc..
+		// run with privileges so we can remount etc..
 		// this might not make sense in the most general sense, but it is
 		// important to many kind commands
 		"--privileged",

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package kustomize contains helpers for working with embeded kustomize commands
+// Package kustomize contains helpers for working with embedded kustomize commands
 package kustomize
 
 import (

--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -17,9 +17,8 @@ checkout our [design docs][design] where we explain how things are implemented.
 For those interested in contributing to the project with code or documentation,
 the [development guide][dev guide] will give you a more in-depth look into how 
 kind works. 
-We will start by getting the required software and setting up the environemnt
-and then take a look into how the kind and its different packages are layed
-out.
+We will start by getting the required software and setting up the environment
+and then take a look into how kind and its different packages are laid out.
 
 You man also be interested in the [roadmap].
 

--- a/site/content/docs/contributing/1.0-roadmap.md
+++ b/site/content/docs/contributing/1.0-roadmap.md
@@ -20,7 +20,7 @@ stability by the end of Q1 2019 / the Kubernetes 1.14 release cycle
 - [x] Support multi-node clusters - [#117]
 - [ ] Support offline / air-gapped clusters
   - [ ] pre-loaded / offline CNI - [#200]
-- [ ] Support mounting host directores - [#62]
+- [ ] Support mounting host directories - [#62]
 - [ ] Improve Windows support
   - [x] add Windows binaries to releases - [#155]
   - [ ] improve instructions for KUBECONFIG in particular

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -181,7 +181,7 @@ flag.
 For a sample kind configuration file see [kind-example-config][kind-example-config].
 
 In particular, many users may be interested in multi-node clusters. A simple
-configuration for this can be acheived with the following config file contents:
+configuration for this can be achieved with the following config file contents:
 ```yaml
 # three node (two workers) cluster config
 kind: Config


### PR DESCRIPTION
- pull and build misspell in a temporary dir and run tests on the
kind tree, while skipping vendor.
- update verify-all to run this test first, and move the govet test
before verify-generated.sh.

/kind feature
/area testing
/priority important-longterm
/hold
