### PR TITLE
base-image: inherit the host environment when building

### DIFF
--- a/pkg/build/base/base.go
+++ b/pkg/build/base/base.go
@@ -121,7 +121,7 @@ func (c *BuildContext) buildEntrypoint(dir string) error {
 
 	cmd := exec.Command(c.goCmd, "build", "-o", entrypointDest, entrypointSrc)
 	// TODO(bentheelder): we may need to map between docker image arch and GOARCH
-	cmd.SetEnv("GOOS=linux", "GOARCH="+c.arch)
+	cmd.SetEnv(append(os.Environ(), "GOOS=linux", "GOARCH="+c.arch)...)
 
 	// actually build
 	log.Info("Building entrypoint binary ...")


### PR DESCRIPTION
With modules enabled in the repo and without this change,
errors seem to be thrown when building the base image - e.g. for
GOCACHE or HOME not being defined.

Inherit the host environment when calling `go build`
for the entry point binary.

https://github.com/golang/go/issues/29267

/kind bug
/priority important-longterm
