### PR TITLE
introduce logging shim

### DIFF
--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/kind/cmd/kind/get"
 	"sigs.k8s.io/kind/cmd/kind/load"
 	"sigs.k8s.io/kind/cmd/kind/version"
+	"sigs.k8s.io/kind/pkg/env"
 	logutil "sigs.k8s.io/kind/pkg/log"
 )
 
@@ -104,7 +105,7 @@ func Main() {
 		// we force colors because this only forces over the isTerminal check
 		// and this will not be accurately checkable later on when we wrap
 		// the logger output with our logutil.StatusFriendlyWriter
-		ForceColors: logutil.IsTerminal(log.StandardLogger().Out),
+		ForceColors: env.IsTerminal(log.StandardLogger().Out),
 	})
 	if err := Run(); err != nil {
 		os.Exit(1)

--- a/pkg/build/kube/bazelbuildbits.go
+++ b/pkg/build/kube/bazelbuildbits.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/version"
+	"sigs.k8s.io/kind/pkg/env"
 	"sigs.k8s.io/kind/pkg/exec"
-	"sigs.k8s.io/kind/pkg/util"
 )
 
 // BazelBuildBits implements Bits for a local Bazel build
@@ -66,7 +66,7 @@ func (b *BazelBuildBits) Build() error {
 
 	// TODO(bentheelder): we assume the host arch, but cross compiling should
 	// be possible now
-	arch := util.GetArch()
+	arch := env.GetArch()
 	bazelGoosGoarch := fmt.Sprintf("linux_%s", arch)
 
 	// build artifacts

--- a/pkg/build/kube/dockerbuildbits.go
+++ b/pkg/build/kube/dockerbuildbits.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"sigs.k8s.io/kind/pkg/util"
+	"sigs.k8s.io/kind/pkg/env"
 
 	"github.com/pkg/errors"
 
@@ -89,7 +89,7 @@ func (b *DockerBuildBits) Build() error {
 }
 
 func dockerBuildOsAndArch() string {
-	return "linux/" + util.GetArch()
+	return "linux/" + env.GetArch()
 }
 
 // binary and image build when we have `make quick-release-images` support
@@ -165,7 +165,7 @@ func (b *DockerBuildBits) buildBash() error {
 
 	// mimic `make quick-release` internals, clear previous images
 	if err := os.RemoveAll(filepath.Join(
-		".", "_output", "release-images", util.GetArch(),
+		".", "_output", "release-images", env.GetArch(),
 	)); err != nil {
 		return errors.Wrap(err, "failed to remove old release-images")
 	}
@@ -177,7 +177,7 @@ func (b *DockerBuildBits) buildBash() error {
 		"source build/lib/release.sh;",
 		"kube::version::get_version_vars;",
 		fmt.Sprintf(`kube::release::create_docker_images_for_server "${LOCAL_OUTPUT_ROOT}/dockerized/bin/%s" "%s"`,
-			dockerBuildOsAndArch(), util.GetArch()),
+			dockerBuildOsAndArch(), env.GetArch()),
 	}
 	cmd = exec.Command("bash", "-c", strings.Join(buildImages, " "))
 	cmd.SetEnv(
@@ -196,10 +196,10 @@ func (b *DockerBuildBits) buildBash() error {
 // Paths implements Bits.Paths
 func (b *DockerBuildBits) Paths() map[string]string {
 	binDir := filepath.Join(b.kubeRoot,
-		"_output", "dockerized", "bin", "linux", util.GetArch(),
+		"_output", "dockerized", "bin", "linux", env.GetArch(),
 	)
 	imageDir := filepath.Join(b.kubeRoot,
-		"_output", "release-images", util.GetArch(),
+		"_output", "release-images", env.GetArch(),
 	)
 	return map[string]string{
 		// binaries (hyperkube)

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -34,9 +34,9 @@ import (
 
 	"sigs.k8s.io/kind/pkg/build/kube"
 	"sigs.k8s.io/kind/pkg/container/docker"
+	"sigs.k8s.io/kind/pkg/env"
 	"sigs.k8s.io/kind/pkg/exec"
 	"sigs.k8s.io/kind/pkg/fs"
-	"sigs.k8s.io/kind/pkg/util"
 )
 
 // DefaultImage is the default name:tag for the built image
@@ -101,7 +101,7 @@ func NewBuildContext(options ...Option) (ctx *BuildContext, err error) {
 		mode:      DefaultMode,
 		image:     DefaultImage,
 		baseImage: DefaultBaseImage,
-		arch:      util.GetArch(),
+		arch:      env.GetArch(),
 	}
 	// apply user options
 	for _, option := range options {

--- a/pkg/cluster/internal/create/actions/action.go
+++ b/pkg/cluster/internal/create/actions/action.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/config"
 	"sigs.k8s.io/kind/pkg/cluster/internal/context"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
-	logutil "sigs.k8s.io/kind/pkg/log"
+	"sigs.k8s.io/kind/pkg/log/status"
 )
 
 // Action defines a step of bringing up a kind cluster after initial node
@@ -33,7 +33,7 @@ type Action interface {
 
 // ActionContext is data supplied to all actions
 type ActionContext struct {
-	Status         *logutil.Status
+	Status         *status.Status
 	Config         *config.Cluster
 	ClusterContext *context.Context
 	cache          *cachedData
@@ -43,7 +43,7 @@ type ActionContext struct {
 func NewActionContext(
 	cfg *config.Cluster,
 	ctx *context.Context,
-	status *logutil.Status,
+	status *status.Status,
 ) *ActionContext {
 	return &ActionContext{
 		Status:         status,

--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/config/encoding"
 	"sigs.k8s.io/kind/pkg/cluster/internal/context"
 	"sigs.k8s.io/kind/pkg/cluster/internal/delete"
-	logutil "sigs.k8s.io/kind/pkg/log"
+	"sigs.k8s.io/kind/pkg/log/status"
 
 	configaction "sigs.k8s.io/kind/pkg/cluster/internal/create/actions/config"
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/installcni"
@@ -62,7 +62,7 @@ func Cluster(ctx *context.Context, cfg *config.Cluster, opts *Options) error {
 		return err
 	}
 
-	status := logutil.NewStatus(os.Stdout)
+	status := status.New(os.Stdout)
 	status.MaybeWrapLogrus(log.StandardLogger())
 
 	// attempt to explicitly pull the required node images if they doesn't exist locally

--- a/pkg/cluster/internal/create/images.go
+++ b/pkg/cluster/internal/create/images.go
@@ -24,19 +24,19 @@ import (
 
 	"sigs.k8s.io/kind/pkg/cluster/config"
 	"sigs.k8s.io/kind/pkg/container/docker"
-	logutil "sigs.k8s.io/kind/pkg/log"
+	"sigs.k8s.io/kind/pkg/log/status"
 )
 
 // ensureNodeImages ensures that the node images used by the create
 // configuration are present
-func ensureNodeImages(status *logutil.Status, cfg *config.Cluster) {
+func ensureNodeImages(s *status.Status, cfg *config.Cluster) {
 	// pull each required image
 	for _, image := range requiredImages(cfg).List() {
 		// prints user friendly message
 		if strings.Contains(image, "@sha256:") {
 			image = strings.Split(image, "@sha256:")[0]
 		}
-		status.Start(fmt.Sprintf("Ensuring node image (%s) 🖼", image))
+		s.Start(fmt.Sprintf("Ensuring node image (%s) 🖼", image))
 
 		// attempt to explicitly pull the image if it doesn't exist locally
 		// we don't care if this errors, we'll still try to run which also pulls

--- a/pkg/cluster/internal/create/nodes.go
+++ b/pkg/cluster/internal/create/nodes.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/concurrent"
 	"sigs.k8s.io/kind/pkg/container/cri"
-	logutil "sigs.k8s.io/kind/pkg/log"
+	"sigs.k8s.io/kind/pkg/log/status"
 )
 
 // provisioning order for nodes by role
@@ -76,26 +76,26 @@ func copyConfigNodes(toCopy []config.Node) []config.Node {
 // provisionNodes takes care of creating all the containers
 // that will host `kind` nodes
 func provisionNodes(
-	status *logutil.Status, cfg *config.Cluster, clusterName, clusterLabel string,
+	s *status.Status, cfg *config.Cluster, clusterName, clusterLabel string,
 ) error {
-	defer status.End(false)
+	defer s.End(false)
 
-	if err := createNodeContainers(status, cfg, clusterName, clusterLabel); err != nil {
+	if err := createNodeContainers(s, cfg, clusterName, clusterLabel); err != nil {
 		return err
 	}
 
-	status.End(true)
+	s.End(true)
 	return nil
 }
 
 func createNodeContainers(
-	status *logutil.Status, cfg *config.Cluster, clusterName, clusterLabel string,
+	s *status.Status, cfg *config.Cluster, clusterName, clusterLabel string,
 ) error {
-	defer status.End(false)
+	defer s.End(false)
 
 	// compute the desired nodes, and inform the user that we are setting them up
 	desiredNodes := nodesToCreate(cfg, clusterName)
-	status.Start("Preparing nodes " + strings.Repeat("📦", len(desiredNodes)))
+	s.Start("Preparing nodes " + strings.Repeat("📦", len(desiredNodes)))
 
 	// create all of the node containers, concurrently
 	fns := []func() error{}
@@ -111,7 +111,7 @@ func createNodeContainers(
 		return err
 	}
 
-	status.End(true)
+	s.End(true)
 	return nil
 }
 

--- a/pkg/container/docker/exec.go
+++ b/pkg/container/docker/exec.go
@@ -19,8 +19,8 @@ package docker
 import (
 	"io"
 
+	"sigs.k8s.io/kind/pkg/env"
 	"sigs.k8s.io/kind/pkg/exec"
-	"sigs.k8s.io/kind/pkg/log"
 )
 
 // containerCmder implements exec.Cmder for docker containers
@@ -68,7 +68,7 @@ func (c *containerCmd) Run() error {
 		)
 	}
 	// if the command is hooked up to the processes's output we want a tty
-	if log.IsTerminal(c.stderr) || log.IsTerminal(c.stdout) {
+	if env.IsTerminal(c.stderr) || env.IsTerminal(c.stdout) {
 		args = append(args,
 			"-t",
 		)

--- a/pkg/env/doc.go
+++ b/pkg/env/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package env contains helpers for environmental details
+package env

--- a/pkg/env/osarch.go
+++ b/pkg/env/osarch.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package env
 
 import (
 	"fmt"

--- a/pkg/env/terminal.go
+++ b/pkg/env/terminal.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package env
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// IsTerminal returns true if the writer w is a terminal
+func IsTerminal(w io.Writer) bool {
+	if v, ok := (w).(*os.File); ok {
+		return terminal.IsTerminal(int(v.Fd()))
+	}
+	return false
+}

--- a/pkg/log/default.go
+++ b/pkg/log/default.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,22 +17,22 @@ limitations under the License.
 package log
 
 import (
-	"strings"
-
-	"github.com/sirupsen/logrus"
+	"sync"
 )
 
-// LevelsString returns a string representing all log levels
-// this is useful for help text / flag info
-func LevelsString() string {
-	var b strings.Builder
-	b.WriteString("[")
-	for i, level := range logrus.AllLevels {
-		b.WriteString(level.String())
-		if i+1 != len(logrus.AllLevels) {
-			b.WriteString(", ")
-		}
-	}
-	b.WriteString("]")
-	return b.String()
+var std LeveledLogger
+var stdMu sync.Mutex
+
+// SetDefault sets the default logger
+func SetDefault(logger LeveledLogger) {
+	stdMu.Lock()
+	defer stdMu.Unlock()
+	std = logger
+}
+
+// V is leveled logging implemented against the default logger
+func V(level Level) Logger {
+	stdMu.Lock()
+	defer stdMu.Unlock()
+	return std.V(level)
 }

--- a/pkg/log/doc.go
+++ b/pkg/log/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,25 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package log contains logging related functionality
 package log
-
-import (
-	"strings"
-
-	"github.com/sirupsen/logrus"
-)
-
-// LevelsString returns a string representing all log levels
-// this is useful for help text / flag info
-func LevelsString() string {
-	var b strings.Builder
-	b.WriteString("[")
-	for i, level := range logrus.AllLevels {
-		b.WriteString(level.String())
-		if i+1 != len(logrus.AllLevels) {
-			b.WriteString(", ")
-		}
-	}
-	b.WriteString("]")
-	return b.String()
-}

--- a/pkg/log/klog/klog.go
+++ b/pkg/log/klog/klog.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package klog contains logging related functionality
+package klog
+
+import (
+	"k8s.io/klog"
+
+	"sigs.k8s.io/kind/pkg/log"
+)
+
+// Use installs this logger as the default
+func Use() {
+	log.SetDefault(New())
+}
+
+// New returns an opaque implementation of log.LeveledLogger against klog
+func New() log.LeveledLogger {
+	return &leveledLogger{}
+}
+
+// leveledLogger implements log.LeveledLogger against klog
+type leveledLogger struct{}
+
+var _ log.LeveledLogger = &leveledLogger{}
+
+func (l *leveledLogger) V(level log.Level) log.Logger {
+	return klog.V(klog.Level(level))
+}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+// Level is a leveled logging level, see https://github.com/kubernetes/klog
+type Level int32
+
+// LeveledLogger is a subset of what https://github.com/kubernetes/klog
+// provides that kind's library code may use. You can (and should) inject your
+// own default logger using SetDefault()
+//
+// See also klog.Use() in our klog package under this one
+type LeveledLogger interface {
+	V(Level) Logger
+}
+
+// Logger is an interface like klog.Verbose
+// see: https://github.com/kubernetes/klog
+type Logger interface {
+	Info(args ...interface{})
+	Infoln(args ...interface{})
+	Infof(format string, args ...interface{})
+}

--- a/pkg/log/status/status.go
+++ b/pkg/log/status/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,18 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package log contains logging related functionality
-package log
+// Package status contains functionality for showing CLI application status
+package status
 
 import (
 	"fmt"
 	"io"
-	"os"
 
+	"sigs.k8s.io/kind/pkg/env"
 	"sigs.k8s.io/kind/pkg/log/fidget"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 // Status is used to track ongoing status in a CLI, with a nice loading spinner
@@ -36,8 +35,8 @@ type Status struct {
 	writer  io.Writer
 }
 
-// NewStatus creates a new default Status
-func NewStatus(w io.Writer) *Status {
+// New creates a new default Status
+func New(w io.Writer) *Status {
 	spin := fidget.NewSpinner(w)
 	s := &Status{
 		spinner: spin,
@@ -46,16 +45,16 @@ func NewStatus(w io.Writer) *Status {
 	return s
 }
 
-// StatusFriendlyWriter is used to wrap another Writer to make it toggle the
+// FriendlyWriter is used to wrap another Writer to make it toggle the
 // status spinner before and after writes so that they do not collide
-type StatusFriendlyWriter struct {
+type FriendlyWriter struct {
 	status *Status
 	inner  io.Writer
 }
 
-var _ io.Writer = &StatusFriendlyWriter{}
+var _ io.Writer = &FriendlyWriter{}
 
-func (ww *StatusFriendlyWriter) Write(p []byte) (n int, err error) {
+func (ww *FriendlyWriter) Write(p []byte) (n int, err error) {
 	ww.status.spinner.Stop()
 	ww.inner.Write([]byte("\r"))
 	n, err = ww.inner.Write(p)
@@ -63,15 +62,15 @@ func (ww *StatusFriendlyWriter) Write(p []byte) (n int, err error) {
 	return n, err
 }
 
-// WrapWriter returns a StatusFriendlyWriter for w
+// WrapWriter returns a FriendlyWriter for w
 func (s *Status) WrapWriter(w io.Writer) io.Writer {
-	return &StatusFriendlyWriter{
+	return &FriendlyWriter{
 		status: s,
 		inner:  w,
 	}
 }
 
-// WrapLogrus wraps a logrus logger's output with a StatusFriendlyWriter
+// WrapLogrus wraps a logrus logger's output with a FriendlyWriter
 func (s *Status) WrapLogrus(logger *logrus.Logger) {
 	logger.SetOutput(s.WrapWriter(logger.Out))
 }
@@ -79,7 +78,7 @@ func (s *Status) WrapLogrus(logger *logrus.Logger) {
 // MaybeWrapWriter returns a StatusFriendlyWriter for w IFF w and spinner's
 // output are a terminal, otherwise it returns w
 func (s *Status) MaybeWrapWriter(w io.Writer) io.Writer {
-	if IsTerminal(s.writer) && IsTerminal(w) {
+	if env.IsTerminal(s.writer) && env.IsTerminal(w) {
 		return s.WrapWriter(w)
 	}
 	return w
@@ -90,20 +89,12 @@ func (s *Status) MaybeWrapLogrus(logger *logrus.Logger) {
 	logger.SetOutput(s.MaybeWrapWriter(logger.Out))
 }
 
-// IsTerminal returns true if the writer w is a terminal
-func IsTerminal(w io.Writer) bool {
-	if v, ok := (w).(*os.File); ok {
-		return terminal.IsTerminal(int(v.Fd()))
-	}
-	return false
-}
-
 // Start starts a new phase of the status, if attached to a terminal
 // there will be a loading spinner with this status
 func (s *Status) Start(status string) {
 	s.End(true)
 	// set new status
-	isTerm := IsTerminal(s.writer)
+	isTerm := env.IsTerminal(s.writer)
 	s.status = status
 	if isTerm {
 		s.spinner.SetSuffix(fmt.Sprintf(" %s ", s.status))
@@ -120,7 +111,7 @@ func (s *Status) End(success bool) {
 		return
 	}
 
-	isTerm := IsTerminal(s.writer)
+	isTerm := env.IsTerminal(s.writer)
 	if isTerm {
 		s.spinner.Stop()
 		fmt.Fprint(s.writer, "\r")


### PR DESCRIPTION
NOTE: this does not actually switch to using it yet, to keep the PR reviewable I'm merely introducing _how_ we can refactor the logging first. The next PR will switch everything over and introduce a compatibility layer in the flags.

To do this I also first refactored the logging / util code to better organize it.

Part of #176 #109 

The basic idea is:
- [PR 1] Have a logging interface (yes, our own) that is a subset of what klog provides. This **only** includes leveled info logging. Why?
  - Only CLI code / main should be able to Panic() / Fatal(), everything else should be returning errors instead. Library packages are banned from exiting the application. This interface excludes these, but the application will have set up the logger and can do this itself separately not via the interface.
   - Having a shim means users do not _have_ to use klog, if they're happy with klog they just need to import and call `sigs.k8s.io/kind/pkg/log/klog.Use()` somewhere, otherwise they can implement the little log interface and pass it to `sigs.k8s.io/kind/pkg/log.SetDefault()`. klog is standard in the kubernetes ecosystem and `V()` logging is nice, but we can be flexible.
  - User facing messages in CLI apps should happen via stdout / stderr with human readable messages, logging should be reserved for debugging. If this were a server application I'd use logrus with JSON logs everywhere and something like stackdriver to search them etc.. but it is **not** a server application and it's unreasonable to expect the output to go through a logging pipeline.
- [PR 2] Map `--loglevel` to `-v` levels temporarily and warn about deprecation `--loglevel` is set.
- [PR 2] Call `sigs.k8s.io/kind/pkg/log/klog.Use()` in the root kind command
- [PR 2] Use the default logger in `sigs.k8s.io/kind/pkg/log.V()` pervasively throughout the `pkg/` and `cmd/`  / replace logrus
- kindnetd isn't meant to be reused and can just use klog directly.