### PR TITLE
Fix HTTPS_PROXY and pass through proxy vars if set

### DIFF
--- a/hack/build/go_container.sh
+++ b/hack/build/go_container.sh
@@ -73,9 +73,9 @@ run_in_go_container() {
       -e GOOS="${GOOS}" \
       -e GOARCH="${GOARCH}" \
     `# pass through proxy settings from the host` \
-      -e HTTP_PROXY="${HTTP_PROXY:+}" \
-      -e HTTPS_PROXY="${HTTPS_PROX:+}" \
-      -e NO_PROXY="${NO_PROXY:+}" \
+      -e HTTP_PROXY \
+      -e HTTPS_PROXY \
+      -e NO_PROXY \
     `# run as if the host user for consistent file permissions` \
       --user "${_UID}:${_GID}" \
     `# use the golang image for the container` \


### PR DESCRIPTION
Build script was looking for "${HTTPS_PROX:+}" instead of
"${HTTPS_PROXY:+}" to use resulting in failure to build from behind
proxies.

To prevent typos from occurring it is easier to simply ask Docker to
pass through environment variables that are set by using `-e VAR`
instead of `-e VAR=VALUE`.