### PR TITLE
Feat/kubeconfig multi cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.2.1
 	k8s.io/api v0.0.0-20181026145037-6e4b5aa967ee // indirect
 	k8s.io/apimachinery v0.0.0-20181126191516-4a9a8137c0a1
 	k8s.io/client-go v7.0.0+incompatible

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -71,6 +71,15 @@ func CombinedOutputLines(cmd Cmd) (lines []string, err error) {
 	return lines, err
 }
 
+// Output is like os/exec's cmd.Output(), but over our Cmd interface
+func Output(cmd Cmd) ([]byte, error) {
+	var buff bytes.Buffer
+	cmd.SetStdout(&buff)
+	cmd.SetStderr(&buff)
+	err := cmd.Run()
+	return buff.Bytes(), err
+}
+
 // InheritOutput sets cmd's output to write to the current process's stdout and stderr
 func InheritOutput(cmd Cmd) Cmd {
 	cmd.SetStderr(os.Stderr)


### PR DESCRIPTION
Modify kubeconfig for multiple clusters ( #112 )

kubeadm does not currently allow to configure a user reference id,
and instead always uses kubernetes-admin.  This causes a problem
when we create multiple clusters with Kind and want to use
each corresponding kubeconfig file at the same time in KUBECONFIG.

Until kubeadm supports configuring a user reference id, the only
option to fix this for Kind is to modify the kubeconfig file that
kubeadm provides.  As Kind already did this with the server name,
it made sense to take the logic further and also make the user
reference id unique to a cluster.

Three approaches were considered:

1- continue with the current approach of parsing each line of
   the admin.conf kubeconfig file, and make the modifications
   necessary.  After implementing this approach, the solution
   seemed quite brittle as it uses regex but no yaml structure.

2- use the go package yaml.v2 to -fully- parse the yaml of the
   admin.conf kubeconfig file, make the modifications, and then
   output the new yaml kubeconfig file.  This solution requires
   to define a detailed struct of every field contained in the
   original yaml file. Having to map every field in advance is
   brittle as any modification that kubeadm may make to the file
   in the future would require adaptation in Kind.

3- use the go package yaml.v2 to -generically- parse the yaml of
   the admin.conf kubeconfig file, make the modifications, and then
   output the new yaml kubeconfig file.  This solution only
   accesses the yaml fields that are required to be modified.
   Although any future changes from kubeadm to those fields would
   require modifications in Kind, modifications to all other fields
   would not.

This PR implements solution #3 which was felt to be the most
future-proof and least brittle of the three.