### PR TITLE
Masquerade link local addresses

### DIFF
--- a/pkg/build/node/const.go
+++ b/pkg/build/node/const.go
@@ -303,7 +303,7 @@ data:
   config: |-
     nonMasqueradeCIDRs:
       - {{ .PodSubnet }}
-    masqLinkLocal: false
+    masqLinkLocal: true
     resyncInterval: 60s
 ---
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
The ip-masq agent no masquerade traffic directed to the link-local network 169.254.0.0/16 by default. 
It turns out that the Travis CI uses an IP address from that range as the DNS server for their workers.
We need to masquerade the traffic to the link-local range in order to allow the connectivity between the cluster DNS  pods and the Travis CI DNS server.

Fixes #562 