### PR TITLE
Add a preflight check that asserts docker connectivity

### DIFF
--- a/cmd/kind/create/cluster/createcluster.go
+++ b/cmd/kind/create/cluster/createcluster.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/cluster/config/encoding"
 	"sigs.k8s.io/kind/pkg/cluster/create"
+	"sigs.k8s.io/kind/pkg/preflight/runtime"
 	"sigs.k8s.io/kind/pkg/util"
 )
 
@@ -75,6 +76,11 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 			log.Error(problem)
 		}
 		return errors.New("aborting due to invalid configuration")
+	}
+
+	// Run container runtime preflight checks, connectivity etc.
+	if err := runtime.Preflight(); err != nil {
+		return err
 	}
 
 	// Check if the cluster name already exists

--- a/cmd/kind/delete/cluster/deletecluster.go
+++ b/cmd/kind/delete/cluster/deletecluster.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cluster"
+	"sigs.k8s.io/kind/pkg/preflight/runtime"
 )
 
 type flagpole struct {
@@ -49,6 +50,11 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	// Run container runtime preflight checks, connectivity etc.
+	if err := runtime.Preflight(); err != nil {
+		return err
+	}
+
 	// Check if the cluster name exists
 	known, err := cluster.IsKnown(flags.Name)
 	if err != nil {

--- a/cmd/kind/export/logs/logs.go
+++ b/cmd/kind/export/logs/logs.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/fs"
+	"sigs.k8s.io/kind/pkg/preflight/runtime"
 )
 
 type flagpole struct {
@@ -49,6 +50,11 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	// Run container runtime preflight checks, connectivity etc.
+	if err := runtime.Preflight(); err != nil {
+		return err
+	}
+
 	// Check if the cluster name exists
 	known, err := cluster.IsKnown(flags.Name)
 	if err != nil {

--- a/cmd/kind/get/clusters/clusters.go
+++ b/cmd/kind/get/clusters/clusters.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cluster"
+	"sigs.k8s.io/kind/pkg/preflight/runtime"
 )
 
 // NewCommand returns a new cobra.Command for getting the list of clusters
@@ -41,6 +42,11 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(cmd *cobra.Command, args []string) error {
+	// Run container runtime preflight checks, connectivity etc.
+	if err := runtime.Preflight(); err != nil {
+		return err
+	}
+
 	clusters, err := cluster.List()
 	if err != nil {
 		return err

--- a/cmd/kind/get/nodes/nodes.go
+++ b/cmd/kind/get/nodes/nodes.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/kind/pkg/cluster"
 	clusternodes "sigs.k8s.io/kind/pkg/cluster/nodes"
+	"sigs.k8s.io/kind/pkg/preflight/runtime"
 )
 
 type flagpole struct {
@@ -53,6 +54,11 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	// Run container runtime preflight checks, connectivity etc.
+	if err := runtime.Preflight(); err != nil {
+		return err
+	}
+
 	// List nodes by cluster context name
 	n, err := clusternodes.ListByCluster()
 	if err != nil {

--- a/cmd/kind/load/docker-image/docker-image.go
+++ b/cmd/kind/load/docker-image/docker-image.go
@@ -28,6 +28,7 @@ import (
 	clusternodes "sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/container/docker"
 	"sigs.k8s.io/kind/pkg/fs"
+	"sigs.k8s.io/kind/pkg/preflight/runtime"
 )
 
 type flagpole struct {
@@ -68,6 +69,11 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	// Run container runtime preflight checks, connectivity etc.
+	if err := runtime.Preflight(); err != nil {
+		return err
+	}
+
 	// List nodes by cluster context name
 	n, err := clusternodes.ListByCluster()
 	if err != nil {

--- a/cmd/kind/load/image-archive/image-archive.go
+++ b/cmd/kind/load/image-archive/image-archive.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/kind/pkg/cluster"
 	clusternodes "sigs.k8s.io/kind/pkg/cluster/nodes"
+	"sigs.k8s.io/kind/pkg/preflight/runtime"
 )
 
 type flagpole struct {
@@ -65,6 +66,11 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
+	// Run container runtime preflight checks, connectivity etc.
+	if err := runtime.Preflight(); err != nil {
+		return err
+	}
+
 	// List nodes by cluster context name
 	n, err := clusternodes.ListByCluster()
 	if err != nil {

--- a/pkg/preflight/runtime/docker.go
+++ b/pkg/preflight/runtime/docker.go
@@ -14,7 +14,7 @@ func Preflight() error {
 
 	for _, check := range checks {
 		if err := check(); err != nil {
-			return errors.Wrap(err, "Preflight check failed")
+			return errors.Wrap(err, "preflight check failed")
 		}
 	}
 
@@ -25,7 +25,7 @@ func Preflight() error {
 func dockerIsRunning() error {
 	err := exec.Command("docker", "ps").Run()
 	if err != nil {
-		return errors.Wrap(err, "Could not connect to a docker daemon")
+		return errors.Wrap(err, "could not connect to a Docker daemon")
 	}
 	return nil
 }

--- a/pkg/preflight/runtime/docker.go
+++ b/pkg/preflight/runtime/docker.go
@@ -1,0 +1,31 @@
+package runtime
+
+import (
+	"github.com/pkg/errors"
+	"os/exec"
+)
+
+// Preflight runs checks to make sure that the container runtime
+// is working as expected
+func Preflight() error {
+	checks := []func() error{
+		dockerIsRunning,
+	}
+
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return errors.Wrap(err, "Preflight check failed")
+		}
+	}
+
+	return nil
+}
+
+// dockerIsRunning asserts that the docker daemon is running and is responsive
+func dockerIsRunning() error {
+	err := exec.Command("docker", "ps").Run()
+	if err != nil {
+		return errors.Wrap(err, "Could not connect to a docker daemon")
+	}
+	return nil
+}


### PR DESCRIPTION
Assert that the docker daemon is running, and that we're able to connect to it.
This is done by executing 'docker ps', and checking the exit code.

#39
#554