### PR TITLE
small correctness fix

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -107,6 +107,7 @@ func RunWithStdoutReader(cmd Cmd, readerFunc func(io.Reader) error) error {
 	errChan := make(chan error, 1)
 	go func() {
 		errChan <- readerFunc(pr)
+		pr.Close()
 	}()
 
 	err = cmd.Run()


### PR DESCRIPTION
handle reader exiting early

we haven't observed this in our current usage, but this is more correct