### PR TITLE
Add github submission templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -18,7 +18,7 @@ labels: kind/bug
 
 **Environment:**
 
-- Kind version: (use `kind version`):
+- kind version: (use `kind version`):
 - Kubernetes version: (use `kubectl version`):
 - Docker version: (use `docker info`):
 - OS (e.g. from `/etc/os-release`):

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -18,7 +18,7 @@ labels: kind/bug
 
 **Environment:**
 
-- KIND version: (use `kind version`):
+- Kind version: (use `kind version`):
 - Kubernetes version: (use `kubectl version`):
 - Docker version: (use `docker info`):
 - OS (e.g. from `/etc/os-release`):

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Report a bug encountered using kind
+labels: kind/bug
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!-->
+
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment:**
+
+- KIND version: (use `kind version`):
+- Kubernetes version: (use `kubectl version`):
+- Docker version: (use `docker info`):
+- OS (e.g. from `/etc/os-release`):
+

--- a/.github/ISSUE_TEMPLATE/cleanup.md
+++ b/.github/ISSUE_TEMPLATE/cleanup.md
@@ -1,0 +1,13 @@
+---
+name: Cleanup 
+about: Pay down technical debt, reduce friction, etc.
+labels: kind/cleanup
+
+---
+
+<!-- Please use this template while filing an issue to highlight technical debt to be paid down, or friction to be reduced -->
+
+**What should be cleaned up or changed**:
+
+**Why is this needed**:
+

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,11 @@
+---
+name: Documentation Request
+about: Suggest what should be documented in kind
+labels: kind/documentation
+
+---
+<!-- Please only use this template for submitting documentation requests -->
+
+**What would you like to be documented**:
+
+**Why is this needed**:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to kind
+labels: kind/feature
+
+---
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why is this needed**:


### PR DESCRIPTION
Github submission templates are important for the contributor experience, it helps the project maintainers to have better issues and the users to write better bug reports/suggestions

Fixes #323 