### PR TITLE
Remove leftover on CoreDNS IPv6 config

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -144,7 +144,6 @@ data:
     .:53 {
         errors
         health
-        rewrite name google.com my-google.default.svc.cluster.local
         kubernetes cluster.local in-addr.arpa ip6.arpa {
            pods insecure
         }


### PR DESCRIPTION
The rewrite config was used on my CircleCI setup to fake the google.com service so some tests don´t fail

https://github.com/aojea/kubernetes/blob/circleci_master/.circleci/fake-google-com.yaml