### PR TITLE
support disabling default cni

### DIFF
--- a/pkg/cluster/config/types.go
+++ b/pkg/cluster/config/types.go
@@ -99,4 +99,7 @@ type Networking struct {
 	// PodSubnet is the CIDR used for pod IPs
 	// kind will select a default if unspecified
 	PodSubnet string
+	// If DisableDefaultCNI is true, kind will not install the default CNI setup.
+	// Instead the user should install their own CNI after creating the cluster.
+	DisableDefaultCNI bool
 }

--- a/pkg/cluster/config/v1alpha3/types.go
+++ b/pkg/cluster/config/v1alpha3/types.go
@@ -99,4 +99,7 @@ type Networking struct {
 	// PodSubnet is the CIDR used for pod IPs
 	// kind will select a default if unspecified
 	PodSubnet string `json:"podSubnet,omitempty"`
+	// If DisableDefaultCNI is true, kind will not install the default CNI setup.
+	// Instead the user should install their own CNI after creating the cluster.
+	DisableDefaultCNI bool `json:"disableDefaultCNI,omitempty"`
 }

--- a/pkg/cluster/config/v1alpha3/zz_generated.conversion.go
+++ b/pkg/cluster/config/v1alpha3/zz_generated.conversion.go
@@ -104,6 +104,7 @@ func autoConvert_v1alpha3_Networking_To_config_Networking(in *Networking, out *c
 	out.APIServerPort = in.APIServerPort
 	out.APIServerAddress = in.APIServerAddress
 	out.PodSubnet = in.PodSubnet
+	out.DisableDefaultCNI = in.DisableDefaultCNI
 	return nil
 }
 
@@ -116,6 +117,7 @@ func autoConvert_config_Networking_To_v1alpha3_Networking(in *config.Networking,
 	out.APIServerPort = in.APIServerPort
 	out.APIServerAddress = in.APIServerAddress
 	out.PodSubnet = in.PodSubnet
+	out.DisableDefaultCNI = in.DisableDefaultCNI
 	return nil
 }
 

--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -86,8 +86,16 @@ func Cluster(ctx *context.Context, cfg *config.Cluster, opts *Options) error {
 	}
 	if opts.SetupKubernetes {
 		actionsToRun = append(actionsToRun,
-			kubeadminit.NewAction(),                   // run kubeadm init
-			installcni.NewAction(),                    // install CNI
+			kubeadminit.NewAction(), // run kubeadm init
+		)
+		// this step might be skipped, but is next after init
+		if !cfg.Networking.DisableDefaultCNI {
+			actionsToRun = append(actionsToRun,
+				installcni.NewAction(), // install CNI
+			)
+		}
+		// add remaining steps
+		actionsToRun = append(actionsToRun,
 			installstorage.NewAction(),                // install StorageClass
 			kubeadmjoin.NewAction(),                   // run kubeadm join
 			waitforready.NewAction(opts.WaitForReady), // wait for cluster readiness


### PR DESCRIPTION
fixes https://github.com/kubernetes-sigs/kind/issues/205 (though perhaps we need to follow up with docs :upside_down_face: )

With this feature, users can skip the CNI installation and instead install their own CNI using the usual mechanisms (`kubectl apply -f my-cni-manifest.yaml ...`). This is an advanced use case and not strongly supported, but should be available. It seems a number of projects have found installing / testing their own CNI useful, and this makes it easier to do without poking at kind's internals :wink: 