### PR TITLE
Don't use routes field in CNI configuration

### DIFF
--- a/pkg/build/node/cni.go
+++ b/pkg/build/node/cni.go
@@ -140,10 +140,6 @@ data:
           "ipam": {
             "type": "host-local",
             "dataDir": "/run/cni-ipam-state",
-            "routes": [
-              {"dst": "0.0.0.0/0"},
-              {"dst": "::/0"}
-            ],
             "ranges": [
               [
                 {


### PR DESCRIPTION
The CNI `routes` parameter is optional https://github.com/containernetworking/cni/blob/spec-v0.3.1/SPEC.md and seems that is redundant with the `gateway` paramater in the `ranges` field https://github.com/containernetworking/plugins/tree/master/plugins/ipam/host-local

Also the ptp plugin seems to install a default route into the pod obtained from the ipam plugin
https://github.com/containernetworking/plugins/blob/master/plugins/main/ptp/ptp.go#L54-L63