### PR TITLE
break up kubeadm init action into logical actions

### DIFF
--- a/pkg/cluster/internal/create/actions/installcni/cni.go
+++ b/pkg/cluster/internal/create/actions/installcni/cni.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package installcni implements the install CNI action
+package installcni
+
+import (
+	"github.com/pkg/errors"
+
+	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions"
+	"sigs.k8s.io/kind/pkg/cluster/nodes"
+)
+
+type action struct{}
+
+// NewAction returns a new action for installing default CNI
+func NewAction() actions.Action {
+	return &action{}
+}
+
+// Execute runs the action
+func (a *action) Execute(ctx *actions.ActionContext) error {
+	ctx.Status.Start("Installing CNI 🔌")
+	defer ctx.Status.End(false)
+
+	allNodes, err := ctx.Nodes()
+	if err != nil {
+		return err
+	}
+
+	// get the target node for this task
+	node, err := nodes.BootstrapControlPlaneNode(allNodes)
+	if err != nil {
+		return err
+	}
+
+	// install the CNI network plugin
+	// TODO(bentheelder): support other overlay networks
+	// first probe for a pre-installed manifest
+	haveDefaultCNIManifest := true
+	if err := node.Command("test", "-f", "/kind/manifests/default-cni.yaml").Run(); err != nil {
+		haveDefaultCNIManifest = false
+	}
+	if haveDefaultCNIManifest {
+		// we found the default manifest, install that
+		// the images should already be loaded along with kubernetes
+		if err := node.Command(
+			"kubectl", "create", "--kubeconfig=/etc/kubernetes/admin.conf",
+			"-f", "/kind/manifests/default-cni.yaml",
+		).Run(); err != nil {
+			return errors.Wrap(err, "failed to apply overlay network")
+		}
+	} else {
+		// fallback to our old pattern of installing weave using their recommended method
+		if err := node.Command(
+			"/bin/sh", "-c",
+			`kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version --kubeconfig=/etc/kubernetes/admin.conf | base64 | tr -d '\n')"`,
+		).Run(); err != nil {
+			return errors.Wrap(err, "failed to apply overlay network")
+		}
+	}
+
+	// mark success
+	ctx.Status.End(true)
+	return nil
+}

--- a/pkg/cluster/internal/create/actions/installstorage/storage.go
+++ b/pkg/cluster/internal/create/actions/installstorage/storage.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package installstorage implements the an action to isntall a default
+// storageclass
+package installstorage
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions"
+	"sigs.k8s.io/kind/pkg/cluster/nodes"
+)
+
+type action struct{}
+
+// NewAction returns a new action for installing storage
+func NewAction() actions.Action {
+	return &action{}
+}
+
+// Execute runs the action
+func (a *action) Execute(ctx *actions.ActionContext) error {
+	ctx.Status.Start("Installing StorageClass 💾")
+	defer ctx.Status.End(false)
+
+	allNodes, err := ctx.Nodes()
+	if err != nil {
+		return err
+	}
+
+	// get the target node for this task
+	node, err := nodes.BootstrapControlPlaneNode(allNodes)
+	if err != nil {
+		return err
+	}
+
+	// add the default storage class
+	if err := addDefaultStorageClass(node); err != nil {
+		return errors.Wrap(err, "failed to add default storage class")
+	}
+
+	// mark success
+	ctx.Status.End(true)
+	return nil
+}
+
+// a default storage class
+// we need this for e2es (StatefulSet)
+const defaultStorageClassManifest = `# host-path based default storage class
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  namespace: kube-system
+  name: standard
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+provisioner: kubernetes.io/host-path`
+
+func addDefaultStorageClass(controlPlane *nodes.Node) error {
+	in := strings.NewReader(defaultStorageClassManifest)
+	cmd := controlPlane.Command(
+		"kubectl",
+		"--kubeconfig=/etc/kubernetes/admin.conf", "apply", "-f", "-",
+	)
+	cmd.SetStdin(in)
+	return cmd.Run()
+}

--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -33,6 +33,8 @@ import (
 	logutil "sigs.k8s.io/kind/pkg/log"
 
 	configaction "sigs.k8s.io/kind/pkg/cluster/internal/create/actions/config"
+	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/installcni"
+	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/installstorage"
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/kubeadminit"
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/kubeadmjoin"
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/loadbalancer"
@@ -85,6 +87,8 @@ func Cluster(ctx *context.Context, cfg *config.Cluster, opts *Options) error {
 	if opts.SetupKubernetes {
 		actionsToRun = append(actionsToRun,
 			kubeadminit.NewAction(),                   // run kubeadm init
+			installcni.NewAction(),                    // install CNI
+			installstorage.NewAction(),                // install StorageClass
 			kubeadmjoin.NewAction(),                   // run kubeadm join
 			waitforready.NewAction(opts.WaitForReady), // wait for cluster readiness
 		)


### PR DESCRIPTION
installing CNI and the default StorageClass were always logically distinct actions, but they were bundled into the kubeadminit step, breaking that up. xref: #324 

updated output:
```
$ time kind create cluster
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.14.1) 🖼
 ✓ Preparing nodes 📦 
 ✓ Creating kubeadm config 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Cluster creation complete. You can now use the cluster with:

export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
kubectl cluster-info

real    0m32.512s
user    0m0.753s
sys     0m0.580s
```