### PR TITLE
use fmt.Println instead of println

### DIFF
--- a/cmd/kind/version/version.go
+++ b/cmd/kind/version/version.go
@@ -18,6 +18,8 @@ limitations under the License.
 package version
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -33,7 +35,7 @@ func NewCommand() *cobra.Command {
 		Short: "prints the kind CLI version",
 		Long:  "prints the kind CLI version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			println(Version)
+			fmt.Println(Version)
 			return nil
 		},
 	}

--- a/pkg/build/kube/bazelbuildbits.go
+++ b/pkg/build/kube/bazelbuildbits.go
@@ -136,7 +136,7 @@ func fixOldImageTags(path, arch string) error {
 	archSuffix := "-" + arch
 	repositoryFixer := func(repository string) string {
 		if !strings.HasSuffix(repository, archSuffix) {
-			println("fixed: " + repository + " -> " + repository + archSuffix)
+			fmt.Println("fixed: " + repository + " -> " + repository + archSuffix)
 			repository = repository + archSuffix
 		}
 		return repository


### PR DESCRIPTION
println uses stderr which is surprising and unintended. supersedes https://github.com/kubernetes-sigs/kind/pull/203