### PR TITLE
configure proxy settings on all processes under systemd

### DIFF
--- a/images/base/entrypoint
+++ b/images/base/entrypoint
@@ -80,11 +80,22 @@ fix_kmsg() {
   fi
 }
 
+configure_proxy() {
+  # ensure all processes receive the proxy settings by default
+  # https://www.freedesktop.org/software/systemd/man/systemd-system.conf.html
+  mkdir -p /etc/systemd/system.conf.d/
+  cat <<EOF >/etc/systemd/system.conf.d/proxy-default-environment.conf
+[Manager]
+DefaultEnvironment="HTTP_PROXY=${HTTP_PROXY:-}" "HTTPS_PROXY=${HTTPS_PROXY:-}" "NO_PROXY=${NO_PROXY:-}"
+EOF
+}
+
 # run pre-init fixups
 fix_kmsg
 fix_mount
 fix_machine_id
 fix_product_name
+configure_proxy
 
 # we want the command (expected to be systemd) to be PID1, so exec to it
 exec "$@"

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -44,7 +44,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20190626-0e2d441@sha256:d69fff65f7d31a7c910f543f2a6d3159403aa37414d1b1534f4db50e7df1261d"
+const DefaultBaseImage = "kindest/base:v20190708-022110d@sha256:8acfd3b9b8a3a42385a761f8c6aa3bdad4241cac220c12d3309f1b7a6d70af24"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
we also probably need to consider a more thorough approach that covers exec (eg `kubeadm init`).

that will be easier after some other pending refactors, this PR in particular is merely an alternative to the existing outgoing PRs around containerd on the nodes