### PR TITLE
Build arm32 kind and ctr variants

### DIFF
--- a/hack/release/build/cross.sh
+++ b/hack/release/build/cross.sh
@@ -52,6 +52,7 @@ build() {
 # TODO(bentheelder): support more platforms
 echo "Building in parallel for:"
 build "linux" "amd64" & \
+build "linux" "arm" & \
 build "linux" "arm64" & \
 build "linux" "ppc64le" & \
 build "darwin" "amd64" & \

--- a/hack/release/build/ctr/run.sh
+++ b/hack/release/build/ctr/run.sh
@@ -53,6 +53,7 @@ REVISION=$(git rev-parse HEAD)$(if ! git diff --no-ext-diff --quiet --exit-code;
 
 # submit a build for each arch
 GOARCHES=(
+  "arm"
   "arm64"
   "amd64"
   "ppc64le"

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -70,7 +70,7 @@ RUN clean-install \
     && rm -f /lib/systemd/system/basic.target.wants/* \
     && echo "ReadKMsg=no" >> /etc/systemd/journald.conf \
     && systemctl enable containerd \
-    && export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/') \
+    && export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') \
     && curl -fSL -o /usr/local/bin/ctr \
       "https://storage.googleapis.com/bentheelder-kind-dev/containerd/linux/${ARCH}/ctr" \
     && chmod +x /usr/local/bin/ctr \
@@ -90,7 +90,7 @@ RUN containerd --version \
 # TODO(bentheelder): doc why / what here
 ARG CNI_VERSION="0.7.5"
 ARG CNI_BASE_URL="https://storage.googleapis.com/kubernetes-release/network-plugins/"
-RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/') \
+RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') \
     && export CNI_TARBALL="cni-plugins-${ARCH}-v${CNI_VERSION}.tgz" \
     && export CNI_URL="${CNI_BASE_URL}${CNI_TARBALL}" \
     && curl -sSL --retry 5 --output /tmp/cni.tgz "${CNI_URL}" \
@@ -101,7 +101,7 @@ RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/') \
 
 # Install crictl to /usr/local/bin
 ARG CRICTL_VERSION="v1.14.0"
-RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/') \
+RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') \
     && curl -fSL "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCH}.tar.gz" | tar xzC /usr/local/bin \
     && echo 'runtime-endpoint: unix:///var/run/containerd/containerd.sock' > /etc/crictl.yaml
 

--- a/pkg/build/kube/dockerbuildbits.go
+++ b/pkg/build/kube/dockerbuildbits.go
@@ -121,6 +121,7 @@ func (b *DockerBuildBits) build() error {
 		// we don't want to build these images as we don't use them...
 		"KUBE_BUILD_HYPERKUBE=n",
 		"KUBE_BUILD_CONFORMANCE=n",
+		"KUBE_BUILD_PLATFORMS="+dockerBuildOsAndArch(),
 	)
 	cmd.SetEnv(os.Environ()...)
 	exec.InheritOutput(cmd)

--- a/pkg/util/osarch.go
+++ b/pkg/util/osarch.go
@@ -26,6 +26,8 @@ func GetArch() string {
 	switch runtime.GOARCH {
 	case "amd64":
 		return "amd64"
+	case "arm":
+		return "arm"
 	case "arm64":
 		return "arm64"
 	case "ppc64le":


### PR DESCRIPTION
Raspberry Pi's by default run in 32-bit mode, for {reasons}.

This means that when building a node image on a raspberry pi, currently it errors with:

```
curl -fSL -o /usr/local/bin/ctr       "https://storage.googleapis.com/bentheelder-kind-dev/containerd/linux/${ARCH}/ctr"     && chmod +x /usr/local/bin/ctr     && echo "done installing packages"' returned a non-zero code: 22
```

This is because there is no `arm` variant of containerd published to the bucket.

This PR adds `arm` as a build target for `containerd`, as well as for the `kind` binary itself (to make peoples lives easier 😄).

As we don't publish multi arch *node images* currently, users will still be required to build their own. But this at least edges us closer towards it being *possible* 😄.

~I've not actually tested the `kind build base-image` command after running this, but I *have* run the `ctr` build script which succeeds.~

EDIT: with a few more changes, it's now possible to build the base image for arm32. More work is required to get the node image to build 😄 

/cc @BenTheElder 