### PR TITLE
add a workaround to a Docker (aufs) bug

### DIFF
--- a/images/base/entrypoint
+++ b/images/base/entrypoint
@@ -37,6 +37,11 @@ fix_mount() {
   chown root:root /bin/mount
   chmod -s /bin/mount
 
+  # This is a workaround to an AUFS bug that might cause `Text file
+  # busy` on `mount` command below. See more details in
+  # https://github.com/moby/moby/issues/9547
+  sync
+
   # systemd-in-a-container should have read only /sys
   # https://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/
   # however, we need other things from `docker run --privileged` ...

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -43,7 +43,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20190506-d0ac573"
+const DefaultBaseImage = "kindest/base:v20190617-20bc0c3@sha256:3c2586fdc22b9dc4ce8d550bd4c3bd4b29482d701165d49fb4a487cd748bdca4"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
You might see the entrypoint script throw out errors like the following:
```
/usr/bin/mount: Text file busy
```

This is due to this bug (likely in AUFS):
https://github.com/moby/moby/issues/9547

This patch workarounds it by inserting a `sync` in between.