### PR TITLE
fix panic on create/config validation

### DIFF
--- a/cmd/kind/create/cluster/createcluster.go
+++ b/cmd/kind/create/cluster/createcluster.go
@@ -69,7 +69,7 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	err = cfg.Validate()
 	if err != nil {
 		log.Error("Invalid configuration!")
-		configErrors := err.(*util.Errors)
+		configErrors := err.(util.Errors)
 		for _, problem := range configErrors.Errors() {
 			log.Error(problem)
 		}

--- a/pkg/cluster/config/validate.go
+++ b/pkg/cluster/config/validate.go
@@ -52,7 +52,7 @@ func (n *Node) Validate() error {
 		ExternalEtcdRole,
 		ExternalLoadBalancerRole:
 	default:
-		errs = append(errs, errors.New("role is a required field"))
+		errs = append(errs, errors.Errorf("%q is not a valid node role", n.Role))
 	}
 
 	// image should be defined


### PR DESCRIPTION
This PR fixes a panic on create when the config validation does not pass e.g. because the role is not valid

```bash
$kind create cluster --image kindest/node:latest  --config config.yaml
ERRO[09:44:48] Invalid configuration!
panic: interface conversion: error is util.Errors, not *util.Errors

goroutine 1 [running]:
sigs.k8s.io/kind/cmd/kind/create/cluster.runE(0xc00048e500, 0xc0001b7b80, 0xc00048e6c0, 0x0, 0x4, 0x0, 0x0)
	/Users/us01890/Documents/workspace/go/src/sigs.k8s.io/kind/cmd/kind/create/cluster/createcluster.go:72 +0x682
sigs.k8s.io/kind/cmd/kind/create/cluster.NewCommand.func1(0xc0001b7b80, 0xc00048e6c0, 0x0, 0x4, 0x0, 0x0)
	/Users/us01890/Documents/workspace/go/src/sigs.k8s.io/kind/cmd/kind/create/cluster/createcluster.go:50 +0x52
sigs.k8s.io/kind/vendor/github.com/spf13/cobra.(*Command).execute(0xc0001b7b80, 0xc00048e680, 0x4, 0x4, 0xc0001b7b80, 0xc00048e680)
	/Users/us01890/Documents/workspace/go/src/sigs.k8s.io/kind/vendor/github.com/spf13/cobra/command.go:762 +0x473
sigs.k8s.io/kind/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc0001b6f00, 0xc000147680, 0xc000146780, 0xc0001b7900)
	/Users/us01890/Documents/workspace/go/src/sigs.k8s.io/kind/vendor/github.com/spf13/cobra/command.go:852 +0x2fd
sigs.k8s.io/kind/vendor/github.com/spf13/cobra.(*Command).Execute(0xc0001b6f00, 0x1d849b0, 0xc0000e407c)
	/Users/us01890/Documents/workspace/go/src/sigs.k8s.io/kind/vendor/github.com/spf13/cobra/command.go:800 +0x2b
sigs.k8s.io/kind/cmd/kind.Run(0x1e42880, 0xc00048e4c0)
	/Users/us01890/Documents/workspace/go/src/sigs.k8s.io/kind/cmd/kind/kind.go:90 +0x27
sigs.k8s.io/kind/cmd/kind.Main()
	/Users/us01890/Documents/workspace/go/src/sigs.k8s.io/kind/cmd/kind/kind.go:107 +0xb8
main.main()
	/Users/us01890/Documents/workspace/go/src/sigs.k8s.io/kind/main.go:25 +0x20
```

While testing, I changed the error message for invalid role as well in order to make it more clear

/assign @BenTheElder @neolit123 
/priority important-soon
/kind bug