### PR TITLE
[WIP] enable concurrent join of both worker and control-plane nodes

### DIFF
--- a/pkg/internal/cluster/create/actions/kubeadmjoin/join.go
+++ b/pkg/internal/cluster/create/actions/kubeadmjoin/join.go
@@ -35,10 +35,10 @@ import (
 )
 
 // Action implements action for creating the kubeadm join
-// and deployng it on the bootrap control-plane node.
+// and deploying it on the bootrap control-plane node.
 type Action struct{}
 
-// NewAction returns a new action for creating the kubeadm jion
+// NewAction returns a new action for creating the kubeadm join
 func NewAction() actions.Action {
 	return &Action{}
 }
@@ -121,7 +121,7 @@ func joinWorkers(
 	return nil
 }
 
-// runKubeadmJoinControlPlane executes kubadm join --control-plane command
+// runKubeadmJoinControlPlane executes kubeadm join --control-plane command
 func runKubeadmJoinControlPlane(
 	allNodes []nodes.Node,
 	node *nodes.Node,


### PR DESCRIPTION
(first commit fixes some typos)

concurrent join of CP nodes should be now supported in k/k master for kubeadm.
no test signal in kinder yet though.

this change works for me, but oddly, i don't see much improvements in performance by using `time kind create cluster...` with a `3CPx3W` cluster. it's roughly 10 seconds reduced from 2 minutes 40 seconds without the change, but the numbers vary a lot for me.

i'm noticing that once `kind create cluster` finishes most pods (e.g 24 of 26) are already running for this 6 node setup, which should not be the case - most of the pods should be still creating once the kind binary exists, unless this is desired?

do we have sync points or "wait for node/pods ready" logic in kind?

cc @BenTheElder @aojea @fabriziopandini 
