### PR TITLE
Automatically add the docker network to no_proxy

### DIFF
--- a/images/base/entrypoint
+++ b/images/base/entrypoint
@@ -18,19 +18,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-configure_proxy() {
-  # Don't use proxy for the local network
-  LOCAL_NETWORK=$(ip route list dev eth0 proto kernel | awk '{ print $1 }')
-
-  mkdir -p /etc/systemd/system/containerd.service.d/
-  cat <<EOF >/etc/systemd/system/containerd.service.d/http-proxy.conf
-[Service]
-Environment="HTTP_PROXY=${HTTP_PROXY:-}"
-Environment="HTTPS_PROXY=${HTTPS_PROXY:-}"
-Environment="NO_PROXY=${NO_PROXY:-localhost},${LOCAL_NETWORK}"
-EOF
-}
-
 fix_mount() {
   # necessary only when userns-remap is enabled on the host, but harmless
   # The binary /bin/mount should be owned by root and have the setuid bit
@@ -76,7 +63,6 @@ fix_product_name() {
 fix_mount
 fix_machine_id
 fix_product_name
-configure_proxy
 
 # we want the command (expected to be systemd) to be PID1, so exec to it
 exec "$@"

--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -145,7 +145,10 @@ func createNode(name, image, clusterLabel, role string, mounts []cri.Mount, extr
 	}
 
 	// pass proxy environment variables to be used by node's docker deamon
-	proxyDetails := getProxyDetails()
+	proxyDetails, err := getProxyDetails()
+	if err != nil || proxyDetails == nil {
+		return nil, errors.Wrap(err, "proxy setup error")
+	}
 	for key, val := range proxyDetails.Envs {
 		runArgs = append(runArgs, "-e", fmt.Sprintf("%s=%s", key, val))
 	}

--- a/pkg/cluster/nodes/node.go
+++ b/pkg/cluster/nodes/node.go
@@ -33,6 +33,14 @@ import (
 	"sigs.k8s.io/kind/pkg/exec"
 )
 
+const (
+	// Docker default bridge network is named "bridge" (https://docs.docker.com/network/bridge/#use-the-default-bridge-network)
+	defaultNetwork = "bridge"
+	httpProxy      = "HTTP_PROXY"
+	httpsProxy     = "HTTPS_PROXY"
+	noProxy        = "NO_PROXY"
+)
+
 // Node represents a handle to a kind node
 // This struct must be created by one of: CreateControlPlane
 // It should not be manually instantiated
@@ -257,7 +265,7 @@ type proxyDetails struct {
 // getProxyDetails returns a struct with the host environment proxy settings
 // that should be passed to the nodes
 func getProxyDetails() proxyDetails {
-	var proxyEnvs = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+	var proxyEnvs = []string{httpProxy, httpsProxy, noProxy}
 	var val string
 	var details proxyDetails
 	details.Envs = make(map[string]string)
@@ -273,5 +281,23 @@ func getProxyDetails() proxyDetails {
 			}
 		}
 	}
+
+	// Specifically add the docker network subnets to NO_PROXY
+	subnets, err := getSubnets(defaultNetwork)
+	if err == nil {
+		details.Envs[noProxy] = strings.Join(append(subnets, details.Envs[noProxy]), ",")
+		details.Envs[strings.ToLower(noProxy)] = strings.Join(append(subnets, details.Envs[strings.ToLower(noProxy)]), ",")
+	}
+
 	return details
+}
+
+// getSubnets returns a slice of subnets for a specified network
+func getSubnets(networkName string) ([]string, error) {
+	format := `{{range (index (index . "IPAM") "Config")}}{{index . "Subnet"}} {{end}}`
+	lines, err := docker.NetworkInspect([]string{networkName}, format)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(lines[0], " "), nil
 }

--- a/pkg/container/docker/network.go
+++ b/pkg/container/docker/network.go
@@ -1,0 +1,16 @@
+package docker
+
+import (
+	"strings"
+
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+// NetworkInspect displays detailed information on one or more networks
+func NetworkInspect(networkNames []string, format string) ([]string, error) {
+	cmd := exec.Command("docker", "network", "inspect",
+		"-f", format,
+		strings.Join(networkNames, " "),
+	)
+	return exec.CombinedOutputLines(cmd)
+}


### PR DESCRIPTION
fixes https://github.com/kubernetes-sigs/kind/issues/525

Compute the host docker network subnets and plumb through the NO_PROXY env.