### PR TITLE
Fix creating bindir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@
 # get the repo root and output path, go_container.sh respects these
 REPO_ROOT:=${CURDIR}
 OUT_DIR=$(REPO_ROOT)/bin
+INSTALL?=install
 # make install will place binaries here
 # the default path attempts to mimic go install
 INSTALL_DIR?=$(shell hack/build/goinstalldir.sh)
@@ -42,7 +43,7 @@ build: kind
 
 # use: make install INSTALL_DIR=/usr/local/bin
 install: build
-	install $(OUT_DIR)/$(KIND_BINARY_NAME) $(INSTALL_DIR)/$(KIND_BINARY_NAME)
+	$(INSTALL) $(OUT_DIR)/$(KIND_BINARY_NAME) $(INSTALL_DIR)/$(KIND_BINARY_NAME)
 
 # cleans the cache volume
 clean-cache:

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ build: kind
 
 # use: make install INSTALL_DIR=/usr/local/bin
 install: build
+	$(INSTALL) -d $(INSTALL_DIR)
 	$(INSTALL) $(OUT_DIR)/$(KIND_BINARY_NAME) $(INSTALL_DIR)/$(KIND_BINARY_NAME)
 
 # cleans the cache volume


### PR DESCRIPTION
Right now, if the `INSTALL_DIR` doesn't exist, `install` will error out with an error message. This could happen if, for example, a package manager like Homebrew was trying to install the `kind` binary to a binary path that won't exist at the start of the installation process. I've added a call to `install -d` beforehand to ensure it gets created.

I've also made the `install` tool configurable; this is pretty common for people who want to specify an alternate binary, for example to switch between BSD and GNU bintools.