### PR TITLE
Add IPv6 support

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -102,6 +102,8 @@ create_cluster() {
 # necessary for conformance
 kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
+networking:
+  ipFamily: ${IP_FAMILY:-ipv4}
 nodes:
 # the control plane node
 - role: control-plane

--- a/pkg/cluster/config/default.go
+++ b/pkg/cluster/config/default.go
@@ -41,14 +41,32 @@ func SetDefaults_Cluster(obj *Cluster) {
 			},
 		}
 	}
-	// default to listening on 127.0.0.1:randomPort
-	// TODO(bentheelder): this defaulting will need to be ipv6 aware as well
+	if obj.Networking.IPFamily == "" {
+		obj.Networking.IPFamily = "ipv4"
+	}
+	// default to listening on 127.0.0.1:randomPort on ipv4
+	// and [::1]:randomPort on ipv6
 	if obj.Networking.APIServerAddress == "" {
 		obj.Networking.APIServerAddress = "127.0.0.1"
+		if obj.Networking.IPFamily == "ipv6" {
+			obj.Networking.APIServerAddress = "::1"
+		}
 	}
 	// default the pod CIDR
 	if obj.Networking.PodSubnet == "" {
 		obj.Networking.PodSubnet = "10.244.0.0/16"
+		if obj.Networking.IPFamily == "ipv6" {
+			obj.Networking.PodSubnet = "fd00:10:244::/64"
+		}
+	}
+	// default the service CIDR using the kubeadm default
+	// https://github.com/kubernetes/kubernetes/blob/746404f82a28e55e0b76ffa7e40306fb88eb3317/cmd/kubeadm/app/apis/kubeadm/v1beta2/defaults.go#L32
+	// Note: kubeadm is doing it already but this simplifies kind's logic
+	if obj.Networking.ServiceSubnet == "" {
+		obj.Networking.ServiceSubnet = "10.96.0.0/12"
+		if obj.Networking.IPFamily == "ipv6" {
+			obj.Networking.ServiceSubnet = "fd00:10:96::/112"
+		}
 	}
 }
 

--- a/pkg/cluster/config/fuzzer/fuzzer.go
+++ b/pkg/cluster/config/fuzzer/fuzzer.go
@@ -42,6 +42,8 @@ func fuzzConfig(obj *config.Cluster, c fuzz.Continue) {
 	}}
 	obj.Networking.APIServerAddress = "127.0.0.1"
 	obj.Networking.PodSubnet = "10.244.0.0/16"
+	obj.Networking.ServiceSubnet = "10.96.0.0/12"
+	obj.Networking.IPFamily = "ipv4"
 }
 
 func fuzzNode(obj *config.Node, c fuzz.Continue) {

--- a/pkg/cluster/config/types.go
+++ b/pkg/cluster/config/types.go
@@ -88,6 +88,8 @@ const (
 
 // Networking contains cluster wide network settings
 type Networking struct {
+	// IPFamily is the network cluster model, currently it can be ipv4 or ipv6
+	IPFamily ClusterIPFamily
 	// APIServerPort is the listen port on the host for the Kubernetes API Server
 	// Defaults to a random port on the host
 	APIServerPort int32
@@ -99,7 +101,20 @@ type Networking struct {
 	// PodSubnet is the CIDR used for pod IPs
 	// kind will select a default if unspecified
 	PodSubnet string
+	// ServiceSubnet is the CIDR used for services VIPs
+	// kind will select a default if unspecified
+	ServiceSubnet string
 	// If DisableDefaultCNI is true, kind will not install the default CNI setup.
 	// Instead the user should install their own CNI after creating the cluster.
 	DisableDefaultCNI bool
 }
+
+// ClusterIPFamily defines cluster network IP family
+type ClusterIPFamily string
+
+const (
+	// IPv4Family sets ClusterIPFamily to ipv4
+	IPv4Family ClusterIPFamily = "ipv4"
+	// IPv6Family sets ClusterIPFamily to ipv6
+	IPv6Family ClusterIPFamily = "ipv6"
+)

--- a/pkg/cluster/config/v1alpha3/default.go
+++ b/pkg/cluster/config/v1alpha3/default.go
@@ -41,14 +41,32 @@ func SetDefaults_Cluster(obj *Cluster) {
 			},
 		}
 	}
-	// default to listening on 127.0.0.1:randomPort
-	// TODO(bentheelder): this defaulting will need to be ipv6 aware as well
+	if obj.Networking.IPFamily == "" {
+		obj.Networking.IPFamily = "ipv4"
+	}
+	// default to listening on 127.0.0.1:randomPort on ipv4
+	// and [::1]:randomPort on ipv6
 	if obj.Networking.APIServerAddress == "" {
 		obj.Networking.APIServerAddress = "127.0.0.1"
+		if obj.Networking.IPFamily == "ipv6" {
+			obj.Networking.APIServerAddress = "::1"
+		}
 	}
 	// default the pod CIDR
 	if obj.Networking.PodSubnet == "" {
 		obj.Networking.PodSubnet = "10.244.0.0/16"
+		if obj.Networking.IPFamily == "ipv6" {
+			obj.Networking.PodSubnet = "fd00:10:244::/64"
+		}
+	}
+	// default the service CIDR using the kubeadm default
+	// https://github.com/kubernetes/kubernetes/blob/746404f82a28e55e0b76ffa7e40306fb88eb3317/cmd/kubeadm/app/apis/kubeadm/v1beta2/defaults.go#L32
+	// Note: kubeadm is doing it already but this simplifies kind's logic
+	if obj.Networking.ServiceSubnet == "" {
+		obj.Networking.ServiceSubnet = "10.96.0.0/12"
+		if obj.Networking.IPFamily == "ipv6" {
+			obj.Networking.ServiceSubnet = "fd00:10:96::/112"
+		}
 	}
 }
 

--- a/pkg/cluster/config/v1alpha3/types.go
+++ b/pkg/cluster/config/v1alpha3/types.go
@@ -88,6 +88,8 @@ const (
 
 // Networking contains cluster wide network settings
 type Networking struct {
+	// IPFamily is the network cluster model, currently it can be ipv4 or ipv6
+	IPFamily ClusterIPFamily `json:"ipFamily,omitempty"`
 	// APIServerPort is the listen port on the host for the Kubernetes API Server
 	// Defaults to a random port on the host
 	APIServerPort int32 `json:"apiServerPort,omitempty"`
@@ -99,7 +101,20 @@ type Networking struct {
 	// PodSubnet is the CIDR used for pod IPs
 	// kind will select a default if unspecified
 	PodSubnet string `json:"podSubnet,omitempty"`
+	// ServiceSubnet is the CIDR used for services VIPs
+	// kind will select a default if unspecified for IPv6
+	ServiceSubnet string `json:"serviceSubnet,omitempty"`
 	// If DisableDefaultCNI is true, kind will not install the default CNI setup.
 	// Instead the user should install their own CNI after creating the cluster.
 	DisableDefaultCNI bool `json:"disableDefaultCNI,omitempty"`
 }
+
+// ClusterIPFamily defines cluster network IP family
+type ClusterIPFamily string
+
+const (
+	// IPv4Family sets ClusterIPFamily to ipv4
+	IPv4Family ClusterIPFamily = "ipv4"
+	// IPv6Family sets ClusterIPFamily to ipv6
+	IPv6Family ClusterIPFamily = "ipv6"
+)

--- a/pkg/cluster/config/v1alpha3/zz_generated.conversion.go
+++ b/pkg/cluster/config/v1alpha3/zz_generated.conversion.go
@@ -101,9 +101,11 @@ func Convert_config_Cluster_To_v1alpha3_Cluster(in *config.Cluster, out *Cluster
 }
 
 func autoConvert_v1alpha3_Networking_To_config_Networking(in *Networking, out *config.Networking, s conversion.Scope) error {
+	out.IPFamily = config.ClusterIPFamily(in.IPFamily)
 	out.APIServerPort = in.APIServerPort
 	out.APIServerAddress = in.APIServerAddress
 	out.PodSubnet = in.PodSubnet
+	out.ServiceSubnet = in.ServiceSubnet
 	out.DisableDefaultCNI = in.DisableDefaultCNI
 	return nil
 }
@@ -114,9 +116,11 @@ func Convert_v1alpha3_Networking_To_config_Networking(in *Networking, out *confi
 }
 
 func autoConvert_config_Networking_To_v1alpha3_Networking(in *config.Networking, out *Networking, s conversion.Scope) error {
+	out.IPFamily = ClusterIPFamily(in.IPFamily)
 	out.APIServerPort = in.APIServerPort
 	out.APIServerAddress = in.APIServerAddress
 	out.PodSubnet = in.PodSubnet
+	out.ServiceSubnet = in.ServiceSubnet
 	out.DisableDefaultCNI = in.DisableDefaultCNI
 	return nil
 }

--- a/pkg/cluster/config/validate.go
+++ b/pkg/cluster/config/validate.go
@@ -54,6 +54,10 @@ func (c *Cluster) Validate() error {
 	if _, _, err := net.ParseCIDR(c.Networking.PodSubnet); err != nil {
 		errs = append(errs, errors.Wrapf(err, "invalid podSubnet"))
 	}
+	// serviceSubnet should be a valid CIDR
+	if _, _, err := net.ParseCIDR(c.Networking.ServiceSubnet); err != nil {
+		errs = append(errs, errors.Wrapf(err, "invalid serviceSubnet"))
+	}
 
 	if len(errs) > 0 {
 		return util.NewErrors(errs)

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -19,7 +19,9 @@ package kubeadm
 import (
 	"bytes"
 	"strings"
-	"text/template"
+  "text/template"
+  log "github.com/sirupsen/logrus"
+
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -440,6 +442,7 @@ metadata:
 // Config returns a kubeadm config generated from config data, in particular
 // the kubernetes version
 func Config(data ConfigData) (config string, err error) {
+  log.Debugf("Configuration Input data: %v", data)
 	ver, err := version.ParseGeneric(data.KubernetesVersion)
 	if err != nil {
 		return "", err
@@ -468,6 +471,7 @@ func Config(data ConfigData) (config string, err error) {
 	err = t.Execute(&buff, data)
 	if err != nil {
 		return "", errors.Wrap(err, "error executing config template")
-	}
+  }
+  log.Debugf("Configuration generated:\n %v", buff.String())
 	return buff.String(), nil
 }

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -45,6 +45,10 @@ type ConfigData struct {
 	Token string
 	// The subnet used for pods
 	PodSubnet string
+	// The subnet used for services
+	ServiceSubnet string
+	// IPv4 values take precedence over IPv6 by default, if true set IPv6 default values
+	IPv6 bool
 	// DerivedConfigData is populated by Derive()
 	// These auto-generated fields are available to Config templates,
 	// but not meant to be set by hand
@@ -104,9 +108,14 @@ apiServerExtraVolumes:
 # on docker for mac we have to expose the api server via port forward,
 # so we need to ensure the cert is valid for localhost so we can talk
 # to the cluster after rewriting the kubeconfig to point to localhost
-apiServerCertSANs: [localhost, {{.APIServerAddress}}]
+apiServerCertSANs: [localhost, "{{.APIServerAddress}}"]
 kubeletConfiguration:
   baseConfig:
+    # configure ipv6 addresses in IPv6 mode
+    {{ if .IPv6 -}}
+    address: "::"
+    healthzBindAddress: "::"
+    {{- end }}
     # disable disk resource management by default
     # kubelet will see the host disk that the inner container runtime
     # is ultimately backed by and attempt to recover disk space.
@@ -151,6 +160,9 @@ metadata:
 kubernetesVersion: {{.KubernetesVersion}}
 clusterName: "{{.ClusterName}}"
 controlPlaneEndpoint: {{ .ControlPlaneEndpoint }}
+networking:
+  podSubnet: "{{ .PodSubnet }}"
+  serviceSubnet: "{{ .ServiceSubnet }}"
 # we need nsswitch.conf so we use /etc/hosts
 # https://github.com/kubernetes/kubernetes/issues/69195
 apiServerExtraVolumes:
@@ -162,7 +174,7 @@ apiServerExtraVolumes:
 # on docker for mac we have to expose the api server via port forward,
 # so we need to ensure the cert is valid for localhost so we can talk
 # to the cluster after rewriting the kubeconfig to point to localhost
-apiServerCertSANs: [localhost, {{.APIServerAddress}}]
+apiServerCertSANs: [localhost, "{{.APIServerAddress}}"]
 controllerManagerExtraArgs:
   enable-hostpath-provisioner: "true"
 networking:
@@ -210,6 +222,11 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 metadata:
   name: config
+# configure ipv6 addresses in IPv6 mode
+{{ if .IPv6 -}}
+address: "::"
+healthzBindAddress: "::"
+{{- end }}
 # disable disk resource management by default
 # kubelet will see the host disk that the inner container runtime
 # is ultimately backed by and attempt to recover disk space. we don't want that.
@@ -239,12 +256,24 @@ controlPlaneEndpoint: {{ .ControlPlaneEndpoint }}
 # so we need to ensure the cert is valid for localhost so we can talk
 # to the cluster after rewriting the kubeconfig to point to localhost
 apiServer:
-  certSANs: [localhost, {{.APIServerAddress}}]
+  certSANs: [localhost, "{{.APIServerAddress}}"]
 controllerManager:
   extraArgs:
     enable-hostpath-provisioner: "true"
+    # configure ipv6 default addresses for IPv6 clusters
+    {{ if .IPv6 -}}
+    bind-address: "::"
+    {{- end }}
+scheduler:
+  extraArgs:
+    # configure ipv6 default addresses for IPv6 clusters
+    {{ if .IPv6 -}}
+    address: "::"
+    bind-address: "::1"
+    {{- end }}
 networking:
   podSubnet: "{{ .PodSubnet }}"
+  serviceSubnet: "{{ .ServiceSubnet }}"
 ---
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: InitConfiguration
@@ -290,6 +319,11 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 metadata:
   name: config
+# configure ipv6 addresses in IPv6 mode
+{{ if .IPv6 -}}
+address: "::"
+healthzBindAddress: "::"
+{{- end }}
 # disable disk resource management by default
 # kubelet will see the host disk that the inner container runtime
 # is ultimately backed by and attempt to recover disk space. we don't want that.
@@ -319,12 +353,24 @@ controlPlaneEndpoint: {{ .ControlPlaneEndpoint }}
 # so we need to ensure the cert is valid for localhost so we can talk
 # to the cluster after rewriting the kubeconfig to point to localhost
 apiServer:
-  certSANs: [localhost, {{.APIServerAddress}}]
+  certSANs: [localhost, "{{.APIServerAddress}}"]
 controllerManager:
   extraArgs:
     enable-hostpath-provisioner: "true"
+    # configure ipv6 default addresses for IPv6 clusters
+    {{ if .IPv6 -}}
+    bind-address: "::"
+    {{- end }}
+scheduler:
+  extraArgs:
+    # configure ipv6 default addresses for IPv6 clusters
+    {{ if .IPv6 -}}
+    address: "::"
+    bind-address: "::1"
+    {{- end }}
 networking:
   podSubnet: "{{ .PodSubnet }}"
+  serviceSubnet: "{{ .ServiceSubnet }}"
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
@@ -370,6 +416,11 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 metadata:
   name: config
+# configure ipv6 addresses in IPv6 mode
+{{ if .IPv6 -}}
+address: "::"
+healthzBindAddress: "::"
+{{- end }}
 # disable disk resource management by default
 # kubelet will see the host disk that the inner container runtime
 # is ultimately backed by and attempt to recover disk space. we don't want that.

--- a/pkg/cluster/internal/loadbalancer/config.go
+++ b/pkg/cluster/internal/loadbalancer/config.go
@@ -27,6 +27,7 @@ import (
 type ConfigData struct {
 	ControlPlanePort int
 	BackendServers   map[string]string
+	IPv6             bool
 }
 
 // DefaultConfigTemplate is the loadbalancer config template
@@ -42,6 +43,9 @@ stream {
 
     server {
         listen {{ .ControlPlanePort }};
+        {{ if .IPv6 -}}
+        listen [::]:{{ .ControlPlanePort }};
+        {{- end }}
         proxy_pass tcp_backend;
     }
 }

--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -59,11 +59,12 @@ func CreateControlPlaneNode(name, image, clusterLabel, listenAddress string, por
 		port = p
 	}
 
+	portMapping := net.JoinHostPort(listenAddress, fmt.Sprintf("%d", port)) + fmt.Sprintf(":%d", kubeadm.APIServerPort)
 	node, err = createNode(
 		name, image, clusterLabel, constants.ControlPlaneNodeRoleValue, mounts,
 		// publish selected port for the API server
 		"--expose", fmt.Sprintf("%d", port),
-		"-p", fmt.Sprintf("%s:%d:%d", listenAddress, port, kubeadm.APIServerPort),
+		"-p", portMapping,
 	)
 	if err != nil {
 		return node, err
@@ -90,11 +91,12 @@ func CreateExternalLoadBalancerNode(name, image, clusterLabel, listenAddress str
 		port = p
 	}
 
+	portMapping := net.JoinHostPort(listenAddress, fmt.Sprintf("%d", port)) + fmt.Sprintf(":%d", loadbalancer.ControlPlanePort)
 	node, err = createNode(name, image, clusterLabel, constants.ExternalLoadBalancerNodeRoleValue,
 		nil,
 		// publish selected port for the control plane
 		"--expose", fmt.Sprintf("%d", port),
-		"-p", fmt.Sprintf("%s:%d:%d", listenAddress, port, loadbalancer.ControlPlanePort),
+		"-p", portMapping,
 	)
 	if err != nil {
 		return node, err

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -216,6 +216,7 @@ flag:
 kind create cluster --config kind-example-config.yaml
 ```
 
+#### Multi-node clusters
 In particular, many users may be interested in multi-node clusters. A simple
 configuration for this can be achieved with the following config file contents:
 ```yaml
@@ -228,6 +229,7 @@ nodes:
 - role: worker
 ```
 
+#### Control-plane HA
 You can also have a cluster with multiple control-plane nodes:
 ```yaml
 # a cluster with 3 control-plane nodes and 3 workers
@@ -280,10 +282,24 @@ nodes:
 - role: control-plane
 # the three workers
 - role: worker
+```
+
+#### IPv6 clusters
+You can run ipv6 only clusters using `kind`, but first you need to
+[enable ipv6 in your docker daemon][docker enable ipv6].
+
+```yaml
+# an ipv6 cluster
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+networking:
+  ipFamily: ipv6
+nodes:
+# the control plane node
+- role: control-plane
 - role: worker
 - role: worker
 ```
-
 
 ### Configure kind to use a proxy
 If you are running kind in an environment that requires a proxy, you may need to configure kind to use it.
@@ -347,3 +363,4 @@ kind, the Kubernetes cluster itself, etc.
 [Kubernetes imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [Private Registries]: /docs/user/private-registries
 [customize control plane with kubeadm]: https://kubernetes.io/docs/setup/independent/control-plane-flags/
+[docker enable ipv6]: https://docs.docker.com/config/daemon/ipv6/


### PR DESCRIPTION
This PR adds allows creating IPv6 Kubernetes clusters with `kind` and have in mind a future dual-stack implementation, considering for simplicity, only one address of each protocol.

It adds a new option `ipFamily` to the v1alpha3 API that allows choosing the IP family of the cluster.
To avoid issues with the different networking options the **podSubnet** and the **serviceSubnet** `kubeadm` values are predefined with the following values:

```
	Default PodSubnet          = "10.244.0.0/16"
	Default ServicesSubnet     = "10.96.0.0/12"
	Default PodSubnetIPv6      = "fd00:10:244::/64"
	Default ServicesSubnetIPv6 = "fd00:10:96::/112"
```

We can create a Kubernetes IPv6 cluster with the following config:

```
# necessary for conformance
kind: Cluster
apiVersion: kind.sigs.k8s.io/v1alpha3
networking:
  ipFamily: ipv6
nodes:
# the control plane node
- role: control-plane
- role: worker
- role: worker
```

**Test results with IPv4 and IPv6**
* [Conformance Tests](https://circleci.com/workflow-run/b898d823-9683-4ef2-b8ed-fba0fedf6dd5)

**References:** 
* https://github.com/kubernetes-sigs/kind/issues/280
* https://docs.google.com/document/d/17e3TWWLfnIZrsVxpln9wNi4x0JVn2oHIHDYjaeENdVE/edit?ts=5c9af5b4#heading=h.on33tp91ehzk

Fixes #280 