### PR TITLE
Add log info messages for build config

### DIFF
--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -120,6 +120,13 @@ func NewBuildContext(options ...Option) (ctx *BuildContext, err error) {
 		}
 		ctx.kubeRoot = kubeRoot
 	}
+	log.Infof("Finished preparing Build Configuration")
+	log.Infof("  kube-root : %s", ctx.kubeRoot)
+	log.Infof("  arch      : %s", ctx.arch)
+	log.Infof("  mode      : %s", ctx.mode)
+	log.Infof("  image     : %s", ctx.image)
+	log.Infof("  base-image: %s", ctx.baseImage)
+
 	// initialize bits
 	bits, err := kube.NewNamedBits(ctx.mode, ctx.kubeRoot)
 	if err != nil {


### PR DESCRIPTION
### What?
Adding extra log messages to print build context while executing `kind build node-image`. 

#### Motivation
As a user, I want to know what `kube-root` got auto-detected in debug logs.

#### Sample Output
```
INFO[08:04:45] Finished preparing Build Configuration
INFO[08:04:45]   kube-root : /Users/taggarwal/workspace/go/src/k8s.io/kubernetes
INFO[08:04:45]   arch      : amd64
INFO[08:04:45]   mode      : docker
INFO[08:04:45]   image     : kindest/node:latest
INFO[08:04:45]   base-image: kindest/base:v20190708-022110d@sha256:8acfd3b9b8a3a42385a761f8c6aa3bdad4241cac220c12d3309f1b7a6d70af24
INFO[08:04:45] Starting to build Kubernetes
DEBU[08:04:45] Running: build/run.sh [build/run.sh make all WHAT=cmd/kubeadm cmd/kubectl cmd/kubelet KUBE_BUILD_PLATFORMS=linux/amd64 KUBE_VERBOSE=0]
+++ [0717 08:04:45] Verifying Prerequisites....
+++ [0717 08:04:45] Using Docker for MacOS
+++ [0717 08:04:47] Building Docker image kube-build:build-caab1c1b32-5-v1.12.7-1
+++ [0717 08:04:50] Keeping container kube-build-data-caab1c1b32-5-v1.12.7-1
+++ [0717 08:04:50] Keeping container wordpress-control-plane
+++ [0717 08:04:51] Keeping container wonderful_antonelli
+++ [0717 08:04:51] Keeping container affectionate_brown
.................
```