### PR TITLE
haproxy: prepull the image during build

### DIFF
--- a/pkg/build/node/const.go
+++ b/pkg/build/node/const.go
@@ -23,6 +23,9 @@ const (
 	defaultCNIManifestLocation = "/kind/manifests/default-cni.yaml"
 )
 
+// defaultHAProxyImage defines the haproxy image:tag
+const defaultHAProxyImage = "haproxy:1.8.14-alpine"
+
 /*
 The default CNI manifest and images are from weave currently.
 

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -391,8 +391,11 @@ func (c *BuildContext) prePullImages(dir, containerID string) error {
 		return err
 	}
 
-	// all builds should isntall the default CNI images currently
+	// all builds should install the default CNI images currently
 	requiredImages = append(requiredImages, defaultCNIImages...)
+
+	// install the haproxy image
+	requiredImages = append(requiredImages, defaultHAProxyImage)
 
 	// Create "images" subdir.
 	imagesDir := path.Join(dir, "bits", "images")

--- a/pkg/cluster/internal/haproxy/const.go
+++ b/pkg/cluster/internal/haproxy/const.go
@@ -18,6 +18,3 @@ package haproxy
 
 // ControlPlanePort defines the port where the control plane is listening on the load balancer node
 const ControlPlanePort = 6443
-
-// Image defines the haproxy image:tag
-const Image = "haproxy:1.8.14-alpine"


### PR DESCRIPTION
Currently the haproxy image is being pulled when
haproxy is being run on the LB nodes.

To prevent that, prepull the image and support air gapped
HA setups. This requires finding what tag was preloaded
for the haproxy image.

In case no haproxy tags are found in the node-image
pull the default tag.

/kind feature
/priority important-longterm
