### PR TITLE
add Port mappings to Node specs

### DIFF
--- a/pkg/cluster/config/types.go
+++ b/pkg/cluster/config/types.go
@@ -71,6 +71,10 @@ type Node struct {
 	// ExtraMounts describes additional mount points for the node container
 	// These may be used to bind a hostPath
 	ExtraMounts []cri.Mount
+
+	// ExtraPortMappings describes additional port mappings for the node container
+	// binded to a host Port
+	ExtraPortMappings []cri.PortMapping
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/cluster/config/v1alpha2/zz_generated.conversion.go
+++ b/pkg/cluster/config/v1alpha2/zz_generated.conversion.go
@@ -83,5 +83,6 @@ func autoConvert_config_Node_To_v1alpha2_Node(in *config.Node, out *Node, s conv
 	out.Role = NodeRole(in.Role)
 	out.Image = in.Image
 	out.ExtraMounts = *(*[]cri.Mount)(unsafe.Pointer(&in.ExtraMounts))
+	// WARNING: in.ExtraPortMappings requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/pkg/cluster/config/v1alpha3/types.go
+++ b/pkg/cluster/config/v1alpha3/types.go
@@ -71,6 +71,10 @@ type Node struct {
 	// ExtraMounts describes additional mount points for the node container
 	// These may be used to bind a hostPath
 	ExtraMounts []cri.Mount `json:"extraMounts,omitempty"`
+
+	// ExtraPortMappings describes additional port mappings for the node container
+	// binded to a host Port
+	ExtraPortMappings []cri.PortMapping `json:"extraPortMappings,omitempty"`
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/cluster/config/v1alpha3/zz_generated.conversion.go
+++ b/pkg/cluster/config/v1alpha3/zz_generated.conversion.go
@@ -134,6 +134,7 @@ func autoConvert_v1alpha3_Node_To_config_Node(in *Node, out *config.Node, s conv
 	out.Role = config.NodeRole(in.Role)
 	out.Image = in.Image
 	out.ExtraMounts = *(*[]cri.Mount)(unsafe.Pointer(&in.ExtraMounts))
+	out.ExtraPortMappings = *(*[]cri.PortMapping)(unsafe.Pointer(&in.ExtraPortMappings))
 	return nil
 }
 
@@ -146,6 +147,7 @@ func autoConvert_config_Node_To_v1alpha3_Node(in *config.Node, out *Node, s conv
 	out.Role = NodeRole(in.Role)
 	out.Image = in.Image
 	out.ExtraMounts = *(*[]cri.Mount)(unsafe.Pointer(&in.ExtraMounts))
+	out.ExtraPortMappings = *(*[]cri.PortMapping)(unsafe.Pointer(&in.ExtraPortMappings))
 	return nil
 }
 

--- a/pkg/cluster/config/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/cluster/config/v1alpha3/zz_generated.deepcopy.go
@@ -93,6 +93,11 @@ func (in *Node) DeepCopyInto(out *Node) {
 		*out = make([]cri.Mount, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExtraPortMappings != nil {
+		in, out := &in.ExtraPortMappings, &out.ExtraPortMappings
+		*out = make([]cri.PortMapping, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/cluster/config/zz_generated.deepcopy.go
+++ b/pkg/cluster/config/zz_generated.deepcopy.go
@@ -93,6 +93,11 @@ func (in *Node) DeepCopyInto(out *Node) {
 		*out = make([]cri.Mount, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExtraPortMappings != nil {
+		in, out := &in.ExtraPortMappings, &out.ExtraPortMappings
+		*out = make([]cri.PortMapping, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/cluster/internal/create/nodes.go
+++ b/pkg/cluster/internal/create/nodes.go
@@ -215,7 +215,7 @@ func (d *nodeSpec) Create(clusterLabel string) (node *nodes.Node, err error) {
 	// TODO(bentheelder): decouple from config objects further
 	switch d.Role {
 	case constants.ExternalLoadBalancerNodeRoleValue:
-		node, err = nodes.CreateExternalLoadBalancerNode(d.Name, d.Image, clusterLabel, d.APIServerAddress, d.APIServerPort, d.ExtraPortMappings)
+		node, err = nodes.CreateExternalLoadBalancerNode(d.Name, d.Image, clusterLabel, d.APIServerAddress, d.APIServerPort)
 	case constants.ControlPlaneNodeRoleValue:
 		node, err = nodes.CreateControlPlaneNode(d.Name, d.Image, clusterLabel, d.APIServerAddress, d.APIServerPort, d.ExtraMounts, d.ExtraPortMappings)
 	case constants.WorkerNodeRoleValue:

--- a/pkg/cluster/internal/create/nodes.go
+++ b/pkg/cluster/internal/create/nodes.go
@@ -215,7 +215,7 @@ func (d *nodeSpec) Create(clusterLabel string) (node *nodes.Node, err error) {
 	// TODO(bentheelder): decouple from config objects further
 	switch d.Role {
 	case constants.ExternalLoadBalancerNodeRoleValue:
-		node, err = nodes.CreateExternalLoadBalancerNode(d.Name, d.Image, clusterLabel, d.APIServerAddress, d.APIServerPort)
+		node, err = nodes.CreateExternalLoadBalancerNode(d.Name, d.Image, clusterLabel, d.APIServerAddress, d.APIServerPort, d.ExtraPortMappings)
 	case constants.ControlPlaneNodeRoleValue:
 		node, err = nodes.CreateControlPlaneNode(d.Name, d.Image, clusterLabel, d.APIServerAddress, d.APIServerPort, d.ExtraMounts, d.ExtraPortMappings)
 	case constants.WorkerNodeRoleValue:

--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -84,7 +84,7 @@ func CreateControlPlaneNode(name, image, clusterLabel, listenAddress string, por
 
 // CreateExternalLoadBalancerNode creates an external loab balancer node
 // and gets ready for exposing the the API server and the load balancer admin console
-func CreateExternalLoadBalancerNode(name, image, clusterLabel, listenAddress string, port int32, portMappings []cri.PortMapping) (node *Node, err error) {
+func CreateExternalLoadBalancerNode(name, image, clusterLabel, listenAddress string, port int32) (node *Node, err error) {
 	// gets a random host port for control-plane load balancer
 	// gets a random host port for the API server
 	if port == 0 {
@@ -96,13 +96,13 @@ func CreateExternalLoadBalancerNode(name, image, clusterLabel, listenAddress str
 	}
 
 	// load balancer port mapping
-	portMappingsWithLoadBalancer := append(portMappings, cri.PortMapping{
+	portMappings := []cri.PortMapping{{
 		ListenAddress: listenAddress,
 		HostPort:      port,
 		ContainerPort: loadbalancer.ControlPlanePort,
-	})
+	}}
 	node, err = createNode(name, image, clusterLabel, constants.ExternalLoadBalancerNodeRoleValue,
-		nil, portMappingsWithLoadBalancer,
+		nil, portMappings,
 		// publish selected port for the control plane
 		"--expose", fmt.Sprintf("%d", port),
 	)

--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -49,7 +49,7 @@ func getPort() (int32, error) {
 
 // CreateControlPlaneNode creates a contol-plane node
 // and gets ready for exposing the the API server
-func CreateControlPlaneNode(name, image, clusterLabel, listenAddress string, port int32, mounts []cri.Mount) (node *Node, err error) {
+func CreateControlPlaneNode(name, image, clusterLabel, listenAddress string, port int32, mounts []cri.Mount, portMappings []cri.PortMapping) (node *Node, err error) {
 	// gets a random host port for the API server
 	if port == 0 {
 		p, err := getPort()
@@ -61,7 +61,7 @@ func CreateControlPlaneNode(name, image, clusterLabel, listenAddress string, por
 
 	portMapping := net.JoinHostPort(listenAddress, fmt.Sprintf("%d", port)) + fmt.Sprintf(":%d", kubeadm.APIServerPort)
 	node, err = createNode(
-		name, image, clusterLabel, constants.ControlPlaneNodeRoleValue, mounts,
+		name, image, clusterLabel, constants.ControlPlaneNodeRoleValue, mounts, portMappings,
 		// publish selected port for the API server
 		"--expose", fmt.Sprintf("%d", port),
 		"-p", portMapping,
@@ -93,7 +93,7 @@ func CreateExternalLoadBalancerNode(name, image, clusterLabel, listenAddress str
 
 	portMapping := net.JoinHostPort(listenAddress, fmt.Sprintf("%d", port)) + fmt.Sprintf(":%d", loadbalancer.ControlPlanePort)
 	node, err = createNode(name, image, clusterLabel, constants.ExternalLoadBalancerNodeRoleValue,
-		nil,
+		nil, nil,
 		// publish selected port for the control plane
 		"--expose", fmt.Sprintf("%d", port),
 		"-p", portMapping,
@@ -111,8 +111,8 @@ func CreateExternalLoadBalancerNode(name, image, clusterLabel, listenAddress str
 }
 
 // CreateWorkerNode creates a worker node
-func CreateWorkerNode(name, image, clusterLabel string, mounts []cri.Mount) (node *Node, err error) {
-	node, err = createNode(name, image, clusterLabel, constants.WorkerNodeRoleValue, mounts)
+func CreateWorkerNode(name, image, clusterLabel string, mounts []cri.Mount, portMappings []cri.PortMapping) (node *Node, err error) {
+	node, err = createNode(name, image, clusterLabel, constants.WorkerNodeRoleValue, mounts, portMappings)
 	if err != nil {
 		return node, err
 	}
@@ -123,7 +123,7 @@ func CreateWorkerNode(name, image, clusterLabel string, mounts []cri.Mount) (nod
 // createNode `docker run`s the node image, note that due to
 // images/node/entrypoint being the entrypoint, this container will
 // effectively be paused until we call actuallyStartNode(...)
-func createNode(name, image, clusterLabel, role string, mounts []cri.Mount, extraArgs ...string) (handle *Node, err error) {
+func createNode(name, image, clusterLabel, role string, mounts []cri.Mount, portMappings []cri.PortMapping, extraArgs ...string) (handle *Node, err error) {
 	runArgs := []string{
 		"-d", // run the container detached
 		"-t", // allocate a tty for entrypoint logs
@@ -165,6 +165,7 @@ func createNode(name, image, clusterLabel, role string, mounts []cri.Mount, extr
 		image,
 		docker.WithRunArgs(runArgs...),
 		docker.WithMounts(mounts),
+		docker.WithPortMappings(portMappings),
 	)
 
 	// we should return a handle so the caller can clean it up

--- a/pkg/container/cri/types.go
+++ b/pkg/container/cri/types.go
@@ -53,13 +53,14 @@ type Mount struct {
 // In yaml this looks like:
 //  containerPort: 80
 //  hostPort: 8000
-//  readOnly: true
+//  listenAddress: 127.0.0.1
 type PortMapping struct {
 	// Port within the container.
-	ContainerPort int32 `protobuf:"varint,1,opt,name=container_path,json=containerPort,proto3" json:"containerPort,omitempty"`
+	ContainerPort int32 `protobuf:"varint,1,opt,name=container_port,json=containerPort,proto3" json:"containerPort,omitempty"`
 	// Port on the host.
 	HostPort int32 `protobuf:"varint,2,opt,name=host_path,json=hostPort,proto3" json:"hostPort,omitempty"`
 	// TODO: add protocol (tcp/udp) and port-ranges
+	ListenAddress string `protobuf:"bytes,3,opt,name=listenAddress,json=hostPort,proto3" json:"listenAddress,omitempty"`
 }
 
 // MountPropagation represents an "enum" for mount propagation options,

--- a/pkg/container/cri/types.go
+++ b/pkg/container/cri/types.go
@@ -49,6 +49,19 @@ type Mount struct {
 	Propagation MountPropagation `protobuf:"varint,5,opt,name=propagation,proto3,enum=runtime.v1alpha2.MountPropagation" json:"propagation,omitempty"`
 }
 
+// PortMapping specifies a host port mapped into a container port.
+// In yaml this looks like:
+//  containerPort: 80
+//  hostPort: 8000
+//  readOnly: true
+type PortMapping struct {
+	// Port within the container.
+	ContainerPort int32 `protobuf:"varint,1,opt,name=container_path,json=containerPort,proto3" json:"containerPort,omitempty"`
+	// Port on the host.
+	HostPort int32 `protobuf:"varint,2,opt,name=host_path,json=hostPort,proto3" json:"hostPort,omitempty"`
+	// TODO: add protocol (tcp/udp) and port-ranges
+}
+
 // MountPropagation represents an "enum" for mount propagation options,
 // see also Mount.
 type MountPropagation int32

--- a/pkg/container/docker/critoflags.go
+++ b/pkg/container/docker/critoflags.go
@@ -71,3 +71,13 @@ func generateMountBindings(mounts ...cri.Mount) []string {
 	}
 	return result
 }
+
+func generatePortMappings(portMappings ...cri.PortMapping) []string {
+	result := make([]string, 0, len(portMappings))
+	for _, pm := range portMappings {
+		publish := fmt.Sprintf("%d:%d", pm.HostPort, pm.ContainerPort)
+		publish = fmt.Sprintf("-p %s", publish)
+		result = append(result, publish)
+	}
+	return result
+}

--- a/pkg/container/docker/critoflags.go
+++ b/pkg/container/docker/critoflags.go
@@ -18,6 +18,7 @@ package docker
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -75,11 +76,13 @@ func generateMountBindings(mounts ...cri.Mount) []string {
 func generatePortMappings(portMappings ...cri.PortMapping) []string {
 	result := make([]string, 0, len(portMappings))
 	for _, pm := range portMappings {
-		publish := fmt.Sprintf("%d:%d", pm.HostPort, pm.ContainerPort)
+		var hostPortBinding string
 		if pm.ListenAddress != "" {
-			publish = fmt.Sprintf("%s:%s", pm.ListenAddress, publish)
+			hostPortBinding = net.JoinHostPort(pm.ListenAddress, fmt.Sprintf("%d", pm.HostPort))
+		} else {
+			hostPortBinding = fmt.Sprintf("%d", pm.HostPort)
 		}
-		publish = fmt.Sprintf("--publish=%s", publish)
+		publish := fmt.Sprintf("--publish=%s:%d", hostPortBinding, pm.ContainerPort)
 		result = append(result, publish)
 	}
 	return result

--- a/pkg/container/docker/critoflags.go
+++ b/pkg/container/docker/critoflags.go
@@ -76,7 +76,10 @@ func generatePortMappings(portMappings ...cri.PortMapping) []string {
 	result := make([]string, 0, len(portMappings))
 	for _, pm := range portMappings {
 		publish := fmt.Sprintf("%d:%d", pm.HostPort, pm.ContainerPort)
-		publish = fmt.Sprintf("-p %s", publish)
+		if pm.ListenAddress != "" {
+			publish = fmt.Sprintf("%s:%s", pm.ListenAddress, publish)
+		}
+		publish = fmt.Sprintf("--publish=%s", publish)
 		result = append(result, publish)
 	}
 	return result

--- a/pkg/container/docker/run.go
+++ b/pkg/container/docker/run.go
@@ -32,6 +32,7 @@ type runOpts struct {
 	RunArgs       []string
 	ContainerArgs []string
 	Mounts        []cri.Mount
+	PortMappings  []cri.PortMapping
 }
 
 // WithRunArgs sets the args for docker run
@@ -61,6 +62,14 @@ func WithMounts(mounts []cri.Mount) RunOpt {
 	}
 }
 
+// WithPortMappings sets the container port mappings to the host
+func WithPortMappings(portMappings []cri.PortMapping) RunOpt {
+	return func(r *runOpts) *runOpts {
+		r.PortMappings = portMappings
+		return r
+	}
+}
+
 // Run creates a container with "docker run", with some error handling
 func Run(image string, opts ...RunOpt) error {
 	o := &runOpts{}
@@ -71,6 +80,9 @@ func Run(image string, opts ...RunOpt) error {
 	runArgs := o.RunArgs
 	for _, mount := range o.Mounts {
 		runArgs = append(runArgs, generateMountBindings(mount)...)
+	}
+	for _, portMapping := range o.PortMappings {
+		runArgs = append(runArgs, generatePortMappings(portMapping)...)
 	}
 	// construct the actual docker run argv
 	args := []string{"run"}

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -244,6 +244,21 @@ nodes:
 - role: worker
 ```
 
+#### Mapping ports to the host machine
+You can map extra ports from the nodes to the host machine with `extraPortMappings`:
+```yaml
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+- role: control-plane
+- role: worker
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    listenAddress: "127.0.0.1" # Optional, defaults to "0.0.0.0"
+```
+This can be useful if using `NodePort` services or daemonsets exposing host ports.
+
 ### Enable Feature Gates in Your Cluster
 
 Feature gates are a set of key=value pairs that describe alpha or experimental features. In order to enable a gate you have to [customize your kubeadm configuration][customize control plane with kubeadm], and it will depend on what gate and component you want to enable. An example kind config can be:


### PR DESCRIPTION
Fixes #99: Allows to specify in configuration port mappings for the cluster nodes:

```yaml
kind: Cluster
apiVersion: kind.sigs.k8s.io/v1alpha3
nodes:
- role: control-plane
  extraPortMappings:
  - containerPort: 80
    hostPort: 80
  extraMounts:
  - containerPath: /mounts
    hostPath: /var/lib/kind/mounts
```
I have tested and used this locally exposing ingress as a daemonset and hostPorts: