### PR TITLE
add a minimal template for question issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,8 @@
+---
+name: Question
+about: Ask a question about using kind
+labels: triage/support
+
+---
+
+<!-- Consider also checking https://kind.sigs.k8s.io/#community-discussion-contribution-and-support for support, our slack community is especially helpful! -->


### PR DESCRIPTION
a lot of issues filed aren't clearly bugs, feature requests, documentation (though they ought to get documented!) or cleanup requests ... plenty of them are just questions for clarification about usage, failures when using, etc.

we should embrace this and label them appropriately :-)