### PR TITLE
Release 0.2.0

### DIFF
--- a/cmd/kind/version/version.go
+++ b/cmd/kind/version/version.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Version is the kind CLI version
-const Version = "0.2.0"
+const Version = "0.3.0-alpha"
 
 // NewCommand returns a new cobra.Command for version
 func NewCommand() *cobra.Command {

--- a/cmd/kind/version/version.go
+++ b/cmd/kind/version/version.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Version is the kind CLI version
-const Version = "0.2.0-alpha"
+const Version = "0.2.0"
 
 // NewCommand returns a new cobra.Command for version
 func NewCommand() *cobra.Command {


### PR DESCRIPTION
This tags the 0.2.0 release and bumps us to 0.3.0-alpha.

All issues in the milestone are in, now we just need to write release notes and plan 0.3