### PR TITLE
add name to the HAproxy container 

### DIFF
--- a/pkg/cluster/internal/create/actions/loadbalancer/haproxy.go
+++ b/pkg/cluster/internal/create/actions/loadbalancer/haproxy.go
@@ -96,7 +96,7 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 	if err := loadBalancerNode.Command(
 		"/bin/sh", "-c",
 		fmt.Sprintf(
-			"docker run -d -v /kind/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro --network host --restart always %s",
+			"docker run -d -v /kind/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro --network host --restart always --name haproxy %s",
 			haproxy.Image,
 		),
 	).Run(); err != nil {


### PR DESCRIPTION
After adding a new control-plane to the cluster, it is necessary to reconfigure the HA proxy;
This PR add a name to the HAproxy container, making it possible to trigger config reload.

/assign @BenTheElder 
/assign @neolit123 