### PR TITLE
bump golang 1.12.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # Only requires docker on the host
 
 # settings
-GO_VERSION=1.12.4
+GO_VERSION=1.12.5
 GO_IMAGE=golang:$(GO_VERSION)
 REPO_ROOT=$(PWD)
 CACHE_VOLUME=kind-build-cache


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>


go1.12.5 (released 2019/05/06) includes fixes to the compiler, the linker,
the go command, the runtime, and the <code>os</code> package. See the
<a href="https://github.com/golang/go/issues?q=milestone%3AGo1.12.5">Go 1.12.5 milestone</a> on our issue tracker for details.

https://github.com/golang/go/compare/go1.12.4...go1.12.5

