### PR TITLE
Adjusted node suffix to start at 1

### DIFF
--- a/pkg/cluster/internal/create/nodes.go
+++ b/pkg/cluster/internal/create/nodes.go
@@ -271,7 +271,7 @@ func makeNodeNamer(clusterName string) func(string) string {
 	counter := make(map[string]int)
 	return func(role string) string {
 		count := 1
-		suffix := ""
+		suffix := "1"
 		if v, ok := counter[role]; ok {
 			count += v
 			suffix = fmt.Sprintf("%d", count)


### PR DESCRIPTION
Adjusted the node suffix in `makeNodeNamer` to start at `1`


fixes #447