### PR TITLE
switch off of the bazel debs

### DIFF
--- a/pkg/build/kube/bits.go
+++ b/pkg/build/kube/bits.go
@@ -38,6 +38,8 @@ type Bits interface {
 	Paths() map[string]string
 	// Install should install the built sources on the node, assuming paths
 	// have been populated
+	// TODO(bentheelder): eliminate install, make install file-copies only,
+	// support cross-building
 	Install(InstallContext) error
 }
 


### PR DESCRIPTION
easiest answer to fixing the bazel build after cross compliation landed.
/hold

positive:
- the bazel build and the non-bazel build have the same install process now
- we can probably refactor the build to only COPY operations and support cross-compilation #166
- no longer broken by changes to the debs, the binaries are less in-flux

negative:
- no longer installing the debs