### PR TITLE
simplify output (just bin/ instead of _output/bin), speed up verify-g…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-# build outputs
+# build and test outputs
+/bin
 /_output
 /_artifacts
 
-# used for the code generators
+# used for the code generators only
 /vendor
 
 # macOS

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ REPO_ROOT:=${CURDIR}
 # autodetect host GOOS and GOARCH by default, even if go is not installed
 GOOS=$(shell hack/util/goos.sh)
 GOARCH=$(shell hack/util/goarch.sh)
+# make install will place binaries here
+# the default path attempst to mimic go install
 INSTALL_DIR=$(shell hack/util/goinstalldir.sh)
 # use the official module proxy by default
 GOPROXY=https://proxy.golang.org
@@ -31,8 +33,8 @@ CACHE_VOLUME=kind-build-cache
 
 # variables for consistent logic, don't override these
 CONTAINER_REPO_DIR=/src/kind
-CONTAINER_OUT_DIR=$(CONTAINER_REPO_DIR)/_output/bin
-HOST_OUT_DIR=$(REPO_ROOT)/_output/bin
+CONTAINER_OUT_DIR=$(CONTAINER_REPO_DIR)/bin
+OUT_DIR=$(REPO_ROOT)/bin
 
 # standard "make" target -> builds
 all: build
@@ -47,18 +49,19 @@ clean-cache:
 
 # creates the output directory
 out-dir:
-	mkdir -p $(REPO_ROOT)/_output/bin
+	mkdir -p $(OUT_DIR)
 
 # cleans the output directory
 clean-output:
-	rm -rf $(REPO_ROOT)/_output
+	rm -rf $(OUT_DIR)/
 
-# builds kind in a container, outputs to $(REPO_ROOT)/_output/bin
+# builds kind in a container, outputs to $(OUT_DIR)
 kind: make-cache out-dir
 	docker run \
 		--rm \
 		-v $(CACHE_VOLUME):/go \
 		-e GOCACHE=/go/cache \
+		-v $(OUT_DIR):/out \
 		-v $(REPO_ROOT):$(CONTAINER_REPO_DIR) \
 		-w $(CONTAINER_REPO_DIR) \
 		-e GO111MODULE=on \
@@ -67,14 +70,14 @@ kind: make-cache out-dir
 		-e GOOS=$(GOOS) \
 		-e GOARCH=$(GOARCH) \
 		$(GO_IMAGE) \
-		go build -v -o $(CONTAINER_OUT_DIR)/kind .
+		go build -v -o /out/kind .
 
 # alias for building kind
 build: kind
 
 # use: make install INSTALL_DIR=/usr/local/bin
 install: build
-	cp $(HOST_OUT_DIR)/kind $(INSTALL_DIR)/kind
+	cp $(OUT_DIR)/kind $(INSTALL_DIR)/kind
 
 # standard cleanup target
 clean: clean-cache clean-output

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ build: kind
 
 # use: make install INSTALL_DIR=/usr/local/bin
 install: build
-	cp $(OUT_DIR)/kind $(INSTALL_DIR)/kind
+	install $(OUT_DIR)/kind $(INSTALL_DIR)/kind
 
 # standard cleanup target
 clean: clean-cache clean-output

--- a/hack/build/cross.sh
+++ b/hack/build/cross.sh
@@ -23,7 +23,7 @@ set -o pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
-OUT="${REPO_ROOT}/_output/bin"
+OUT="${REPO_ROOT}/bin"
 mkdir -p "${OUT}"
 
 CLEAN="false"

--- a/hack/build/push-base.sh
+++ b/hack/build/push-base.sh
@@ -23,7 +23,7 @@ cd "${REPO_ROOT}"
 
 # ensure we have up to date kind
 make build
-KIND="${REPO_ROOT}/_output/bin/kind"
+KIND="${REPO_ROOT}/bin/kind"
 
 # generate tag
 DATE="$(date +v%Y%m%d)"

--- a/hack/build/push-node.sh
+++ b/hack/build/push-node.sh
@@ -23,7 +23,7 @@ cd "${REPO_ROOT}"
 
 # ensure we have up to date kind
 make build
-KIND="${REPO_ROOT}/_output/bin/kind"
+KIND="${REPO_ROOT}/bin/kind"
 
 # generate tag
 DATE="$(date +v%Y%m%d)"

--- a/hack/update-generated.sh
+++ b/hack/update-generated.sh
@@ -18,7 +18,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 cd "${REPO_ROOT}"
 
 # enable modules and the proxy cache
@@ -27,7 +27,7 @@ GOPROXY="${GOPROXY:-https://proxy.golang.org}"
 export GOPROXY
 
 # build the generators
-BINDIR="${REPO_ROOT}/_output/bin"
+BINDIR="${REPO_ROOT}/bin"
 go build -o "${BINDIR}/defaulter-gen" k8s.io/code-generator/cmd/defaulter-gen
 go build -o "${BINDIR}/deepcopy-gen" k8s.io/code-generator/cmd/deepcopy-gen
 go build -o "${BINDIR}/conversion-gen" k8s.io/code-generator/cmd/conversion-gen

--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -23,7 +23,7 @@ cd "${REPO_ROOT}"
 
 
 # place to stick temp binaries
-BINDIR="${REPO_ROOT}/_output/bin"
+BINDIR="${REPO_ROOT}/bin"
 mkdir -p "${BINDIR}"
 
 # TMP_REPO is used in make_temp_repo_copy
@@ -38,10 +38,14 @@ cleanup() {
 
 # copies repo into a temp root saved to TMP_REPO
 make_temp_repo_copy() {
-  # we need to copy everything but _output (which is .gitignore anyhow)
+  # we need to copy everything but bin (and the old _output) (which is .gitignore anyhow)
   find . \
     -mindepth 1 -maxdepth 1 \
-    -type d -path "./_output" -prune -o \
+    \( \
+      -type d -path "./.git" -o \
+      -type d -path "./bin" -o \
+      -type d -path "./_output" \
+    \) -prune -o \
     -exec bash -c 'cp -r "${0}" "${1}/${0}" >/dev/null 2>&1' {} "${TMP_REPO}" \;
 }
 
@@ -53,11 +57,12 @@ main() {
 
   # run generated code update script
   cd "${TMP_REPO}"
-  hack/update-generated.sh
+  REPO_ROOT="${TMP_REPO}" hack/update-generated.sh
 
   # make sure the temp repo has no changes relative to the real repo
   diff=$(diff -Nupr \
           -x ".git" \
+          -x "bin" \
           -x "_output" \
           -x "vendor" \
          "${REPO_ROOT}" "${TMP_REPO}" 2>/dev/null || true)


### PR DESCRIPTION
…enerated

bin/ is more idiomatic, `_output` is a weird holdover from kubernetes. we should switch this, and then document and stop changing it. Hardcoding `${REPO}/bin/kind` in other scripts is slightly more reasonable than `${REPO}/_output/bin/kind`

- don't copy git when verifying generated, tweak update-generated make that work correctly. speeds up the check 

- use `install` instead of `cp`. this seems to be widely available in busybox, bsd utils (and macOS), gnu coreutils. `install` has better behavior for installing.

cc @neolit123 @krzyzacy 