### PR TITLE
Use config file to join nodes to the cluster

### DIFF
--- a/pkg/cluster/internal/create/actions/config/config.go
+++ b/pkg/cluster/internal/create/actions/config/config.go
@@ -65,22 +65,11 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 		return errors.Wrap(err, "failed to get kubernetes version from node")
 	}
 
-	// get the control plane endpoint, in case the cluster has an external load balancer in
-	// front of the control-plane nodes
+	// get the control plane endpoint
 	controlPlaneEndpoint, err := nodes.GetControlPlaneEndpoint(allNodes)
 	if err != nil {
 		// TODO(bentheelder): logging here
 		return err
-	}
-
-	// if there is no load balancer the bootstrap node address is the control plane endpoint
-	if controlPlaneEndpoint == "" {
-		// get the bootstrap node ip address
-		nodeAddress, err := node.IP()
-		if err != nil {
-			return errors.Wrap(err, "failed to get IP for node")
-		}
-		controlPlaneEndpoint = nodeAddress
 	}
 
 	// create kubeadm init config

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -114,6 +114,9 @@ controllerManagerExtraArgs:
   enable-hostpath-provisioner: "true"
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
+  kubeletExtraArgs:
+    fail-swap-on: "false"
+    node-ip: "{{ .NodeAddress }}"
 networking:
   podSubnet: "{{ .PodSubnet }}"
 ---
@@ -121,8 +124,15 @@ apiVersion: kubeadm.k8s.io/v1alpha2
 kind: NodeConfiguration
 metadata:
   name: config
+clusterName: "{{.ClusterName}}"
+discoveryTokenAPIServers: ["{{ .ControlPlaneEndpoint }}"]
+token: "{{ .Token }}"
+discoveryTokenUnsafeSkipCAVerification: true
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
+  kubeletExtraArgs:
+    fail-swap-on: "false"
+    node-ip: "{{ .NodeAddress }}"
 `
 
 // ConfigTemplateAlphaV3 is the kubadm config template for API version v1alpha3

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -81,12 +81,11 @@ clusterName: "{{.ClusterName}}"
 # we use a well know token for TLS bootstrap
 bootstrapTokens:
 - token: "{{ .Token }}"
-{{ if .ControlPlaneEndpoint -}}
 controlPlaneEndpoint: {{ .ControlPlaneEndpoint }}
-{{- end }}
 # we use a well know port for making the API server discoverable inside docker network. 
 # from the host machine such port will be accessible via a random local port instead.
 api:
+  advertiseAddress: "{{ .NodeAddress }}"
   bindPort: {{.APIBindPort}}
 # we need nsswitch.conf so we use /etc/hosts
 # https://github.com/kubernetes/kubernetes/issues/69195
@@ -175,7 +174,7 @@ apiVersion: kubeadm.k8s.io/v1alpha3
 kind: JoinConfiguration
 metadata:
   name: config
-discoveryTokenAPIServers: "{{ .ControlPlaneEndpoint }}"
+discoveryTokenAPIServers: ["{{ .ControlPlaneEndpoint }}"]
 token: "{{ .Token }}"
 discoveryTokenUnsafeSkipCAVerification: true
 controlPlane: {{ .ControlPlane }}

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -30,7 +30,8 @@ import (
 type ConfigData struct {
 	ClusterName       string
 	KubernetesVersion string
-	// The ControlPlaneEndpoint, that is the address of the external loadbalancer, if defined
+	// The ControlPlaneEndpoint, that is the address of the external loadbalancer
+	// if defined or the bootstrap node
 	ControlPlaneEndpoint string
 	// The Local API Server port
 	APIBindPort int
@@ -161,6 +162,7 @@ bootstrapTokens:
 # we use a well know port for making the API server discoverable inside docker network. 
 # from the host machine such port will be accessible via a random local port instead.
 apiEndpoint:
+  advertiseAddress: "{{ .NodeAddress }}"
   bindPort: {{.APIBindPort}}
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
@@ -177,7 +179,11 @@ discoveryTokenAPIServers: "{{ .ControlPlaneEndpoint }}"
 token: "{{ .Token }}"
 discoveryTokenUnsafeSkipCAVerification: true
 controlPlane: {{ .ControlPlane }}
-apiEndpoint: "{{ .NodeAddress }}"
+{{ if .ControlPlane -}}
+apiEndpoint:
+  advertiseAddress: "{{ .NodeAddress }}"
+  bindPort: {{.APIBindPort}}
+{{- end }}
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
   kubeletExtraArgs:
@@ -234,6 +240,7 @@ bootstrapTokens:
 # we use a well know port for making the API server discoverable inside docker network. 
 # from the host machine such port will be accessible via a random local port instead.
 localAPIEndpoint:
+  advertiseAddress: "{{ .NodeAddress }}"
   bindPort: {{.APIBindPort}}
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
@@ -248,7 +255,9 @@ metadata:
   name: config
 {{ if .ControlPlane -}}	
 controlPlane:
-  localAPIEndpoint: "{{ .NodeAddress }}"
+  localAPIEndpoint:
+    advertiseAddress: "{{ .NodeAddress }}"
+    bindPort: {{.APIBindPort}}
 {{- end }}
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
@@ -311,6 +320,7 @@ bootstrapTokens:
 # we use a well know port for making the API server discoverable inside docker network. 
 # from the host machine such port will be accessible via a random local port instead.
 localAPIEndpoint:
+  advertiseAddress: "{{ .NodeAddress }}"
   bindPort: {{.APIBindPort}}
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
@@ -325,7 +335,9 @@ metadata:
   name: config
 {{ if .ControlPlane -}}
 controlPlane:
-  localAPIEndpoint: "{{ .NodeAddress }}"
+  localAPIEndpoint:
+    advertiseAddress: "{{ .NodeAddress }}"
+    bindPort: {{.APIBindPort}}
 {{- end }}
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -173,10 +173,11 @@ apiVersion: kubeadm.k8s.io/v1alpha3
 kind: JoinConfiguration
 metadata:
   name: config
-apiServerEndpoint: "{{ .ControlPlaneEndpoint }}"
+discoveryTokenAPIServers: "{{ .ControlPlaneEndpoint }}"
 token: "{{ .Token }}"
 discoveryTokenUnsafeSkipCAVerification: true
 controlPlane: {{ .ControlPlane }}
+apiEndpoint: "{{ .NodeAddress }}"
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
   kubeletExtraArgs:


### PR DESCRIPTION
This avoids having to write configuration files on runtime, ~however, seems that the control plane nodes can't use it~