### PR TITLE
Build cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,22 +43,27 @@ all: build
 
 # creates the cache volume
 make-cache:
+	@echo + Ensuring build cache volume exists
 	docker volume create $(CACHE_VOLUME)
 
 # cleans the cache volume
 clean-cache:
+	@echo + Removing build cache volume
 	docker volume rm $(CACHE_VOLUME)
 
 # creates the output directory
 out-dir:
+	@echo + Ensuring build output directory exists
 	mkdir -p $(OUT_DIR)
 
 # cleans the output directory
 clean-output:
+	@echo + Removing build output directory
 	rm -rf $(OUT_DIR)/
 
 # builds kind in a container, outputs to $(OUT_DIR)
 kind: make-cache out-dir
+	@echo + Building kind binary
 	docker run \
 		--rm \
 		-v $(CACHE_VOLUME):/go \
@@ -74,12 +79,14 @@ kind: make-cache out-dir
 		--user $(UID):$(GID) \
 		$(GO_IMAGE) \
 		go build -v -o /out/kind .
+	@echo + Built kind binary to $(OUT_DIR)/kind
 
 # alias for building kind
 build: kind
 
 # use: make install INSTALL_DIR=/usr/local/bin
 install: build
+	@echo + Copying kind binary to INSTALL_DIR
 	install $(OUT_DIR)/kind $(INSTALL_DIR)/kind
 
 # standard cleanup target

--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,20 @@
 # settings
 REPO_ROOT:=${CURDIR}
 # autodetect host GOOS and GOARCH by default, even if go is not installed
-GOOS=$(shell hack/util/goos.sh)
-GOARCH=$(shell hack/util/goarch.sh)
+GOOS?=$(shell hack/util/goos.sh)
+GOARCH?=$(shell hack/util/goarch.sh)
 # make install will place binaries here
 # the default path attempst to mimic go install
-INSTALL_DIR=$(shell hack/util/goinstalldir.sh)
+INSTALL_DIR?=$(shell hack/util/goinstalldir.sh)
+# the output binary name, overridden when cross compiling
+KIND_BINARY_NAME?=kind
 # use the official module proxy by default
-GOPROXY=https://proxy.golang.org
+GOPROXY?=https://proxy.golang.org
 # default build image
-GO_VERSION=1.12.5
-GO_IMAGE=golang:$(GO_VERSION)
+GO_VERSION?=1.12.5
+GO_IMAGE?=golang:$(GO_VERSION)
 # docker volume name, used as a go module / build cache
-CACHE_VOLUME=kind-build-cache
+CACHE_VOLUME?=kind-build-cache
 
 # variables for consistent logic, don't override these
 CONTAINER_REPO_DIR=/src/kind
@@ -78,8 +80,8 @@ kind: make-cache out-dir
 		-e GOARCH=$(GOARCH) \
 		--user $(UID):$(GID) \
 		$(GO_IMAGE) \
-		go build -v -o /out/kind .
-	@echo + Built kind binary to $(OUT_DIR)/kind
+		go build -v -o /out/$(KIND_BINARY_NAME) .
+	@echo + Built kind binary to $(OUT_DIR)/$(KIND_BINARY_NAME)
 
 # alias for building kind
 build: kind
@@ -87,7 +89,7 @@ build: kind
 # use: make install INSTALL_DIR=/usr/local/bin
 install: build
 	@echo + Copying kind binary to INSTALL_DIR
-	install $(OUT_DIR)/kind $(INSTALL_DIR)/kind
+	install $(OUT_DIR)/$(KIND_BINARY_NAME) $(INSTALL_DIR)/$(KIND_BINARY_NAME)
 
 # standard cleanup target
 clean: clean-cache clean-output

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This will put `kind` in `$(go env GOPATH)/bin`. If you encounter the error
 shown [here](https://golang.org/doc/code.html#GOPATH) or do manual installation by cloning the repo and run 
 `make install` from the repository.
 
-Without installing go, kind can be built reproducibly with docker using `make install`.
+Without installing go, kind can be built reproducibly with docker using `make build`.
 
 Stable binaries are also available on the [releases] page. Stable releases are
 generally recommended for CI usage in particular.

--- a/hack/build/cross.sh
+++ b/hack/build/cross.sh
@@ -44,13 +44,9 @@ build() {
     GOARCH="${2}"
     export GOOS
     export GOARCH
-    # build without CGO for cross compiling and distributing
-    CGO_ENABLED=0
-    export CGO_ENABLED
-    local out_path
-    out_path="${OUT}/kind-${GOOS}-${GOARCH}"
-    echo "${out_path}"
-    go build -o "${out_path}" sigs.k8s.io/kind
+    KIND_BINARY_NAME="kind-${GOOS}-${GOARCH}"
+    export KIND_BINARY_NAME
+    make build
 }
 
 # TODO(bentheelder): support more platforms

--- a/hack/release/create.sh
+++ b/hack/release/create.sh
@@ -16,7 +16,7 @@
 # creates a release and following pre-release commit for `kind`
 # builds binaries between the commits
 # Use like: create.sh <release-version> <next-prerelease-version>
-# EG: create.sh 0.0.1 0.1.0-alpha
+# EG: create.sh v0.3.0 v0.4.0-alpha
 set -o nounset
 set -o errexit
 set -o pipefail

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -23,7 +23,7 @@ This will put `kind` in `$(go env GOPATH)/bin`. You may need to add that directo
 shown [here](https://golang.org/doc/code.html#GOPATH) if you encounter the error
 `kind: command not found` after installation.
 
-Without installing go, kind can be built reproducibly with docker using `make install`.
+Without installing go, kind can be built reproducibly with docker using `make build`.
 
 Stable binaries are also available on the [releases] page. Stable releases are
 generally recommended for CI usage in particular.


### PR DESCRIPTION
I want to land this before 0.3 -- `make install` is not the right default target yet, since without go installed it will still basically install to `$GOPATH/bin`, we need time to figure out what the behavior should be then.

Instead:
- suggest `make build`
- the make build prints steps and the target output, eg a cached build (less output):
```console
$ make build
+ Ensuring build cache volume exists
docker volume create kind-build-cache
kind-build-cache
+ Ensuring build output directory exists
mkdir -p /usr/local/google/home/bentheelder/go/src/sigs.k8s.io/kind/bin
+ Building kind binary
docker run \
        --rm \
        -v kind-build-cache:/go \
        -e GOCACHE=/go/cache \
        -v /usr/local/google/home/bentheelder/go/src/sigs.k8s.io/kind/bin:/out \
        -v /usr/local/google/home/bentheelder/go/src/sigs.k8s.io/kind:/src/kind \
        -w /src/kind \
        -e GO111MODULE=on \
        -e GOPROXY=https://proxy.golang.org \
        -e CGO_ENABLED=0 \
        -e GOOS=linux \
        -e GOARCH=amd64 \
        --user 484827:89939 \
        golang:1.12.5 \
        go build -v -o /out/kind .
+ Built kind binary to /usr/local/google/home/bentheelder/go/src/sigs.k8s.io/kind/bin/kind
```

----

Also other fixes for the release:
- make some make variables overrideable properly
- update cross.sh (used when releasing) to use the reproducible build
- update the release instructions to use v notation