### PR TITLE
Release 0.4.0

### DIFF
--- a/cmd/kind/version/version.go
+++ b/cmd/kind/version/version.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Version is the kind CLI version
-const Version = "v0.4.0-alpha"
+const Version = "v0.4.0"
 
 // NewCommand returns a new cobra.Command for version
 func NewCommand() *cobra.Command {

--- a/cmd/kind/version/version.go
+++ b/cmd/kind/version/version.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Version is the kind CLI version
-const Version = "v0.4.0"
+const Version = "v0.5.0-alpha"
 
 // NewCommand returns a new cobra.Command for version
 func NewCommand() *cobra.Command {


### PR DESCRIPTION
marking the release versions for go get etc.