### PR TITLE
Use _redirects file instead of dummy HTML pages

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -42,3 +42,14 @@ sectionPagesMenu = "main"
     title = "contributing"
     url = "/docs/contributing/"
     weight = 6
+
+# enable auto-generated _redirects file
+[mediaTypes."text/netlify"]
+delimiter = ""
+
+[outputFormats.REDIRECTS]
+mediaType = "text/netlify"
+baseName = "_redirects"
+
+[outputs]
+home = ["HTML", "REDIRECTS"]

--- a/site/data/apiVersions.yaml
+++ b/site/data/apiVersions.yaml
@@ -1,0 +1,2 @@
+- v1alpha1
+- v1alpha2

--- a/site/layouts/index.redirects
+++ b/site/layouts/index.redirects
@@ -1,0 +1,4 @@
+{{- $apiVersions := site.Data.apiVersions -}}
+{{- range $apiVersions }}
+/{{ . }}     https://godoc.org/sigs.k8s.io/kind/pkg/cluster/config/{{ . }}
+{{- end }}

--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -1,2 +1,0 @@
-/v1alpha1 https://godoc.org/sigs.k8s.io/kind/pkg/cluster/config/v1alpha1
-/v1alpha2 https://godoc.org/sigs.k8s.io/kind/pkg/cluster/config/v1alpha2

--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -1,0 +1,2 @@
+/v1alpha1 https://godoc.org/sigs.k8s.io/kind/pkg/cluster/config/v1alpha1
+/v1alpha2 https://godoc.org/sigs.k8s.io/kind/pkg/cluster/config/v1alpha2

--- a/site/static/v1alpha1.html
+++ b/site/static/v1alpha1.html
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta http-equiv="refresh" content="0; url=https://godoc.org/sigs.k8s.io/kind/pkg/cluster/config/v1alpha1"/>
-  </head>
-</html>

--- a/site/static/v1alpha2.html
+++ b/site/static/v1alpha2.html
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta http-equiv="refresh" content="0; url=https://godoc.org/sigs.k8s.io/kind/pkg/cluster/config/v1alpha2"/>
-  </head>
-</html>


### PR DESCRIPTION
The links work as expected:

https://deploy-preview-374--k8s-kind.netlify.com/v1alpha1
https://deploy-preview-374--k8s-kind.netlify.com/v1alpha2

To add a new version, simply add it to the list in `data/apiVersions.yaml`