### PR TITLE
use v0.3.0 instead of master in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 kind is a tool for running local Kubernetes clusters using Docker container "nodes".  
 kind is primarily designed for testing Kubernetes 1.11+, initially targeting the [conformance tests].
 
-If you have [go] and [docker] installed `GO111MODULE="on" go get -u sigs.k8s.io/kind@master && kind create cluster` is all you need!
+If you have [go] and [docker] installed `GO111MODULE="on" go get -u sigs.k8s.io/kind@v0.3.0 && kind create cluster` is all you need!
 
 <img src="https://gist.githubusercontent.com/BenTheElder/621bc321fc6d9506fd936feb36d32dd0/raw/13fe81c219e64b4917575c8988e06719c072c7f1/kind-demo.gif" alt="2x speed `kind create cluster` demo" />
 
@@ -25,7 +25,7 @@ kind bootstraps each "node" with [kubeadm][kubeadm]. For more details see [the d
 
 ## Installation and usage
 
-You can install the latest bleeding edge kind code with `GO111MODULE="on" go get -u sigs.k8s.io/kind@master`.
+You can install kind with `GO111MODULE="on" go get -u sigs.k8s.io/kind@v0.3.0`.
 
 **NOTE**: please use the latest go to do this, ideally go 1.12.5 or greater.
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -3,7 +3,7 @@
 [kind] is a tool for running local Kubernetes clusters using Docker container "nodes".  
 kind is primarily designed for testing Kubernetes 1.11+, initially targeting the [conformance tests].
 
-If you have [go] and [docker] installed `GO111MODULE="on" go get -u sigs.k8s.io/kind@master && kind create cluster` is all you need!
+If you have [go] and [docker] installed `GO111MODULE="on" go get -u sigs.k8s.io/kind@v0.3.0 && kind create cluster` is all you need!
 
 <img src="https://gist.githubusercontent.com/BenTheElder/621bc321fc6d9506fd936feb36d32dd0/raw/13fe81c219e64b4917575c8988e06719c072c7f1/kind-demo.gif" alt="2x speed `kind create cluster` demo" />
 

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -14,7 +14,7 @@ This guide covers getting started with the `kind` command.
 
 ## Installation
 
-You can either install the latest bleeding edge kind code with `GO111MODULE="on" go get -u sigs.k8s.io/kind@master` or clone this repo 
+You can either install kind with `GO111MODULE="on" go get -u sigs.k8s.io/kind@v0.3.0` or clone this repo 
 and run `make build` from the repository.
 
 **NOTE**: please use the latest go to do this, ideally go 1.12.5 or greater.


### PR DESCRIPTION
`go get sigs.k8s.io/kind` outside of GOPATH or with `GO111MODULE="on"` will install v0.3.0 as well currently, but it's best to be explicit about having the copy-pastable commands install the tagged release.