### PR TITLE
Configurable podSubnet

### DIFF
--- a/hack/ci/build-all.sh
+++ b/hack/ci/build-all.sh
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# simple script to ensure all of our builds work
+# simple CI script to verify kind's own sources
+# TODO(bentheelder): rename / refactor. consider building kindnetd
 
 set -o errexit
 set -o nounset
@@ -28,5 +29,11 @@ export GO111MODULE="on"
 GOPROXY="${GOPROXY:-https://proxy.golang.org}"
 export GOPROXY
 
-# build
+# build and kind
 go install -v .
+go test -v ./...
+
+# build and test kindnetd
+cd ./cmd/kindnetd
+go install -v .
+go test -v ./...

--- a/pkg/cluster/config/default.go
+++ b/pkg/cluster/config/default.go
@@ -46,6 +46,10 @@ func SetDefaults_Cluster(obj *Cluster) {
 	if obj.Networking.APIServerAddress == "" {
 		obj.Networking.APIServerAddress = "127.0.0.1"
 	}
+	// default the pod CIDR
+	if obj.Networking.PodSubnet == "" {
+		obj.Networking.PodSubnet = "10.244.0.0/16"
+	}
 }
 
 // SetDefaults_Node sets uninitialized fields to their default value.

--- a/pkg/cluster/config/fuzzer/fuzzer.go
+++ b/pkg/cluster/config/fuzzer/fuzzer.go
@@ -39,6 +39,8 @@ func fuzzConfig(obj *config.Cluster, c fuzz.Continue) {
 		Image: "foo:bar",
 		Role:  config.ControlPlaneRole,
 	}}
+	obj.Networking.APIServerAddress = "127.0.0.1"
+	obj.Networking.PodSubnet = "10.244.0.0/16"
 }
 
 func fuzzNode(obj *config.Node, c fuzz.Continue) {

--- a/pkg/cluster/config/types.go
+++ b/pkg/cluster/config/types.go
@@ -96,4 +96,7 @@ type Networking struct {
 	//
 	// Defaults to 127.0.0.1
 	APIServerAddress string
+	// PodSubnet is the CIDR used for pod IPs
+	// kind will select a default if unspecified
+	PodSubnet string
 }

--- a/pkg/cluster/config/v1alpha3/default.go
+++ b/pkg/cluster/config/v1alpha3/default.go
@@ -46,6 +46,10 @@ func SetDefaults_Cluster(obj *Cluster) {
 	if obj.Networking.APIServerAddress == "" {
 		obj.Networking.APIServerAddress = "127.0.0.1"
 	}
+	// default the pod CIDR
+	if obj.Networking.PodSubnet == "" {
+		obj.Networking.PodSubnet = "10.244.0.0/16"
+	}
 }
 
 // SetDefaults_Node sets uninitialized fields to their default value.

--- a/pkg/cluster/config/v1alpha3/types.go
+++ b/pkg/cluster/config/v1alpha3/types.go
@@ -96,4 +96,7 @@ type Networking struct {
 	//
 	// Defaults to 127.0.0.1
 	APIServerAddress string `json:"apiServerAddress,omitempty"`
+	// PodSubnet is the CIDR used for pod IPs
+	// kind will select a default if unspecified
+	PodSubnet string `json:"podSubnet,omitempty"`
 }

--- a/pkg/cluster/config/v1alpha3/zz_generated.conversion.go
+++ b/pkg/cluster/config/v1alpha3/zz_generated.conversion.go
@@ -103,6 +103,7 @@ func Convert_config_Cluster_To_v1alpha3_Cluster(in *config.Cluster, out *Cluster
 func autoConvert_v1alpha3_Networking_To_config_Networking(in *Networking, out *config.Networking, s conversion.Scope) error {
 	out.APIServerPort = in.APIServerPort
 	out.APIServerAddress = in.APIServerAddress
+	out.PodSubnet = in.PodSubnet
 	return nil
 }
 
@@ -114,6 +115,7 @@ func Convert_v1alpha3_Networking_To_config_Networking(in *Networking, out *confi
 func autoConvert_config_Networking_To_v1alpha3_Networking(in *config.Networking, out *Networking, s conversion.Scope) error {
 	out.APIServerPort = in.APIServerPort
 	out.APIServerAddress = in.APIServerAddress
+	out.PodSubnet = in.PodSubnet
 	return nil
 }
 

--- a/pkg/cluster/config/validate.go
+++ b/pkg/cluster/config/validate.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"net"
+
 	"github.com/pkg/errors"
 
 	"sigs.k8s.io/kind/pkg/util"
@@ -46,6 +48,11 @@ func (c *Cluster) Validate() error {
 	numControlPlane, anyControlPlane := numByRole[ControlPlaneRole]
 	if !anyControlPlane || numControlPlane < 1 {
 		errs = append(errs, errors.Errorf("must have at least one %s node", string(ControlPlaneRole)))
+	}
+
+	// podSubnet should be a valid CIDR
+	if _, _, err := net.ParseCIDR(c.Networking.PodSubnet); err != nil {
+		errs = append(errs, errors.Wrapf(err, "invalid podSubnet"))
 	}
 
 	if len(errs) > 0 {

--- a/pkg/cluster/config/validate_test.go
+++ b/pkg/cluster/config/validate_test.go
@@ -22,6 +22,84 @@ import (
 	"sigs.k8s.io/kind/pkg/util"
 )
 
+func TestClusterValidate(t *testing.T) {
+	cases := []struct {
+		Name         string
+		Cluster      Cluster
+		ExpectErrors int
+	}{
+		{
+			Name: "Defaulted",
+			Cluster: func() Cluster {
+				c := Cluster{}
+				SetDefaults_Cluster(&c)
+				return c
+			}(),
+		},
+		{
+			Name: "bogus podSubnet",
+			Cluster: func() Cluster {
+				c := Cluster{}
+				SetDefaults_Cluster(&c)
+				c.Networking.PodSubnet = "aa"
+				return c
+			}(),
+			ExpectErrors: 1,
+		},
+		{
+			Name: "missing control-plane",
+			Cluster: func() Cluster {
+				c := Cluster{}
+				SetDefaults_Cluster(&c)
+				c.Nodes = []Node{}
+				return c
+			}(),
+			ExpectErrors: 1,
+		},
+		{
+			Name: "bogus node",
+			Cluster: func() Cluster {
+				c := Cluster{}
+				SetDefaults_Cluster(&c)
+				n, n2 := Node{}, Node{}
+				SetDefaults_Node(&n)
+				SetDefaults_Node(&n2)
+				n.Role = "bogus"
+				c.Nodes = []Node{n, n2}
+				return c
+			}(),
+			ExpectErrors: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc //capture loop variable
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.Cluster.Validate()
+			// the error can be:
+			// - nil, in which case we should expect no errors or fail
+			if err == nil {
+				if tc.ExpectErrors != 0 {
+					t.Error("received no errors but expected errors for case")
+				}
+				return
+			}
+			// - not castable to *Errors, in which case we have the wrong error type ...
+			configErrors, ok := err.(util.Errors)
+			if !ok {
+				t.Errorf("config.Validate should only return nil or ConfigErrors{...}, got: %v", err)
+				return
+			}
+			// - ConfigErrors, in which case expect a certain number of errors
+			errors := configErrors.Errors()
+			if len(errors) != tc.ExpectErrors {
+				t.Errorf("expected %d errors but got len(%v) = %d", tc.ExpectErrors, errors, len(errors))
+			}
+		})
+	}
+}
+
 // TODO(fabriziopandini): ideally this should use scheme.Default, but this creates a circular dependency
 // So the current solution is to mimic defaulting for the validation test
 func newDefaultedNode(role NodeRole) Node {
@@ -72,7 +150,9 @@ func TestNodeValidate(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc //capture loop variable
 		t.Run(tc.TestName, func(t *testing.T) {
+			t.Parallel()
 			err := tc.Node.Validate()
 			// the error can be:
 			// - nil, in which case we should expect no errors or fail

--- a/pkg/cluster/internal/create/actions/config/config.go
+++ b/pkg/cluster/internal/create/actions/config/config.go
@@ -79,7 +79,7 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 			ControlPlaneEndpoint: controlPlaneEndpoint,
 			APIBindPort:          kubeadm.APIServerPort,
 			Token:                kubeadm.Token,
-			PodSubnet:            "10.244.0.0/16", // TODO: make configurable
+			PodSubnet:            ctx.Config.Networking.PodSubnet,
 		},
 	)
 

--- a/pkg/cluster/internal/create/actions/installcni/cni.go
+++ b/pkg/cluster/internal/create/actions/installcni/cni.go
@@ -70,12 +70,11 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to parse CNI manifest template")
 		}
-		// TODO(bentheelder): make podsubnet configurable
 		var out bytes.Buffer
 		err = t.Execute(&out, &struct {
 			PodSubnet string
 		}{
-			PodSubnet: "10.244.0.0/16",
+			PodSubnet: ctx.Config.Networking.PodSubnet,
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to execute CNI manifest template")

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -109,7 +109,7 @@ controllerManagerExtraArgs:
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
 networking:
-  podSubnet: {{ .PodSubnet }}
+  podSubnet: "{{ .PodSubnet }}"
 ---
 apiVersion: kubeadm.k8s.io/v1alpha2
 kind: NodeConfiguration
@@ -145,7 +145,7 @@ apiServerCertSANs: [localhost]
 controllerManagerExtraArgs:
   enable-hostpath-provisioner: "true"
 networking:
-  podSubnet: {{ .PodSubnet }}
+  podSubnet: "{{ .PodSubnet }}"
 ---
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: InitConfiguration
@@ -209,7 +209,7 @@ controllerManager:
   extraArgs:
     enable-hostpath-provisioner: "true"
 networking:
-  podSubnet: {{ .PodSubnet }}
+  podSubnet: "{{ .PodSubnet }}"
 ---
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: InitConfiguration


### PR DESCRIPTION
Adds to #500, only commits from `add podSubnet to config` and forward are new.

Adds `Cluster.network.podSubnet` config field, and respects it.