### PR TITLE
kubeconfigpath: don't validate the existence of the cluster

### DIFF
--- a/cmd/kind/get/kubeconfigpath/kubeconfigpath.go
+++ b/cmd/kind/get/kubeconfigpath/kubeconfigpath.go
@@ -20,7 +20,6 @@ package kubeconfigpath
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cluster"
@@ -53,14 +52,6 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
-	// Check if a cluster with this name exists
-	known, err := cluster.IsKnown(flags.Name)
-	if err != nil {
-		return err
-	}
-	if !known {
-		return errors.Errorf("unknown cluster %q", flags.Name)
-	}
 	// Obtain the kubeconfig path for this cluster
 	ctx := cluster.NewContext(flags.Name)
 	fmt.Println(ctx.KubeConfigPath())


### PR DESCRIPTION
Make "kind get kubeconfig-path" return the path to a cluster's
kubeconfig file regardless of the cluster existence.

fixes https://github.com/kubernetes-sigs/kind/issues/388

/kind design
/priority backlog
/cc @tao12345666333 
/assign @BenTheElder 
