### PR TITLE
docker cmder: more accurately choose to allocate a tty

### DIFF
--- a/pkg/container/docker/exec.go
+++ b/pkg/container/docker/exec.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"sigs.k8s.io/kind/pkg/exec"
+	"sigs.k8s.io/kind/pkg/log"
 )
 
 // containerCmder implements exec.Cmder for docker containers
@@ -66,9 +67,10 @@ func (c *containerCmd) Run() error {
 			"-i", // interactive so we can supply input
 		)
 	}
-	if c.stderr != nil || c.stdout != nil {
+	// if the command is hooked up to the processes's output we want a tty
+	if log.IsTerminal(c.stderr) || log.IsTerminal(c.stdout) {
 		args = append(args,
-			"-t", // use a tty so we can get output
+			"-t",
 		)
 	}
 	// set env


### PR DESCRIPTION
we only want a TTY when we've EG hooked up the command's stdout to the parent process's stdout

cc @aojea 
xref: #458 