### PR TITLE
windows: Fix running kind: "C:\\ must be a directory to be a root"

### DIFF
--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -59,7 +59,7 @@ func Build(resources, patches []string, patchesJSON6902 []PatchJSON6902) (string
 	// which will add a drive letter if there is none. which drive letter is
 	// unimportant as the path is on the fake filesystem anyhow
 	if runtime.GOOS == "windows" {
-		fakeDir = `C:\\`
+		fakeDir = `C:\`
 	}
 
 	// NOTE: we always write this header as you cannot build without any resources


### PR DESCRIPTION
When running kind on windows, "C:\\ must be a directory to be a root" in kustomize is returned as an error.
This is since `C:\\` in the docstring syntax is expanded to "C:\\\\" which is not what we want here.