### PR TITLE
Add support for stdin config

### DIFF
--- a/pkg/cluster/config/encoding/scheme.go
+++ b/pkg/cluster/config/encoding/scheme.go
@@ -18,6 +18,7 @@ package encoding
 
 import (
 	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -53,10 +54,16 @@ func AddToScheme(scheme *runtime.Scheme) {
 // If path == "" then the default config is returned
 func Load(path string) (*config.Cluster, error) {
 	var latestPublicConfig = &v1alpha3.Cluster{}
+	var err error
+	var contents []byte
 
 	if path != "" {
 		// read in file
-		contents, err := ioutil.ReadFile(path)
+		if path == "-" {
+			contents, err = ioutil.ReadAll(os.Stdin)
+		} else {
+			contents, err = ioutil.ReadFile(path)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cluster/config/encoding/scheme.go
+++ b/pkg/cluster/config/encoding/scheme.go
@@ -52,16 +52,19 @@ func AddToScheme(scheme *runtime.Scheme) {
 // Load reads the file at path and attempts to convert into a `kind` Config; the file
 // can be one of the different API versions defined in scheme.
 // If path == "" then the default config is returned
+// If path == "-" then reads from stdin
 func Load(path string) (*config.Cluster, error) {
 	var latestPublicConfig = &v1alpha3.Cluster{}
-	var err error
-	var contents []byte
 
 	if path != "" {
-		// read in file
+		var err error
+		var contents []byte
+
 		if path == "-" {
+			// read in stdin
 			contents, err = ioutil.ReadAll(os.Stdin)
 		} else {
+			// read in file
 			contents, err = ioutil.ReadFile(path)
 		}
 		if err != nil {


### PR DESCRIPTION
It allows to read the config data from stdin when using a dash `-`  as filename for the `--config` flag


https://github.com/kubernetes-sigs/kind/issues/401