### PR TITLE
fix missing version in download link

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -31,7 +31,7 @@ To install, download the binary for your platform from "Assets" and place this
 into your `$PATH`. E.G. for macOS:
 
 ```
-curl -Lo ./kind-darwin-amd64 https://github.com/kubernetes-sigs/kind/releases/download/0.3.0/kind-darwin-amd64
+curl -Lo ./kind-darwin-amd64 https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-darwin-amd64
 chmod +x ./kind-darwin-amd64
 mv ./kind-darwin-amd64 /some-dir-in-your-PATH/kind
 ```


### PR DESCRIPTION
It seems that the `v` was missing in the download link. Copying the link from the release page: https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-darwin-amd64