### PR TITLE
move tools to their own go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.5 // indirect
-	github.com/jteeuwen/go-bindata v0.0.0-20180305030458-6025e8de665b
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
 	github.com/onsi/ginkgo v1.7.0 // indirect
@@ -24,16 +23,12 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.2 // indirect
 	golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b
-	golang.org/x/lint v0.0.0-20180702182130-06c8688daad7
-	golang.org/x/tools v0.0.0-20180911133044-677d2ff680c1 // indirect
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.0.0-20181026145037-6e4b5aa967ee // indirect
 	k8s.io/apimachinery v0.0.0-20181126191516-4a9a8137c0a1
 	k8s.io/client-go v7.0.0+incompatible
-	k8s.io/code-generator v0.0.0-20181116211957-405721ab9678
-	k8s.io/gengo v0.0.0-20181113154421-fd15ee9cc2f7 // indirect
 	k8s.io/klog v0.1.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20181025202442-3a9b63ab1e39 // indirect
 	sigs.k8s.io/kustomize v2.0.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,6 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
-github.com/jteeuwen/go-bindata v0.0.0-20180305030458-6025e8de665b h1:BGB0sx4T5xzIDW5RhrrKiLB1GieBaJtRyANyax4SlzY=
-github.com/jteeuwen/go-bindata v0.0.0-20180305030458-6025e8de665b/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -66,8 +64,6 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b h1:2b9XGzhjiYsYPnKXoEfL7klWZQIt8IfyRCz62gCqqlQ=
 golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/lint v0.0.0-20180702182130-06c8688daad7 h1:00BeQWmeaGazuOrq8Q5K5d3/cHaGuFrZzpaHBXfrsUA=
-golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181005035420-146acd28ed58 h1:otZG8yDCO4LVps5+9bxOeNiCvgmOyt96J3roHTYs7oE=
 golang.org/x/net v0.0.0-20181005035420-146acd28ed58/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -77,8 +73,6 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUk
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20180911133044-677d2ff680c1 h1:dzEuQYa6+a3gROnSlgly5ERUm4SZKJt+dh+4iSbO+bI=
-golang.org/x/tools v0.0.0-20180911133044-677d2ff680c1/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
@@ -99,10 +93,6 @@ k8s.io/apimachinery v0.0.0-20181126191516-4a9a8137c0a1 h1:u/v3rSGNjiTxclqUNHYgSr
 k8s.io/apimachinery v0.0.0-20181126191516-4a9a8137c0a1/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/client-go v7.0.0+incompatible h1:kiH+Y6hn+pc78QS/mtBfMJAMIIaWevHi++JvOGEEQp4=
 k8s.io/client-go v7.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
-k8s.io/code-generator v0.0.0-20181116211957-405721ab9678 h1:HymXxD0e1DpTrSSXAj+vsAag/sqvq/mCv4J2OONqM90=
-k8s.io/code-generator v0.0.0-20181116211957-405721ab9678/go.mod h1:MYiN+ZJZ9HkETbgVZdWw2AsuAi9PZ4V80cwfuf2axe8=
-k8s.io/gengo v0.0.0-20181113154421-fd15ee9cc2f7 h1:zjNgw2qqBQmKd0S59lGZBQqFxJqUZroVbDphfnVm5do=
-k8s.io/gengo v0.0.0-20181113154421-fd15ee9cc2f7/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.1.0 h1:I5HMfc/DtuVaGR1KPwUrTc476K8NCqNBldC7H4dYEzk=
 k8s.io/klog v0.1.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/kube-openapi v0.0.0-20181025202442-3a9b63ab1e39 h1:4I91xwvUbr2jxozOwbUBFBmo6XvBdoC1RLc85Kfg2dY=

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,0 +1,12 @@
+module sigs.k8s.io/kind/hack/tools
+
+go 1.12
+
+require (
+	github.com/spf13/pflag v1.0.2 // indirect
+	golang.org/x/lint v0.0.0-20180702182130-06c8688daad7
+	golang.org/x/tools v0.0.0-20180911133044-677d2ff680c1 // indirect
+	k8s.io/code-generator v0.0.0-20181116211957-405721ab9678
+	k8s.io/gengo v0.0.0-20181113154421-fd15ee9cc2f7 // indirect
+	k8s.io/klog v0.1.0 // indirect
+)

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -1,0 +1,12 @@
+github.com/spf13/pflag v1.0.2 h1:Fy0orTDgHdbnzHcsOgfCN4LtHf0ec3wwtiwJqwvf3Gc=
+github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+golang.org/x/lint v0.0.0-20180702182130-06c8688daad7 h1:00BeQWmeaGazuOrq8Q5K5d3/cHaGuFrZzpaHBXfrsUA=
+golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+golang.org/x/tools v0.0.0-20180911133044-677d2ff680c1 h1:dzEuQYa6+a3gROnSlgly5ERUm4SZKJt+dh+4iSbO+bI=
+golang.org/x/tools v0.0.0-20180911133044-677d2ff680c1/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+k8s.io/code-generator v0.0.0-20181116211957-405721ab9678 h1:HymXxD0e1DpTrSSXAj+vsAag/sqvq/mCv4J2OONqM90=
+k8s.io/code-generator v0.0.0-20181116211957-405721ab9678/go.mod h1:MYiN+ZJZ9HkETbgVZdWw2AsuAi9PZ4V80cwfuf2axe8=
+k8s.io/gengo v0.0.0-20181113154421-fd15ee9cc2f7 h1:zjNgw2qqBQmKd0S59lGZBQqFxJqUZroVbDphfnVm5do=
+k8s.io/gengo v0.0.0-20181113154421-fd15ee9cc2f7/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/klog v0.1.0 h1:I5HMfc/DtuVaGR1KPwUrTc476K8NCqNBldC7H4dYEzk=
+k8s.io/klog v0.1.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -10,9 +10,6 @@ import (
 	// linter(s)
 	_ "golang.org/x/lint"
 
-	// for packing binary data
-	_ "github.com/jteeuwen/go-bindata/go-bindata"
-
 	// kubernetes code generators
 	_ "k8s.io/code-generator/cmd/conversion-gen"
 	_ "k8s.io/code-generator/cmd/deepcopy-gen"

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -33,3 +33,6 @@ GOPROXY="${GOPROXY:-https://proxy.golang.org}"
 export GOPROXY
 
 go mod tidy
+
+cd "hack/tools"
+go mod tidy

--- a/hack/update-generated.sh
+++ b/hack/update-generated.sh
@@ -28,9 +28,13 @@ export GOPROXY
 
 # build the generators
 BINDIR="${REPO_ROOT}/bin"
+# use the tools module
+cd "hack/tools"
 go build -o "${BINDIR}/defaulter-gen" k8s.io/code-generator/cmd/defaulter-gen
 go build -o "${BINDIR}/deepcopy-gen" k8s.io/code-generator/cmd/deepcopy-gen
 go build -o "${BINDIR}/conversion-gen" k8s.io/code-generator/cmd/conversion-gen
+# go back to the root
+cd "${REPO_ROOT}"
 
 # turn off module mode before running the generators
 # https://github.com/kubernetes/code-generator/issues/69

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -22,7 +22,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
 # check for gofmt diffs
-diff=$(find . -name "*.go" -type f -print0 | xargs -0 gofmt -s -d 2>&1)
+diff=$(find . -name "*.go" | grep -v "\\/vendor\\/" | xargs gofmt -s -d 2>&1)
 if [[ -n "${diff}" ]]; then
   echo "${diff}"
   echo

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -27,4 +27,12 @@ export GO111MODULE="on"
 GOPROXY="${GOPROXY:-https://proxy.golang.org}"
 export GOPROXY
 
-go run golang.org/x/lint/golint -set_exit_status ./pkg/... ./cmd/... .
+# build golint
+BINDIR="${REPO_ROOT}/bin"
+# use the tools module
+cd "hack/tools"
+go build -o "${BINDIR}/golint" golang.org/x/lint/golint
+# go back to the root
+cd "${REPO_ROOT}"
+
+"${BINDIR}/golint" -set_exit_status ./pkg/... ./cmd/... .


### PR DESCRIPTION
quick patch on my way to meetings :^)

this will make operations that don't involve the dev-time tools (like building in CI) faster since they won't need to do anything with those packages

also dropped go-bindata, which we stopped actually using a while back.