### PR TITLE
suggest make build for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can install the latest bleeding edge kind code with `GO111MODULE="on" go get
 This will put `kind` in `$(go env GOPATH)/bin`. If you encounter the error
 `kind: command not found` after installation then you may need to either add that directory to your `$PATH` as
 shown [here](https://golang.org/doc/code.html#GOPATH) or do manual installation by cloning the repo and run 
-`make install` from the repository.
+`make build` from the repository.
 
 Without installing go, kind can be built reproducibly with docker using `make build`.
 

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -15,7 +15,7 @@ This guide covers getting started with the `kind` command.
 ## Installation
 
 You can either install the latest bleeding edge kind code with `GO111MODULE="on" go get -u sigs.k8s.io/kind@master` or clone this repo 
-and run `make install` from the repository.
+and run `make build` from the repository.
 
 **NOTE**: please use the latest go to do this, ideally go 1.12.5 or greater.
 


### PR DESCRIPTION
while `make install` is nicer if you do have `$GOPATH/bin` setup in `$PATH` it's not optimal yet if you don't have one and don't specify `INSTALL_DIR`. for now let's suggest `make build` and follow up with more detailed instructions explaining `make install` usage and `INSTALL_DIR` (especially given we may need to explain $PATH to some of our users...)