### PR TITLE
Export logs and load images only on Internal nodes

### DIFF
--- a/cmd/kind/load/docker-image/docker-image.go
+++ b/cmd/kind/load/docker-image/docker-image.go
@@ -68,14 +68,19 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
-	// List nodes by cluster context name
-	n, err := clusternodes.ListByCluster()
+	// Check if the cluster name exists
+	known, err := cluster.IsKnown(flags.Name)
 	if err != nil {
 		return err
 	}
-	nodes, known := n[flags.Name]
 	if !known {
 		return errors.Errorf("unknown cluster %q", flags.Name)
+	}
+
+	context := cluster.NewContext(flags.Name)
+	nodes, err := context.ListInternalNodes()
+	if err != nil {
+		return err
 	}
 
 	// map cluster nodes by their name

--- a/cmd/kind/load/image-archive/image-archive.go
+++ b/cmd/kind/load/image-archive/image-archive.go
@@ -65,14 +65,19 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
-	// List nodes by cluster context name
-	n, err := clusternodes.ListByCluster()
+	// Check if the cluster name exists
+	known, err := cluster.IsKnown(flags.Name)
 	if err != nil {
 		return err
 	}
-	nodes, known := n[flags.Name]
 	if !known {
 		return errors.Errorf("unknown cluster %q", flags.Name)
+	}
+
+	context := cluster.NewContext(flags.Name)
+	nodes, err := context.ListInternalNodes()
+	if err != nil {
+		return err
 	}
 
 	// map cluster nodes by their name

--- a/pkg/cluster/context.go
+++ b/pkg/cluster/context.go
@@ -91,6 +91,12 @@ func (c *Context) ListNodes() ([]nodes.Node, error) {
 	return c.ic.ListNodes()
 }
 
+// ListInternalNodes returns the list of container IDs for the "nodes" in the cluster
+// that are not external
+func (c *Context) ListInternalNodes() ([]nodes.Node, error) {
+	return c.ic.ListInternalNodes()
+}
+
 // CollectLogs will populate dir with cluster logs and other debug files
 func (c *Context) CollectLogs(dir string) error {
 	nodes, err := c.ListNodes()

--- a/pkg/cluster/context.go
+++ b/pkg/cluster/context.go
@@ -99,7 +99,7 @@ func (c *Context) ListInternalNodes() ([]nodes.Node, error) {
 
 // CollectLogs will populate dir with cluster logs and other debug files
 func (c *Context) CollectLogs(dir string) error {
-	nodes, err := c.ListNodes()
+	nodes, err := c.ListInternalNodes()
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/internal/context/context.go
+++ b/pkg/cluster/internal/context/context.go
@@ -99,3 +99,24 @@ func (c *Context) ClusterLabel() string {
 func (c *Context) ListNodes() ([]nodes.Node, error) {
 	return nodes.List("label=" + c.ClusterLabel())
 }
+
+// ListInternalNodes returns the list of container IDs for the "nodes" in the cluster
+// that are not external
+func (c *Context) ListInternalNodes() ([]nodes.Node, error) {
+	clusterNodes, err := nodes.List("label=" + c.ClusterLabel())
+	if err != nil {
+		return nil, err
+	}
+	selectedNodes := []nodes.Node{}
+	for _, node := range clusterNodes {
+		// Don't load image on external nodes like the load balancer
+		nodeRole, err := node.Role()
+		if err != nil {
+			return nil, err
+		}
+		if nodeRole != constants.ExternalLoadBalancerNodeRoleValue {
+			selectedNodes = append(selectedNodes, node)
+		}
+	}
+	return selectedNodes, nil
+}


### PR DESCRIPTION
The external nodes to the cluster, like the load balancer, should be treated differently.
This adds a new method to `context` to list only the internal nodes of the cluster: control-plane and workers and leverages it for current `kind logs` and `load` operations

Fixes : https://github.com/kubernetes-sigs/kind/issues/589
Related: https://github.com/kubernetes-sigs/kind/issues/588