### PR TITLE
Kindnet: wait until podCIDR

### DIFF
--- a/cmd/kindnetd/main.go
+++ b/cmd/kindnetd/main.go
@@ -100,7 +100,13 @@ func makeNodesReconciler(cniConfigWriter *CNIConfigWriter, hostIP string) func(*
 	reconcileNode := func(node corev1.Node) error {
 		// first get this node's IP
 		nodeIP := internalIP(node)
-		fmt.Printf("Handling node with IP: %s\n", nodeIP)
+
+		// don't do anything unless there is a PodCIDR
+		podCIDR := node.Spec.PodCIDR
+		if podCIDR == "" {
+			fmt.Printf("Node %v has no CIDR, ignoring\n", node.Name)
+			return nil
+		}
 
 		// This is our node. We don't need to add routes, but we might need to
 		// update the cni config.
@@ -116,13 +122,7 @@ func makeNodesReconciler(cniConfigWriter *CNIConfigWriter, hostIP string) func(*
 			return nil
 		}
 
-		// don't do anything unless there is a PodCIDR
-		podCIDR := node.Spec.PodCIDR
-		if podCIDR == "" {
-			fmt.Printf("Node %v has no CIDR, ignoring\n", node.Name)
-			return nil
-		}
-
+		fmt.Printf("Handling node with IP: %s\n", nodeIP)
 		// parse subnet
 		dst, err := netlink.ParseIPNet(podCIDR)
 		if err != nil {

--- a/cmd/kindnetd/main.go
+++ b/cmd/kindnetd/main.go
@@ -100,6 +100,10 @@ func makeNodesReconciler(cniConfigWriter *CNIConfigWriter, hostIP string) func(*
 	reconcileNode := func(node corev1.Node) error {
 		// first get this node's IP
 		nodeIP := internalIP(node)
+		if nodeIP == "" {
+			fmt.Printf("Node %v has no Internal IP, ignoring\n", node.Name)
+			return nil
+		}
 
 		// don't do anything unless there is a PodCIDR
 		podCIDR := node.Spec.PodCIDR


### PR DESCRIPTION
Kindnet should wait for the podCIDR field to be available before doing anything.

Fixes #586