### PR TITLE
lookup kuberoot correctly

### DIFF
--- a/pkg/build/kube/source.go
+++ b/pkg/build/kube/source.go
@@ -29,7 +29,7 @@ const ImportPath = "k8s.io/kubernetes"
 // FindSource attempts to locate a kubernetes checkout using go's build package
 func FindSource() (root string, err error) {
 	// look up the source the way go build would
-	pkg, err := build.Default.Import(ImportPath, ".", build.FindOnly)
+	pkg, err := build.Default.Import(ImportPath, build.Default.GOPATH, build.FindOnly)
 	if err == nil && maybeKubeDir(pkg.Dir) {
 		return pkg.Dir, nil
 	}


### PR DESCRIPTION
this _should_ fix our issues with finding k8s.io/kubernetes in module mode afaict, however this does still require that the user checkout kubernetes to `$(go env GOPATH)/src/k8s.io/kubernetes` or else specify `--kube-root`