### PR TITLE
0.2.1 patch release

### DIFF
--- a/cmd/kind/version/version.go
+++ b/cmd/kind/version/version.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Version is the kind CLI version
-const Version = "0.3.0-alpha"
+const Version = "0.2.1"
 
 // NewCommand returns a new cobra.Command for version
 func NewCommand() *cobra.Command {

--- a/cmd/kind/version/version.go
+++ b/cmd/kind/version/version.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Version is the kind CLI version
-const Version = "0.2.1"
+const Version = "0.3.0-alpha"
 
 // NewCommand returns a new cobra.Command for version
 func NewCommand() *cobra.Command {

--- a/hack/release/create.sh
+++ b/hack/release/create.sh
@@ -29,11 +29,21 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
+# darwin is great
+SED="sed"
+if which gsed &>/dev/null; then
+  SED="gsed"
+fi
+if ! (${SED} --version 2>&1 | grep -q GNU); then
+  echo "!!! GNU sed is required.  If on OS X, use 'brew install gnu-sed'." >&2
+  exit 1
+fi
+
 VERSION_FILE="./cmd/kind/version/version.go"
 
 # update version in go code to $1
 set_version() {
-    sed -i "s/Version = .*/Version = \"${1}\"/" "${VERSION_FILE}"
+    ${SED} -i "s/Version = .*/Version = \"${1}\"/" "${VERSION_FILE}"
     echo "Updated ${VERSION_FILE} for ${1}"
 }
 


### PR DESCRIPTION
This release contains:
- #397 enable hostpath provisioner
- #407 fix possible panics in failed cluster creation
- #413 fix `kind build node-image` on macOS

There are also a few more commits, but they are changes to the site or scripts, not kind itself. 

```
$ git shortlog 0.2.0..0.2.1
Benjamin Elder (7):
      version 0.3.0-alpha
      remove stale TODO
      fix joinWorkers panic on multiple errored workers
      fix potential panic in node creation
      always build kubernetes for linux
      support gsed in hack/release/create.sh
      version 0.2.1

Joe Julian (1):
      feature: enable hostpath provisioner

Kubernetes Prow Robot (6):
      Merge pull request #395 from BenTheElder/release-0.2.0
      Merge pull request #384 from neolit123/site-v1alpha3
      Merge pull request #397 from joejulian/add_hostpath_flag
      Merge pull request #399 from akutz/bugfix/hack-ci-e2e-no-replicas
      Merge pull request #407 from BenTheElder/no-panic-on-err
      Merge pull request #413 from BenTheElder/linux-please

Lubomir I. Ivanov (1):
      site: add examples for v1alpha3

akutz (1):
      Update hack/ci/e2e.sh for alpha3 changes
```

I also had to create a fix for the release script on macOS :sweat_smile: