### PR TITLE
[Only for testing] Run k/k PR presubmit tests with kind

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -221,6 +221,11 @@ EOF
         # [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods
         # It reuires metrics addon, ref: https://github.com/kubernetes/kubernetes/pull/79954
         SKIP="ReplicationController.light.Should.scale.from.1.pod.to.2.pods|${SKIP}"
+        if [[ "${IP_FAMILY:-ipv4}" == "ipv6" ]]; then
+            # TODO(aojea): The ipv6 job times out and have 520 failures at that time
+            # lets skip storage at this moment
+            SKIP="\\[sig-storage\\]|${SKIP}"
+        fi
     else
         SKIP="${SKIP:-}"
         FOCUS="${FOCUS:-"\\[Conformance\\]"}"

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -187,6 +187,7 @@ EOF
         | grep -cv "node-role.kubernetes.io/master" \
     )"
 
+    KUBERNETES_PRESUBMIT_JOB=true
     # ginkgo regexes
     if [[ "${KUBERNETES_PRESUBMIT_JOB:-}" = true ]]; then
         # k/k presubmit jobs regex

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -191,8 +191,8 @@ EOF
     # ginkgo regexes
     if [[ "${KUBERNETES_PRESUBMIT_JOB:-}" = true ]]; then
         # k/k presubmit jobs regex
-        SKIP="${SKIP:-"\\[Slow\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"}"
-        FOCUS="${FOCUS:-""}"
+        SKIP="${SKIP:-"\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"}"
+        FOCUS="${FOCUS:-"\\[Slow\\]"}"
         # skip tests that are not able to rung with kind
         # [sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]
         # https://github.com/kubernetes/kubernetes/issues/80098

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -221,11 +221,6 @@ EOF
         # [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods
         # It reuires metrics addon, ref: https://github.com/kubernetes/kubernetes/pull/79954
         SKIP="ReplicationController.light.Should.scale.from.1.pod.to.2.pods|${SKIP}"
-        if [[ "${IP_FAMILY:-ipv4}" == "ipv6" ]]; then
-            # TODO(aojea): The ipv6 job times out and have 520 failures at that time
-            # lets skip storage at this moment
-            SKIP="\\[sig-storage\\]|${SKIP}"
-        fi
     else
         SKIP="${SKIP:-}"
         FOCUS="${FOCUS:-"\\[Conformance\\]"}"


### PR DESCRIPTION
It adds an environment variable to the script that runs the e2e tests to allow to choose between
conformance tests or the e2e tests that run in a k/k  presubmit job (skipping the ones that have known issues with kind)

https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md

xref: #698