### PR TITLE
[WIP] Run HAProxy as a node

### DIFF
--- a/hack/build/push-haproxy.sh
+++ b/hack/build/push-haproxy.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# builds and pushes the haproxy image for all architectures
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# cd to the repo root
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "${REPO_ROOT}"
+
+# cd to the image
+cd ./images/haproxy
+
+IMAGE="${IMAGE:-kindest/haproxy}"
+TAG="${TAG:-0.1.0}"
+
+ARCHES=(
+  "amd64,amd64"
+  "arm,arm32v6"
+  "arm64,arm64v8"
+  "ppc64le,ppc64le"
+)
+
+# build all images
+images=()
+for arch in "${ARCHES[@]}"; do
+  # split arch pair
+  build_arch="$(sed -r 's/,.*//' <<< "${arch}")"
+  tag_arch="$(sed -r 's/.*,//' <<< "${arch}")"
+  # build image
+  image="${IMAGE}:${build_arch}-${TAG}"
+  docker build "--build-arg=ARCH=${tag_arch}" -f Dockerfile -t "${image}" .
+  docker push "${image}"
+  images+=("${image}")
+done
+
+# This option is required for running the docker manifest command
+export DOCKER_CLI_EXPERIMENTAL="enabled"
+
+# create and push the manifest
+docker manifest create "${IMAGE}:${TAG}" "${images[@]}"
+for image in "${images[@]}"; do
+    # image:arch-tag, grab arch
+    arch="$(sed -r 's/.*://; s/-.*//' <<< "${image}")"
+    docker manifest annotate "${IMAGE}:${TAG}" "${image}" --arch "${arch}"
+done
+docker manifest push -p "${IMAGE}:{TAG}"

--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# standard haproxy image + minimal config so the container will not exit
+ARG ARCH="amd64"
+ARG BASE="haproxy:1.8.14-alpine"
+FROM ${ARCH}/${BASE}
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/images/haproxy/README.md
+++ b/images/haproxy/README.md
@@ -1,0 +1,3 @@
+This image is just the upstream image + a minimal config.
+
+TODO: eliminate this image.

--- a/images/haproxy/haproxy.cfg
+++ b/images/haproxy/haproxy.cfg
@@ -1,0 +1,9 @@
+# minimal config file to avoid haproxy exiting due to invalid config
+# kind will rewrite this config at runtime
+frontend controlPlane
+    bind 0.0.0.0:6443
+    mode tcp
+    default_backend kube-apiservers
+
+backend kube-apiservers
+    mode tcp

--- a/pkg/cluster/internal/create/actions/config/config.go
+++ b/pkg/cluster/internal/create/actions/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kind/pkg/cluster/config"
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions"
@@ -84,6 +85,8 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 		// TODO(bentheelder): logging here
 		return errors.Wrap(err, "failed to generate kubeadm config content")
 	}
+
+	log.Debug("Using kubeadm config:\n" + kubeadmConfig)
 
 	// copy the config to the node
 	if err := node.WriteFile("/kind/kubeadm.conf", kubeadmConfig); err != nil {

--- a/pkg/cluster/internal/create/actions/loadbalancer/haproxy.go
+++ b/pkg/cluster/internal/create/actions/loadbalancer/haproxy.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/internal/haproxy"
 	"sigs.k8s.io/kind/pkg/cluster/internal/kubeadm"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
+	"sigs.k8s.io/kind/pkg/container/docker"
 )
 
 // Action implements and action for configuring and starting the
@@ -57,7 +58,7 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 	}
 
 	// otherwise notify the user
-	ctx.Status.Start("Starting the external load balancer ⚖️")
+	ctx.Status.Start("Configuring the external load balancer ⚖️")
 	defer ctx.Status.End(false)
 
 	// collect info about the existing controlplane nodes
@@ -87,20 +88,14 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 	}
 
 	// create haproxy config on the node
-	if err := loadBalancerNode.WriteFile("/kind/haproxy.cfg", haproxyConfig); err != nil {
+	if err := loadBalancerNode.WriteFile("/usr/local/etc/haproxy/haproxy.cfg", haproxyConfig); err != nil {
 		// TODO: logging here
 		return errors.Wrap(err, "failed to copy haproxy config to node")
 	}
 
-	// starts a docker container with HA proxy load balancer
-	if err := loadBalancerNode.Command(
-		"/bin/sh", "-c",
-		fmt.Sprintf(
-			"docker run -d -v /kind/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro --network host --restart always --name haproxy %s",
-			haproxy.Image,
-		),
-	).Run(); err != nil {
-		return errors.Wrap(err, "failed to start haproxy")
+	// reload the config
+	if err := docker.Kill("SIGHUP", loadBalancerNode.Name()); err != nil {
+		return errors.Wrap(err, "failed to reload haproxy")
 	}
 
 	ctx.Status.End(true)

--- a/pkg/cluster/internal/create/nodes.go
+++ b/pkg/cluster/internal/create/nodes.go
@@ -26,6 +26,7 @@ import (
 
 	"sigs.k8s.io/kind/pkg/cluster/config"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
+	"sigs.k8s.io/kind/pkg/cluster/internal/haproxy"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/container/cri"
 	logutil "sigs.k8s.io/kind/pkg/log"
@@ -197,7 +198,7 @@ func nodesToCreate(cfg *config.Cluster, clusterName string) []nodeSpec {
 		role := constants.ExternalLoadBalancerNodeRoleValue
 		desiredNodes = append(desiredNodes, nodeSpec{
 			Name:             nameNode(role),
-			Image:            controlPlaneImage, // TODO(bentheelder): get from config instead
+			Image:            haproxy.Image, // TODO(bentheelder): get from config instead
 			Role:             role,
 			ExtraMounts:      []cri.Mount{},
 			APIServerAddress: cfg.Networking.APIServerAddress,

--- a/pkg/cluster/internal/haproxy/const.go
+++ b/pkg/cluster/internal/haproxy/const.go
@@ -20,4 +20,4 @@ package haproxy
 const ControlPlanePort = 6443
 
 // Image defines the haproxy image:tag
-const Image = "haproxy:1.8.14-alpine"
+const Image = "kindest/haproxy:0.1.0" //"haproxy:1.8.14-alpine"

--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -141,8 +141,6 @@ func createNode(name, image, clusterLabel, role string, mounts []cri.Mount, extr
 		"--label", clusterLabel,
 		// label the node with the role ID
 		"--label", fmt.Sprintf("%s=%s", constants.NodeRoleKey, role),
-		// explicitly set the entrypoint
-		"--entrypoint=/usr/local/bin/entrypoint",
 	}
 
 	// pass proxy environment variables to be used by node's docker deamon
@@ -163,10 +161,6 @@ func createNode(name, image, clusterLabel, role string, mounts []cri.Mount, extr
 	id, err := docker.Run(
 		image,
 		docker.WithRunArgs(runArgs...),
-		docker.WithContainerArgs(
-			// explicitly pass the entrypoint argument
-			"/sbin/init",
-		),
 		docker.WithMounts(mounts),
 	)
 

--- a/pkg/cluster/nodes/util.go
+++ b/pkg/cluster/nodes/util.go
@@ -31,14 +31,16 @@ func GetControlPlaneEndpoint(allNodes []Node) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// if there is no external load balancer
+	// if there is no external load balancer return the empty string
 	if node == nil {
 		return "", nil
 	}
-	// gets the IP of the load balancer
+
+	// get the IP and port for the load balancer
 	loadBalancerIP, err := node.IP()
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get IP for node: %s", node.Name())
 	}
+
 	return fmt.Sprintf("%s:%d", loadBalancerIP, haproxy.ControlPlanePort), nil
 }

--- a/pkg/container/docker/kill.go
+++ b/pkg/container/docker/kill.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+// Kill sends the named signal to the container
+func Kill(signal, containerNameOrID string) error {
+	cmd := exec.Command(
+		"docker", "kill",
+		"-s", signal,
+		containerNameOrID,
+	)
+	return cmd.Run()
+}


### PR DESCRIPTION
Follow-up to #461, this unbreaks HA mode and simplifies it.

Now we run an haproxy image directly as the external load-balancer node.

To do this we have to get around a few hurdles:
- #468 so we can avoid specifying the entrypoint for nodes (and use the normal haproxy entrypoint)
- we need to have a valid config in the haproxy image always or the container will exit (WIP: our own image with a minimal config added, per the upstream docs https://hub.docker.com/_/haproxy?tab=description)
- we need to send SIGHUP to the node to reload the config after writing it instead of starting a container on the node
