### PR TITLE
Remove extraneous blank entry from NO_PROXY

### DIFF
--- a/pkg/cluster/nodes/node.go
+++ b/pkg/cluster/nodes/node.go
@@ -323,7 +323,7 @@ func getSubnets(networkName string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return strings.Split(lines[0], " "), nil
+	return strings.Split(strings.TrimSpace(lines[0]), " "), nil
 }
 
 // EnableIPv6 enables IPv6 inside the node container and in the inner docker daemon


### PR DESCRIPTION
Strip trailing whitespace from subnet retrieved from docker network
inspection to prevent splitting returning an array with an extraneous
element of ''.

Enabling use of proxies results in a NO_PROXY value containing an
extraneous element signified by ',,' appearing in the value appearing
in the container runtime environment.

This can be seen by running a `docker network inspect ..` command
locally using the same go format string to retrieve the output.

  echo "'$(docker network inspect bridge -f ...)'"
  '172.17.0.0/16 '

This is due to the embedded space in the format string in order to
provide a delimiter should more than one subnet be returned.

To prevent a subsequent split from returning an array that looks like
"['172.17.0.0/16', '']", should first trim any trailing whitespace.

This changes the NO_PROXY variable in the <cluster>-control-plane and
subsequent services from looking like:

  172.17.0.0/16,,localhost,127.0.0.1,...

to:

  172.17.0.0/16,localhost,127.0.0.1,...