### PR TITLE
Image load refactor

### DIFF
--- a/pkg/build/kube/bits.go
+++ b/pkg/build/kube/bits.go
@@ -33,9 +33,10 @@ type Bits interface {
 	// Paths returns a map of path on host machine to desired path in the image
 	// These paths will be populated in the image relative to some base path,
 	// obtainable by NodeInstall.BasePath()
-	// Note: if Images are populated to images/, the cluster provisioning
-	// will load these prior to calling kubeadm
 	Paths() map[string]string
+	// ImagePaths returns a list of paths to image archives to be loaded into
+	// the Node
+	ImagePaths() []string
 	// Install should install the built sources on the node, assuming paths
 	// have been populated
 	// TODO(bentheelder): eliminate install, make install file-copies only,

--- a/pkg/build/kube/dockerbuildbits.go
+++ b/pkg/build/kube/dockerbuildbits.go
@@ -198,21 +198,26 @@ func (b *DockerBuildBits) Paths() map[string]string {
 	binDir := filepath.Join(b.kubeRoot,
 		"_output", "dockerized", "bin", "linux", util.GetArch(),
 	)
-	imageDir := filepath.Join(b.kubeRoot,
-		"_output", "release-images", util.GetArch(),
-	)
 	return map[string]string{
 		// binaries (hyperkube)
 		filepath.Join(binDir, "kubeadm"): "bin/kubeadm",
 		filepath.Join(binDir, "kubelet"): "bin/kubelet",
 		filepath.Join(binDir, "kubectl"): "bin/kubectl",
-		// docker images
-		filepath.Join(imageDir, "kube-apiserver.tar"):          "images/kube-apiserver.tar",
-		filepath.Join(imageDir, "kube-controller-manager.tar"): "images/kube-controller-manager.tar",
-		filepath.Join(imageDir, "kube-scheduler.tar"):          "images/kube-scheduler.tar",
-		filepath.Join(imageDir, "kube-proxy.tar"):              "images/kube-proxy.tar",
 		// version file
 		filepath.Join(b.kubeRoot, "_output", "git_version"): "version",
+	}
+}
+
+// ImagePaths implements Bits.ImagePaths
+func (b *DockerBuildBits) ImagePaths() []string {
+	imageDir := filepath.Join(b.kubeRoot,
+		"_output", "release-images", util.GetArch(),
+	)
+	return []string{
+		filepath.Join(imageDir, "kube-apiserver.tar"),
+		filepath.Join(imageDir, "kube-controller-manager.tar"),
+		filepath.Join(imageDir, "kube-scheduler.tar"),
+		filepath.Join(imageDir, "kube-proxy.tar"),
 	}
 }
 

--- a/pkg/build/node/import.go
+++ b/pkg/build/node/import.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+type imageImporter interface {
+	Prepare() error
+	LoadCommand() exec.Cmd
+	End() error
+}
+
+type containerdImporter struct {
+	containerCmder exec.Cmder
+}
+
+func newContainerdImporter(containerCmder exec.Cmder) imageImporter {
+	return &containerdImporter{
+		containerCmder: containerCmder,
+	}
+}
+
+var _ imageImporter = &containerdImporter{}
+
+func (c *containerdImporter) Prepare() error {
+	if err := c.containerCmder.Command(
+		"bash", "-c", "nohup containerd > /dev/null 2>&1 &",
+	).Run(); err != nil {
+		return err
+	}
+	// TODO(bentheelder): some healthcheck?
+	return nil
+}
+
+func (c *containerdImporter) LoadCommand() exec.Cmd {
+	return c.containerCmder.Command(
+		"ctr", "--namespace=k8s.io", "images", "import", "--no-unpack", "-",
+	)
+}
+
+func (c *containerdImporter) End() error {
+	return c.containerCmder.Command("pkill", "containerd").Run()
+}

--- a/pkg/container/docker/exec.go
+++ b/pkg/container/docker/exec.go
@@ -20,7 +20,6 @@ import (
 	"io"
 
 	"sigs.k8s.io/kind/pkg/exec"
-	"sigs.k8s.io/kind/pkg/log"
 )
 
 // containerCmder implements exec.Cmder for docker containers
@@ -65,12 +64,6 @@ func (c *containerCmd) Run() error {
 	if c.stdin != nil {
 		args = append(args,
 			"-i", // interactive so we can supply input
-		)
-	}
-	// if the command is hooked up to the processes's output we want a tty
-	if log.IsTerminal(c.stderr) || log.IsTerminal(c.stdout) {
-		args = append(args,
-			"-t",
 		)
 	}
 	// set env

--- a/pkg/container/docker/image.go
+++ b/pkg/container/docker/image.go
@@ -17,9 +17,51 @@ limitations under the License.
 package docker
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kind/pkg/exec"
 )
+
+// SplitImage splits an image into (registry,tag) following these cases:
+//
+//  alpine -> (alpine, latest)
+//
+//  alpine:latest -> (alpine, latest)
+//
+//  alpine@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913 -> (alpine, latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913)
+//
+//  alpine:latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913 -> (alpine, latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913)
+//
+// NOTE: for our purposes we consider the sha to be part of the tag, and we
+// resolve the implicit :latest
+func SplitImage(image string) (registry, tag string, err error) {
+	// we are looking for ':' and '@'
+	firstColon := strings.IndexByte(image, 58)
+	firstAt := strings.IndexByte(image, 64)
+
+	// there should be a registry before the tag, and @/: should not be the last
+	// character, these cases are assumed not to exist by the rest of the code
+	if firstColon == 0 || firstAt == 0 || firstColon+1 == len(image) || firstAt+1 == len(image) {
+		return "", "", fmt.Errorf("unexpected image: %q", image)
+	}
+
+	// NOTE: The order of these cases matters
+	// case: alpine
+	if firstColon == -1 && firstAt == -1 {
+		return image, "latest", nil
+	}
+
+	// case: alpine@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913
+	if firstAt != -1 && firstAt < firstColon {
+		return image[:firstAt], "latest" + image[firstAt:], nil
+	}
+
+	// case: alpine:latest
+	// case: alpine:latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913
+	return image[:firstColon], image[firstColon+1:], nil
+}
 
 // ImageInspect return low-level information on containers images
 func ImageInspect(containerNameOrID, format string) ([]string, error) {

--- a/pkg/container/docker/image_test.go
+++ b/pkg/container/docker/image_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import "testing"
+
+func TestSplitImage(t *testing.T) {
+	/*
+		alpine -> (alpine, latest)
+
+		alpine:latest -> (alpine, latest)
+
+		alpine@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913 -> (alpine, latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913)
+
+		alpine:latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913 -> (alpine, latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913)
+	*/
+	cases := []struct {
+		Image            string
+		ExpectedRegistry string
+		ExpectedTag      string
+		ExpectError      bool
+	}{
+		{
+			Image:            "alpine",
+			ExpectedRegistry: "alpine",
+			ExpectedTag:      "latest",
+			ExpectError:      false,
+		},
+		{
+			Image:            "alpine:latest",
+			ExpectedRegistry: "alpine",
+			ExpectedTag:      "latest",
+			ExpectError:      false,
+		},
+		{
+			Image:            "alpine@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913",
+			ExpectedRegistry: "alpine",
+			ExpectedTag:      "latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913",
+			ExpectError:      false,
+		},
+		{
+			Image:            "alpine:latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913",
+			ExpectedRegistry: "alpine",
+			ExpectedTag:      "latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913",
+			ExpectError:      false,
+		},
+		{
+			Image:            "k8s.gcr.io/coredns:1.1.3",
+			ExpectedRegistry: "k8s.gcr.io/coredns",
+			ExpectedTag:      "1.1.3",
+			ExpectError:      false,
+		},
+		{
+			Image:            "k8s.gcr.io/coredns:1.1.3@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913",
+			ExpectedRegistry: "k8s.gcr.io/coredns",
+			ExpectedTag:      "1.1.3@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913",
+			ExpectError:      false,
+		},
+		{
+			Image:            "k8s.gcr.io/coredns:latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913",
+			ExpectedRegistry: "k8s.gcr.io/coredns",
+			ExpectedTag:      "latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913",
+			ExpectError:      false,
+		},
+		{
+			Image:            "k8s.gcr.io/coredns@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913",
+			ExpectedRegistry: "k8s.gcr.io/coredns",
+			ExpectedTag:      "latest@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913",
+			ExpectError:      false,
+		},
+		{
+			Image:            ":",
+			ExpectedRegistry: "",
+			ExpectedTag:      "",
+			ExpectError:      true,
+		},
+		{
+			Image:            "@",
+			ExpectedRegistry: "",
+			ExpectedTag:      "",
+			ExpectError:      true,
+		},
+		{
+			Image:            "a@",
+			ExpectedRegistry: "",
+			ExpectedTag:      "",
+			ExpectError:      true,
+		},
+		{
+			Image:            "a:",
+			ExpectedRegistry: "",
+			ExpectedTag:      "",
+			ExpectError:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc // capture tc
+		t.Run(tc.Image, func(t *testing.T) {
+			t.Parallel()
+
+			registry, tag, err := SplitImage(tc.Image)
+			if err != nil && !tc.ExpectError {
+				t.Fatalf("Unexpected error: %q", err)
+			} else if err == nil && tc.ExpectError {
+				t.Fatalf("Expected error but got nil")
+			}
+			if registry != tc.ExpectedRegistry {
+				t.Fatalf("ExpectedRegistry %q != %q", tc.ExpectedRegistry, registry)
+			}
+			if tag != tc.ExpectedTag {
+				t.Fatalf("ExpectedTag %q != %q", tc.ExpectedTag, tag)
+			}
+		})
+	}
+}


### PR DESCRIPTION
/hold
I need to do some cleanup, but this is the general approach.

- stop copying in images like every other file, instead have bits provide a separate list of image files
- load images directly from the list of image files, no unnecessary copies / staging / rsync / ...
- replace the bash one-liner to load images with a minimal internal API to prepare the container for image loading, load, and cleanup
- leverage loading each image explicitly from the kind code to stream images through a function that rewrites their repositories (tags) as necessary to add / remove `-${arch}`
- remove tag rewriting logic from the bazel build, as we've now centralized it

besides some simple cleanup, the node build desperately needs a refactor. I'm holding that until after the logger is switched out so we can overhaul the output while we move the logic around ...