### PR TITLE
New k8s

### DIFF
--- a/hack/build/push-node.sh
+++ b/hack/build/push-node.sh
@@ -39,8 +39,9 @@ DATE="$(date +v%Y%m%d)"
 TAG="${DATE}-$(git describe --always --dirty)"
 
 # build
+KUBEROOT="${KUBEROOT:-${GOPATH}/src/k8s.io/kubernetes}"
 set -x
-"${KIND}" build node-image --image="kindest/node:${TAG}"
+"${KIND}" build node-image --image="kindest/node:${TAG}" --kube-root="${KUBEROOT}"
 
 # re-tag with kubernetes version
 IMG="kindest/node:${TAG}"

--- a/pkg/cluster/config/defaults/image.go
+++ b/pkg/cluster/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.13.3@sha256:f51da441e32b69363f0979753b3e045ff7d17f7f3dbff38ca9a39ca8d920bdf1"
+const Image = "kindest/node:v1.13.4"


### PR DESCRIPTION
- add `--kube-root` to `hack/build/push-node.sh` to avoid go modules issues
- upgrade to kubernetes v1.13.4 (I've built and pushed this #369)

NOTE: I am _not_ pinning the sha, our images are fully forwards / backwards compatible and have proven to be for some time.