### PR TITLE
Support node/cluster as aliase

### DIFF
--- a/cmd/kind/get/clusters/clusters.go
+++ b/cmd/kind/get/clusters/clusters.go
@@ -30,9 +30,10 @@ func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Args: cobra.NoArgs,
 		// TODO(bentheelder): more detailed usage
-		Use:   "clusters",
-		Short: "lists existing kind clusters by their name",
-		Long:  "lists existing kind clusters by their name",
+		Use:     "clusters",
+		Aliases: []string{"cluster"},
+		Short:   "lists existing kind clusters by their name",
+		Long:    "lists existing kind clusters by their name",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(cmd, args)
 		},

--- a/cmd/kind/get/nodes/nodes.go
+++ b/cmd/kind/get/nodes/nodes.go
@@ -35,10 +35,11 @@ type flagpole struct {
 func NewCommand() *cobra.Command {
 	flags := &flagpole{}
 	cmd := &cobra.Command{
-		Args:  cobra.NoArgs,
-		Use:   "nodes",
-		Short: "lists existing kind nodes by their name",
-		Long:  "lists existing kind nodes by their name",
+		Args:    cobra.NoArgs,
+		Use:     "nodes",
+		Aliases: []string{"node"},
+		Short:   "lists existing kind nodes by their name",
+		Long:    "lists existing kind nodes by their name",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(flags, cmd, args)
 		},


### PR DESCRIPTION
Support `kind get node` and `kind get cluster`

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>