### PR TITLE
Use kind as product_name in the nodes

### DIFF
--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -276,6 +276,13 @@ func (c *BuildContext) buildImage(dir string) error {
 		log.Errorf("Image build Failed! %v", err)
 		return err
 	}
+	// create product_name file
+	if err = execInBuild("/bin/sh", "-c",
+		`echo "kind" > /kind/product_name`,
+	); err != nil {
+		log.Errorf("Image build Failed! %v", err)
+		return err
+	}
 
 	// copy artifacts in
 	if err = execInBuild("rsync", "-r", "/build/bits/", "/kind/"); err != nil {

--- a/pkg/cluster/nodes/node.go
+++ b/pkg/cluster/nodes/node.go
@@ -231,6 +231,10 @@ func (n *Node) FixMounts() error {
 	if err := n.Command("mount", "--make-shared", "/var/lib/docker").Run(); err != nil {
 		return err
 	}
+	// use kind as product name to avoid issues with features that depends on it
+	if err := n.Command("mount", "-o", "ro,bind", "/kind/product_name", "/sys/class/dmi/id/product_name").Run(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/cluster/nodes/node.go
+++ b/pkg/cluster/nodes/node.go
@@ -231,9 +231,16 @@ func (n *Node) FixMounts() error {
 	if err := n.Command("mount", "--make-shared", "/var/lib/docker").Run(); err != nil {
 		return err
 	}
-	// use kind as product name to avoid issues with features that depends on it
-	if err := n.Command("mount", "-o", "ro,bind", "/kind/product_name", "/sys/class/dmi/id/product_name").Run(); err != nil {
-		return err
+	// return kind as product_name to avoid issues with features that depends on this parameter
+	// check if the fake product_name exists to be backwards compatible
+	haveKindProductName := true
+	if err := n.Command("test", "-f", "/kind/product_name").Run(); err != nil {
+		haveKindProductName = false
+	}
+	if haveKindProductName {
+		if err := n.Command("mount", "-o", "ro,bind", "/kind/product_name", "/sys/class/dmi/id/product_name").Run(); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Kubernetes clusters use the  `product_name` for some features and that makes `kind` fail

Fixes #426