### PR TITLE
Revert "Remove entrypoint configuration workaround."

### DIFF
--- a/images/base/entrypoint
+++ b/images/base/entrypoint
@@ -18,6 +18,19 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+configure_proxy() {
+  # Don't use proxy for the local network
+  LOCAL_NETWORK=$(ip route list dev eth0 proto kernel | awk '{ print $1 }')
+
+  mkdir -p /etc/systemd/system/containerd.service.d/
+  cat <<EOF >/etc/systemd/system/containerd.service.d/http-proxy.conf
+[Service]
+Environment="HTTP_PROXY=${HTTP_PROXY:-}"
+Environment="HTTPS_PROXY=${HTTPS_PROXY:-}"
+Environment="NO_PROXY=${NO_PROXY:-localhost},${LOCAL_NETWORK}"
+EOF
+}
+
 fix_mount() {
   echo 'INFO: ensuring we can execute /bin/mount even with userns-remap'
   # necessary only when userns-remap is enabled on the host, but harmless
@@ -85,6 +98,7 @@ fix_kmsg
 fix_mount
 fix_machine_id
 fix_product_name
+configure_proxy
 
 # we want the command (expected to be systemd) to be PID1, so exec to it
 exec "$@"


### PR DESCRIPTION
Containerd needs to set the proxy variables using systemd configuration files

This reverts commit 5f43b701879bbf5519dacb2ae5546caede937e33.

Fixes: #688