### PR TITLE
Update hack/ci/e2e.sh for alpha3 changes

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -98,13 +98,13 @@ create_cluster() {
     cat <<EOF > "${ARTIFACTS}/kind-config.yaml"
 # config for 1 control plane node and 2 workers
 # necessary for conformance
-kind: Config
-apiVersion: kind.sigs.k8s.io/v1alpha2
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
 nodes:
 # the control plane node
 - role: control-plane
 - role: worker
-  replicas: 2
+- role: worker
 EOF
     # mark the cluster as up for cleanup
     # even if kind create fails, kind delete can clean up after it


### PR DESCRIPTION
This patch updates the file `hack/ci/e2e.sh` to use `v1alpha3` in the generated kind config yaml as well as removes the use of `replicas` and manually adds a second worker node entry to the same yaml.

Discovered at https://kubernetes.slack.com/archives/CEKK1KTN2/p1553287552595400?thread_ts=1553287191.592800&cid=CEKK1KTN2.