### PR TITLE
handle lowercase proxy variables

### DIFF
--- a/pkg/cluster/internal/create/nodes.go
+++ b/pkg/cluster/internal/create/nodes.go
@@ -155,7 +155,7 @@ func fixupNode(node *nodes.Node) error {
 	if nodes.NeedProxy() {
 		if err := node.SetProxy(); err != nil {
 			// TODO: logging here
-			return errors.Errorf("failed to set proxy for %s", node.Name())
+			return errors.Wrapf(err, "failed to set proxy for node %s", node.Name())
 		}
 	}
 

--- a/pkg/cluster/internal/create/nodes.go
+++ b/pkg/cluster/internal/create/nodes.go
@@ -155,7 +155,7 @@ func fixupNode(node *nodes.Node) error {
 	if nodes.NeedProxy() {
 		if err := node.SetProxy(); err != nil {
 			// TODO: logging here
-			return errors.Wrapf(err, "failed to set proxy for node %s", node.Name())
+			return errors.Errorf("failed to set proxy for %s", node.Name())
 		}
 	}
 

--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -141,12 +141,10 @@ func createNode(name, image, clusterLabel string, role config.NodeRole, mounts [
 
 	// pass proxy environment variables to be used by node's docker deamon
 	if NeedProxy() {
-		details := getProxyDetails()
-		proxies := ""
-		for key, val := range details {
-			proxies += fmt.Sprintf("-e %s=%s ", key, val)
+		proxyDetails := getProxyDetails()
+		for key, val := range proxyDetails.Envs {
+			runArgs = append(runArgs, "-e", fmt.Sprintf("%s=%s", key, val))
 		}
-		runArgs = append(runArgs, proxies)
 	}
 
 	// adds node specific args

--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -19,7 +19,6 @@ package nodes
 import (
 	"fmt"
 	"net"
-	"os"
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kind/pkg/cluster/config"
@@ -141,18 +140,13 @@ func createNode(name, image, clusterLabel string, role config.NodeRole, mounts [
 	}
 
 	// pass proxy environment variables to be used by node's docker deamon
-	httpProxy := os.Getenv("HTTP_PROXY")
-	if httpProxy != "" {
-		runArgs = append(runArgs, "-e", "HTTP_PROXY="+httpProxy)
-	}
-	httpsProxy := os.Getenv("HTTPS_PROXY")
-	if httpsProxy != "" {
-		runArgs = append(runArgs, "-e", "HTTPS_PROXY="+httpsProxy)
-	}
-
-	noProxy := os.Getenv("NO_PROXY")
-	if noProxy != "" {
-		runArgs = append(runArgs, "-e", "NO_PROXY="+noProxy)
+	if NeedProxy() {
+		details := getProxyDetails()
+		proxies := ""
+		for key, val := range details {
+			proxies += fmt.Sprintf("-e %s=%s ", key, val)
+		}
+		runArgs = append(runArgs, proxies)
 	}
 
 	// adds node specific args

--- a/pkg/cluster/nodes/node.go
+++ b/pkg/cluster/nodes/node.go
@@ -406,7 +406,7 @@ func (n *Node) WriteFile(dest, content string) error {
 // NeedProxy returns true if the host environment appears to have proxy settings
 func NeedProxy() bool {
 	details := getProxyDetails()
-	return len(details) > 0
+	return len(details.Envs) > 0
 }
 
 // SetProxy configures proxy settings for the node
@@ -419,7 +419,7 @@ func (n *Node) SetProxy() error {
 	details := getProxyDetails()
 	// configure Docker daemon to use proxy
 	proxies := ""
-	for key, val := range details {
+	for key, val := range details.Envs {
 		proxies += fmt.Sprintf("\"%s=%s\" ", key, val)
 	}
 
@@ -432,24 +432,30 @@ func (n *Node) SetProxy() error {
 	return nil
 }
 
+// proxyDetails contains proxy settings discovered on the host
+type proxyDetails struct {
+	Envs map[string]string
+	// future proxy details here
+}
+
 // getProxyDetails returns a struct with the host environment proxy settings
 // that should be passed to the nodes
-func getProxyDetails() map[string]string {
+func getProxyDetails() proxyDetails {
 	var proxyEnvs = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
 	var val string
-	details := make(map[string]string)
+	var details proxyDetails
+	details.Envs = make(map[string]string)
 
 	for _, name := range proxyEnvs {
 		val = os.Getenv(name)
 		if val != "" {
-			details[name] = val
+			details.Envs[name] = val
 		} else {
 			val = os.Getenv(strings.ToLower(name))
 			if val != "" {
-				details[name] = val
+				details.Envs[name] = val
 			}
 		}
 	}
 	return details
-
 }


### PR DESCRIPTION
Use an internal struct to store the proxy environment variables.

The function `getProxyDetails()` populates the map inside the internal struct with the proxy environment variables giving preference to the uppercase one.

The function `SetProxy()` consume the map inside the struct to populate the systemd drop-in file with the proxy environment variables

Reference #354

