### PR TITLE
mark release v0.3.0

### DIFF
--- a/cmd/kind/version/version.go
+++ b/cmd/kind/version/version.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Version is the kind CLI version
-const Version = "v0.3.0"
+const Version = "v0.4.0-alpha"
 
 // NewCommand returns a new cobra.Command for version
 func NewCommand() *cobra.Command {

--- a/cmd/kind/version/version.go
+++ b/cmd/kind/version/version.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Version is the kind CLI version
-const Version = "0.3.0-alpha"
+const Version = "v0.3.0"
 
 // NewCommand returns a new cobra.Command for version
 func NewCommand() *cobra.Command {


### PR DESCRIPTION
xref: #531 
created with `hack/release/create.sh v0.3.0 v0.4.0-alpha` at 924359c5bc9778920b75035d8a0a61d7c2a0c827