### PR TITLE
library: breakdown create actions

### DIFF
--- a/pkg/cluster/context.go
+++ b/pkg/cluster/context.go
@@ -72,7 +72,9 @@ func (c *Context) KubeConfigPath() string {
 // Create provisions and starts a kubernetes-in-docker cluster
 func (c *Context) Create(cfg *config.Config, options ...create.ClusterOption) error {
 	// apply create options
-	opts := &internalcreate.Options{}
+	opts := &internalcreate.Options{
+		SetupKubernetes: true,
+	}
 	for _, option := range options {
 		opts = option(opts)
 	}

--- a/pkg/cluster/create/cluster.go
+++ b/pkg/cluster/create/cluster.go
@@ -40,3 +40,13 @@ func WaitForReady(interval time.Duration) ClusterOption {
 		return o
 	}
 }
+
+// SetupKubernetes configures create command to setup kubernetes after creating nodes containers
+// TODO: Refactor this. It is a temporary solution for a phased breakdown of different
+//      operations, specifically create. see https://github.com/kubernetes-sigs/kind/issues/324
+func SetupKubernetes(setupKubernetes bool) ClusterOption {
+	return func(o *internalcreate.Options) *internalcreate.Options {
+		o.SetupKubernetes = setupKubernetes
+		return o
+	}
+}


### PR DESCRIPTION
As discussed in https://github.com/kubernetes-sigs/kind/issues/324, this PR provides a quick win for achieving better control over the kubeadm steps during create, and more specifically a way to provision but stop before `kubeadm init` / `kubeadm join` 

The solution leverage on the options management and makes this feature available only at the library level, while if/how to exposed to the Users can be defined in follow-up PRs.

Rif. https://github.com/kubernetes-sigs/kind/issues/324

/assign @BenTheElder 
/cc @timothysc  
/cc @neolit123 
