### PR TITLE
refactor and dedupe concurrency logic

### DIFF
--- a/pkg/cluster/logs/logs.go
+++ b/pkg/cluster/logs/logs.go
@@ -21,16 +21,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sync"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/kind/pkg/cluster/nodes"
-	"sigs.k8s.io/kind/pkg/exec"
-	"sigs.k8s.io/kind/pkg/util"
-)
 
-type errFn func() error
+	"sigs.k8s.io/kind/pkg/cluster/nodes"
+	"sigs.k8s.io/kind/pkg/concurrent"
+	"sigs.k8s.io/kind/pkg/exec"
+)
 
 // Collect collects logs related to / from the cluster nodes and the host
 // system to the specified directory
@@ -57,7 +55,7 @@ func Collect(nodes []nodes.Node, dir string) error {
 		}
 	}
 	// construct a slice of methods to collect logs
-	fns := []errFn{
+	fns := []func() error{
 		// TODO(bentheelder): record the kind version here as well
 		// record info about the host docker
 		execToPathFn(
@@ -80,7 +78,7 @@ func Collect(nodes []nodes.Node, dir string) error {
 		})
 
 		fns = append(fns, func() error {
-			return coalesce(
+			return concurrent.Coalesce(
 				// record info about the node container
 				execToPathFn(
 					exec.Command("docker", "inspect", name),
@@ -106,37 +104,9 @@ func Collect(nodes []nodes.Node, dir string) error {
 			)
 		})
 	}
-	// run and collect up all errors
-	return coalesce(fns...)
-}
 
-// colaese runs fns concurrently, returning an Errors if there are > 1 errors
-func coalesce(fns ...errFn) error {
-	// run all fns concurrently
-	ch := make(chan error, len(fns))
-	var wg sync.WaitGroup
-	for _, fn := range fns {
-		wg.Add(1)
-		go func(f errFn) {
-			defer wg.Done()
-			ch <- f()
-		}(fn)
-	}
-	wg.Wait()
-	close(ch)
-	// collect up and return errors
-	errs := []error{}
-	for err := range ch {
-		if err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if len(errs) > 1 {
-		return util.Flatten(errs)
-	} else if len(errs) == 1 {
-		return errs[0]
-	}
-	return nil
+	// run and collect up all errors
+	return concurrent.Coalesce(fns...)
 }
 
 // untar reads the tar file from r and writes it into dir.

--- a/pkg/concurrent/concurrent.go
+++ b/pkg/concurrent/concurrent.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concurrent
+
+import (
+	"sync"
+
+	"sigs.k8s.io/kind/pkg/util"
+)
+
+// UntilError runs all funcs in separate goroutines, returning the
+// first non-nil error returned from funcs, or nil if all funcs return nil
+func UntilError(funcs []func() error) error {
+	errCh := make(chan error, len(funcs))
+	for _, f := range funcs {
+		f := f // capture f
+		go func() {
+			errCh <- f()
+		}()
+	}
+	for i := 0; i < len(funcs); i++ {
+		if err := <-errCh; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Coalesce runs fns concurrently, returning an Errors if there are > 1 errors
+func Coalesce(fns ...func() error) error {
+	// run all fns concurrently
+	ch := make(chan error, len(fns))
+	var wg sync.WaitGroup
+	for _, fn := range fns {
+		wg.Add(1)
+		go func(f func() error) {
+			defer wg.Done()
+			ch <- f()
+		}(fn)
+	}
+	wg.Wait()
+	close(ch)
+	// collect up and return errors
+	errs := []error{}
+	for err := range ch {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 1 {
+		return util.Flatten(errs)
+	} else if len(errs) == 1 {
+		return errs[0]
+	}
+	return nil
+}


### PR DESCRIPTION
we use these in a few places, this kind of code tends to be error prone, so let's dedupe it.