### PR TITLE
Make e2e.sh build new base image if arch is not amd64

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -64,7 +64,7 @@ build() {
         /usr/local/bin/create_bazel_cache_rcs.sh || true
     fi
 
-    ARCH=$(dpkg --print-architecture)
+    ARCH=$(go env GOARCH)
     
     if [[ "${ARCH}" == "amd64" ]]; then
         # build the node image w/ kubernetes


### PR DESCRIPTION
As the default base image was built on amd64 platform, makes it
unable to run on other platforms, this change make the script
detect arch and build a new base image from scratch if arch is not
amd64.

Related-Bug: kubernetes-sigs/kind#668