### PR TITLE
Allow make build to use proxies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ kind: make-cache out-dir
 		-e CGO_ENABLED=0 \
 		-e GOOS=$(GOOS) \
 		-e GOARCH=$(GOARCH) \
+		-e HTTP_PROXY=$(HTTP_PROXY) \
+		-e HTTPS_PROXY=$(HTTPS_PROXY) \
+		-e NO_PROXY=$(NO_PROXY) \
 		--user $(UID):$(GID) \
 		$(GO_IMAGE) \
 		go build -v -o /out/$(KIND_BINARY_NAME) .


### PR DESCRIPTION
`make build` uses docker to build `kind`.
On environments that use proxy we need to pass this variables to the container so it can use it to fetch the dependencies.

Fixes #551 