### PR TITLE
load image only if not present

### DIFF
--- a/cmd/kind/load/docker-image/docker-image.go
+++ b/cmd/kind/load/docker-image/docker-image.go
@@ -116,9 +116,8 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	// pick only the nodes that don't have the image
 	selectedNodes := []clusternodes.Node{}
 	for _, node := range candidateNodes {
-		// TODO: move under pkg/
-		cmdNode := node.Command("crictl", "-r", "/var/run/containerd/containerd.sock", "inspecti", imageName)
-		if err := cmdNode.Run(); err != nil {
+		_, err := node.ImageInspect(imageName)
+		if err != nil {
 			selectedNodes = append(selectedNodes, node)
 			log.Debugf("Image: %q not present on node %q", imageName, node.String())
 		}

--- a/pkg/cluster/nodes/node.go
+++ b/pkg/cluster/nodes/node.go
@@ -237,7 +237,7 @@ func (n *Node) WriteFile(dest, content string) error {
 // ImageInspect return low-level information on containers images inside a node
 func (n *Node) ImageInspect(containerNameOrID string) ([]string, error) {
 	cmd := n.Command(
-		"crictl", "-r", "/var/run/containerd/containerd.sock", "inspecti", containerNameOrID,
+		"crictl", "inspecti", containerNameOrID,
 	)
 	return exec.CombinedOutputLines(cmd)
 }

--- a/pkg/cluster/nodes/node.go
+++ b/pkg/cluster/nodes/node.go
@@ -234,6 +234,14 @@ func (n *Node) WriteFile(dest, content string) error {
 	return n.Command("cp", "/dev/stdin", dest).SetStdin(strings.NewReader(content)).Run()
 }
 
+// ImageInspect return low-level information on containers images inside a node
+func (n *Node) ImageInspect(containerNameOrID string) ([]string, error) {
+	cmd := n.Command(
+		"crictl", "-r", "/var/run/containerd/containerd.sock", "inspecti", containerNameOrID,
+	)
+	return exec.CombinedOutputLines(cmd)
+}
+
 // LoadImageArchive will load the image contents in the image reader to the
 // k8s.io namespace on the node such that the image can be used from a
 // Kubernetes pod

--- a/pkg/container/docker/image.go
+++ b/pkg/container/docker/image.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+// ImageInspect return low-level information on containers images
+func ImageInspect(containerNameOrID string) ([]string, error) {
+	cmd := exec.Command("docker", "image", "inspect",
+		containerNameOrID, // ... against the container
+	)
+
+	return exec.CombinedOutputLines(cmd)
+}


### PR DESCRIPTION
1. Load a docker image only on those nodes that don't have it when using `kind load docker-image` 
2. Add sanity checks to `kind load` to verify that the docker-image or the tar-image exists.
3. Load concurrently the images on the nodes

https://github.com/kubernetes-sigs/kind/issues/380