### PR TITLE
Add option to print raw kubeconfig

### DIFF
--- a/cmd/kind/get/get.go
+++ b/cmd/kind/get/get.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/cmd/kind/get/clusters"
+	"sigs.k8s.io/kind/cmd/kind/get/kubeconfig"
 	"sigs.k8s.io/kind/cmd/kind/get/kubeconfigpath"
 	"sigs.k8s.io/kind/cmd/kind/get/nodes"
 )
@@ -31,12 +32,13 @@ func NewCommand() *cobra.Command {
 		Args: cobra.NoArgs,
 		// TODO(bentheelder): more detailed usage
 		Use:   "get",
-		Short: "Gets one of [clusters, nodes, kubeconfig-path]",
-		Long:  "Gets one of [clusters, nodes, kubeconfig-path]",
+		Short: "Gets one of [clusters, nodes, kubeconfig, kubeconfig-path]",
+		Long:  "Gets one of [clusters, nodes, kubeconfig, kubeconfig-path]",
 	}
 	// add subcommands
 	cmd.AddCommand(clusters.NewCommand())
 	cmd.AddCommand(nodes.NewCommand())
+	cmd.AddCommand(kubeconfig.NewCommand())
 	cmd.AddCommand(kubeconfigpath.NewCommand())
 	return cmd
 }

--- a/cmd/kind/get/kubeconfig/kubeconfig.go
+++ b/cmd/kind/get/kubeconfig/kubeconfig.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubeconfig implements the `kubeconfig` command
+package kubeconfig
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+
+	"sigs.k8s.io/kind/pkg/cluster"
+	clusternodes "sigs.k8s.io/kind/pkg/cluster/nodes"
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+type flagpole struct {
+	Name     string
+	Internal bool
+}
+
+// NewCommand returns a new cobra.Command for getting the kubeconfig with the internal node IP address
+func NewCommand() *cobra.Command {
+	flags := &flagpole{}
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "kubeconfig",
+		Short: "prints cluster kubeconfig",
+		Long:  "prints cluster kubeconfig",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags, cmd, args)
+		},
+	}
+	cmd.Flags().StringVar(
+		&flags.Name,
+		"name",
+		cluster.DefaultName,
+		"the cluster context name",
+	)
+	cmd.Flags().BoolVar(
+		&flags.Internal,
+		"internal",
+		false,
+		"get internal kubeconfig",
+	)
+	return cmd
+}
+
+func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	// List nodes by cluster context name
+	n, err := clusternodes.ListByCluster()
+	if err != nil {
+		return err
+	}
+	nodes, known := n[flags.Name]
+	if !known {
+		return errors.Errorf("unknown cluster %q", flags.Name)
+	}
+	// get the bootstrap node to get the kubeconfig
+	node, err := clusternodes.BootstrapControlPlaneNode(nodes)
+	if err != nil {
+		return err
+	}
+	if flags.Internal {
+		// grab kubeconfig version from one of the control plane nodes
+		cmdNode := node.Command("cat", "/etc/kubernetes/admin.conf")
+		exec.InheritOutput(cmdNode)
+		if err := cmdNode.Run(); err != nil {
+			return errors.Wrap(err, "failed to get cluster internal kubeconfig")
+		}
+	} else {
+		ctx := cluster.NewContext(flags.Name)
+		out, err := ioutil.ReadFile(ctx.KubeConfigPath())
+		if err != nil {
+			return errors.Wrap(err, "failed to get cluster kubeconfig")
+		}
+		fmt.Print(string(out))
+	}
+
+	return nil
+}


### PR DESCRIPTION
For some use cases, i.e federation and multinode clusters, the kubeconfig with the internal ip addresses is needed. Currently, kind exports the kubeconfig replacing the node ip address with localhost and the port that is forwarded to the host.

This adds an option to print the raw kubeconfig from a cluster with 
`kind get kubeconfig --name cluster` if you want the host kubeconfig or

`kind get kubeconfig --name cluster --internal` if you want the kubeconfig inside the nodes (with the internal  IP addresses)

Fixes https://github.com/kubernetes-sigs/kind/issues/111 #566 