### PR TITLE
Load docker image if ID is different

### DIFF
--- a/cmd/kind/load/docker-image/docker-image.go
+++ b/cmd/kind/load/docker-image/docker-image.go
@@ -72,14 +72,10 @@ func NewCommand() *cobra.Command {
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	imageName := args[0]
 	// Check that the image exists locally and gets its ID, if not return error
-	lines, err := docker.ImageInspect(imageName, "{{ .Id }}")
+	imageID, err := docker.ImageID(imageName)
 	if err != nil {
 		return errors.Errorf("Image: %q not present locally", imageName)
 	}
-	if len(lines) != 1 {
-		return errors.Errorf("Docker image ID should only be one line, got %d lines", len(lines))
-	}
-	imageID := lines[0]
 	// Check if the cluster name exists
 	known, err := cluster.IsKnown(flags.Name)
 	if err != nil {

--- a/cmd/kind/load/docker-image/docker-image.go
+++ b/cmd/kind/load/docker-image/docker-image.go
@@ -71,11 +71,15 @@ func NewCommand() *cobra.Command {
 
 func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	imageName := args[0]
-	// Check that the image exists locally, if not return error
-	_, err := docker.ImageInspect(imageName)
+	// Check that the image exists locally and gets its ID, if not return error
+	lines, err := docker.ImageInspect(imageName, "{{ .Id }}")
 	if err != nil {
 		return errors.Errorf("Image: %q not present locally", imageName)
 	}
+	if len(lines) != 1 {
+		return errors.Errorf("Docker image ID should only be one line, got %d lines", len(lines))
+	}
+	imageID := lines[0]
 	// Check if the cluster name exists
 	known, err := cluster.IsKnown(flags.Name)
 	if err != nil {
@@ -116,10 +120,10 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	// pick only the nodes that don't have the image
 	selectedNodes := []clusternodes.Node{}
 	for _, node := range candidateNodes {
-		_, err := node.ImageInspect(imageName)
+		_, err := node.ImageInspect(imageID)
 		if err != nil {
 			selectedNodes = append(selectedNodes, node)
-			log.Debugf("Image: %q not present on node %q", imageName, node.String())
+			log.Debugf("Image: %q with ID %q not present on node %q", imageName, imageID, node.String())
 		}
 	}
 

--- a/pkg/container/docker/image.go
+++ b/pkg/container/docker/image.go
@@ -21,8 +21,9 @@ import (
 )
 
 // ImageInspect return low-level information on containers images
-func ImageInspect(containerNameOrID string) ([]string, error) {
+func ImageInspect(containerNameOrID, format string) ([]string, error) {
 	cmd := exec.Command("docker", "image", "inspect",
+		"-f", format,
 		containerNameOrID, // ... against the container
 	)
 

--- a/pkg/container/docker/image.go
+++ b/pkg/container/docker/image.go
@@ -17,6 +17,7 @@ limitations under the License.
 package docker
 
 import (
+	"github.com/pkg/errors"
 	"sigs.k8s.io/kind/pkg/exec"
 )
 
@@ -28,4 +29,16 @@ func ImageInspect(containerNameOrID, format string) ([]string, error) {
 	)
 
 	return exec.CombinedOutputLines(cmd)
+}
+
+// ImageID return the Id of the container image
+func ImageID(containerNameOrID string) (string, error) {
+	lines, err := ImageInspect(containerNameOrID, "{{ .Id }}")
+	if err != nil {
+		return "", err
+	}
+	if len(lines) != 1 {
+		return "", errors.Errorf("Docker image ID should only be one line, got %d lines", len(lines))
+	}
+	return lines[0], nil
 }


### PR DESCRIPTION
We should load the image on the cluster nodes if the ID is different, checking only by name is not enough

Fixes: #680 