### PR TITLE
pre-load CNI

### DIFF
--- a/pkg/build/node/const.go
+++ b/pkg/build/node/const.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+// these are well known paths within the node image
+const (
+	// TODO: refactor kubernetesVersionLocation to a common internal package
+	kubernetesVersionLocation  = "/kind/version"
+	defaultCNIManifestLocation = "/kind/manifests/default-cni.yaml"
+)
+
+/*
+The default CNI manifest and images are from weave currently.
+
+To update these:
+- find the latest stable release at https://github.com/weaveworks/weave/releases
+- copy the weave-daemonset-k8s-1.8.yaml to the defaultCNIManifest string
+- add a comment to the beginning of the string with the source URL
+- update the defaultCNIImages array to include the images in the manifest
+- update the comment below with the release URL
+
+Current version: https://github.com/weaveworks/weave/releases/tag/v2.5.1
+*/
+
+var defaultCNIImages = []string{"weaveworks/weave-kube:2.5.1", "weaveworks/weave-npc:2.5.1"}
+
+const defaultCNIManifest = `# https://github.com/weaveworks/weave/releases/download/v2.5.1/weave-daemonset-k8s-1.8.yaml
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+      namespace: kube-system
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRole
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - pods
+          - namespaces
+          - nodes
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - networkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - 'networking.k8s.io'
+        resources:
+          - networkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+        - ''
+        resources:
+        - nodes/status
+        verbs:
+        - patch
+        - update
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRoleBinding
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+    roleRef:
+      kind: ClusterRole
+      name: weave-net
+      apiGroup: rbac.authorization.k8s.io
+    subjects:
+      - kind: ServiceAccount
+        name: weave-net
+        namespace: kube-system
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: Role
+    metadata:
+      name: weave-net
+      namespace: kube-system
+      labels:
+        name: weave-net
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - configmaps
+        resourceNames:
+          - weave-net
+        verbs:
+          - get
+          - update
+      - apiGroups:
+          - ''
+        resources:
+          - configmaps
+        verbs:
+          - create
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: RoleBinding
+    metadata:
+      name: weave-net
+      namespace: kube-system
+      labels:
+        name: weave-net
+    roleRef:
+      kind: Role
+      name: weave-net
+      apiGroup: rbac.authorization.k8s.io
+    subjects:
+      - kind: ServiceAccount
+        name: weave-net
+        namespace: kube-system
+  - apiVersion: extensions/v1beta1
+    kind: DaemonSet
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+      namespace: kube-system
+    spec:
+      # Wait 5 seconds to let pod connect before rolling next pod
+      minReadySeconds: 5
+      template:
+        metadata:
+          labels:
+            name: weave-net
+        spec:
+          containers:
+            - name: weave
+              command:
+                - /home/weave/launch.sh
+              env:
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: spec.nodeName
+              image: 'weaveworks/weave-kube:2.5.1'
+              readinessProbe:
+                httpGet:
+                  host: 127.0.0.1
+                  path: /status
+                  port: 6784
+              resources:
+                requests:
+                  cpu: 10m
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: weavedb
+                  mountPath: /weavedb
+                - name: cni-bin
+                  mountPath: /host/opt
+                - name: cni-bin2
+                  mountPath: /host/home
+                - name: cni-conf
+                  mountPath: /host/etc
+                - name: dbus
+                  mountPath: /host/var/lib/dbus
+                - name: lib-modules
+                  mountPath: /lib/modules
+                - name: xtables-lock
+                  mountPath: /run/xtables.lock
+                  readOnly: false
+            - name: weave-npc
+              env:
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: spec.nodeName
+              image: 'weaveworks/weave-npc:2.5.1'
+#npc-args
+              resources:
+                requests:
+                  cpu: 10m
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: xtables-lock
+                  mountPath: /run/xtables.lock
+                  readOnly: false
+          hostNetwork: true
+          hostPID: true
+          restartPolicy: Always
+          securityContext:
+            seLinuxOptions: {}
+          serviceAccountName: weave-net
+          tolerations:
+            - effect: NoSchedule
+              operator: Exists
+          volumes:
+            - name: weavedb
+              hostPath:
+                path: /var/lib/weave
+            - name: cni-bin
+              hostPath:
+                path: /opt
+            - name: cni-bin2
+              hostPath:
+                path: /home
+            - name: cni-conf
+              hostPath:
+                path: /etc
+            - name: dbus
+              hostPath:
+                path: /var/lib/dbus
+            - name: lib-modules
+              hostPath:
+                path: /lib/modules
+            - name: xtables-lock
+              hostPath:
+                path: /run/xtables.lock
+                type: FileOrCreate
+      updateStrategy:
+        type: RollingUpdate
+`

--- a/pkg/container/docker/exec.go
+++ b/pkg/container/docker/exec.go
@@ -100,18 +100,22 @@ func (c *containerCmd) Run() error {
 	return cmd.Run()
 }
 
-func (c *containerCmd) SetEnv(env ...string) {
+func (c *containerCmd) SetEnv(env ...string) exec.Cmd {
 	c.env = env
+	return c
 }
 
-func (c *containerCmd) SetStdin(r io.Reader) {
+func (c *containerCmd) SetStdin(r io.Reader) exec.Cmd {
 	c.stdin = r
+	return c
 }
 
-func (c *containerCmd) SetStdout(w io.Writer) {
+func (c *containerCmd) SetStdout(w io.Writer) exec.Cmd {
 	c.stdout = w
+	return c
 }
 
-func (c *containerCmd) SetStderr(w io.Writer) {
+func (c *containerCmd) SetStderr(w io.Writer) exec.Cmd {
 	c.stderr = w
+	return c
 }

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -32,10 +32,10 @@ import (
 type Cmd interface {
 	Run() error
 	// Each entry should be of the form "key=value"
-	SetEnv(...string)
-	SetStdin(io.Reader)
-	SetStdout(io.Writer)
-	SetStderr(io.Writer)
+	SetEnv(...string) Cmd
+	SetStdin(io.Reader) Cmd
+	SetStdout(io.Writer) Cmd
+	SetStderr(io.Writer) Cmd
 }
 
 // Cmder abstracts over creating commands

--- a/pkg/exec/local.go
+++ b/pkg/exec/local.go
@@ -43,23 +43,27 @@ func (c *LocalCmder) Command(name string, arg ...string) Cmd {
 }
 
 // SetEnv sets env
-func (cmd *LocalCmd) SetEnv(env ...string) {
+func (cmd *LocalCmd) SetEnv(env ...string) Cmd {
 	cmd.Env = env
+	return cmd
 }
 
 // SetStdin sets stdin
-func (cmd *LocalCmd) SetStdin(r io.Reader) {
+func (cmd *LocalCmd) SetStdin(r io.Reader) Cmd {
 	cmd.Stdin = r
+	return cmd
 }
 
 // SetStdout set stdout
-func (cmd *LocalCmd) SetStdout(w io.Writer) {
+func (cmd *LocalCmd) SetStdout(w io.Writer) Cmd {
 	cmd.Stdout = w
+	return cmd
 }
 
 // SetStderr sets stderr
-func (cmd *LocalCmd) SetStderr(w io.Writer) {
+func (cmd *LocalCmd) SetStderr(w io.Writer) Cmd {
 	cmd.Stderr = w
+	return cmd
 }
 
 // Run runs


### PR DESCRIPTION
With this patch a cluster can be created fully offline. Fixes #200 

A test image is at: `gcr.io/bentheelder-kind-dev/kindest/node:v1.13.3`

How this works:
- pkg/build/node now contains some private constants for the CNI, with instructions for udpating them
- we write a fixed CNI manifest to a well-known-location when building the node image
- we pull a fixed set of CNI images and pre-load them when building the node image
- when creating a cluster we detect if the manifest exists in the container, if it does we will load that, if not we will fall back to the previous CNI install mechanism

Along the way I cleaned up the image build slightly, and improved the ergonomics of the `exec.Command` interface to allow method chaining.