### PR TITLE
Add an option to enable PodSecurityPolicy

### DIFF
--- a/pkg/apis/config/v1alpha3/types.go
+++ b/pkg/apis/config/v1alpha3/types.go
@@ -49,6 +49,9 @@ type Cluster struct {
 	// KubeadmConfigPatchesJSON6902 are applied to the generated kubeadm config
 	// as patchesJson6902 to `kustomize build`
 	KubeadmConfigPatchesJSON6902 []PatchJSON6902 `json:"kubeadmConfigPatchesJson6902,omitempty"`
+
+	// EnablePodSecurityPolicy enable the admission controller
+	EnablePodSecurityPolicy bool `json:"enablePodSecurityPolicy,omitempty"`
 }
 
 // Node contains settings for a node in the `kind` Cluster.

--- a/pkg/build/node/cni.go
+++ b/pkg/build/node/cni.go
@@ -37,11 +37,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: kindnet
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
 spec:
   privileged: false
   volumes:

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -49,6 +49,9 @@ type Cluster struct {
 	// KubeadmConfigPatchesJSON6902 are applied to the generated kubeadm config
 	// as patchesJson6902 to `kustomize build`
 	KubeadmConfigPatchesJSON6902 []PatchJSON6902
+
+	// EnablePodSecurityPolicy enable the admission controller
+	EnablePodSecurityPolicy bool
 }
 
 // Node contains settings for a node in the `kind` Cluster.

--- a/pkg/internal/apis/config/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/config/v1alpha3/zz_generated.conversion.go
@@ -87,6 +87,7 @@ func autoConvert_v1alpha3_Cluster_To_config_Cluster(in *v1alpha3.Cluster, out *c
 	}
 	out.KubeadmConfigPatches = *(*[]string)(unsafe.Pointer(&in.KubeadmConfigPatches))
 	out.KubeadmConfigPatchesJSON6902 = *(*[]config.PatchJSON6902)(unsafe.Pointer(&in.KubeadmConfigPatchesJSON6902))
+	out.EnablePodSecurityPolicy = in.EnablePodSecurityPolicy
 	return nil
 }
 
@@ -102,6 +103,7 @@ func autoConvert_config_Cluster_To_v1alpha3_Cluster(in *config.Cluster, out *v1a
 	}
 	out.KubeadmConfigPatches = *(*[]string)(unsafe.Pointer(&in.KubeadmConfigPatches))
 	out.KubeadmConfigPatchesJSON6902 = *(*[]v1alpha3.PatchJSON6902)(unsafe.Pointer(&in.KubeadmConfigPatchesJSON6902))
+	out.EnablePodSecurityPolicy = in.EnablePodSecurityPolicy
 	return nil
 }
 

--- a/pkg/internal/cluster/create/actions/config/config.go
+++ b/pkg/internal/cluster/create/actions/config/config.go
@@ -92,6 +92,7 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 		ServiceSubnet:        ctx.Config.Networking.ServiceSubnet,
 		ControlPlane:         true,
 		IPv6:                 ctx.Config.Networking.IPFamily == "ipv6",
+		PodSecurityPolicy:    ctx.Config.EnablePodSecurityPolicy,
 	}
 
 	fns = append(fns, func() error {

--- a/pkg/internal/cluster/create/actions/installpsp/psp.go
+++ b/pkg/internal/cluster/create/actions/installpsp/psp.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package installpsp implements the an action to isntall a default
+// Pod Security Policy
+package installpsp
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"sigs.k8s.io/kind/pkg/cluster/nodes"
+	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions"
+)
+
+type action struct{}
+
+// NewAction returns a new action for installing storage
+func NewAction() actions.Action {
+	return &action{}
+}
+
+// Execute runs the action
+func (a *action) Execute(ctx *actions.ActionContext) error {
+	ctx.Status.Start("Installing Default PodSecurityPolicy  💾")
+	defer ctx.Status.End(false)
+
+	allNodes, err := ctx.Nodes()
+	if err != nil {
+		return err
+	}
+
+	// get the target node for this task
+	node, err := nodes.BootstrapControlPlaneNode(allNodes)
+	if err != nil {
+		return err
+	}
+
+	// add the default storage class
+	if err := addDefaultPodSecurityPolicy(node); err != nil {
+		return errors.Wrap(err, "failed to add default Pod Security Policy")
+	}
+
+	// mark success
+	ctx.Status.End(true)
+	return nil
+}
+
+// a default pod security policy unrestricted
+// we need this for e2es (PodSecurityPolicy)
+const defaultPodSecurityPolicyManifest = `# least restricted policy
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: psp-privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+---
+# Cluster role which grants access to the default pod security policy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp-privileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - psp-privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# Cluster role binding for default pod security policy granting all authenticated users access
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: psp-privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp-privileged
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+`
+
+func addDefaultPodSecurityPolicy(controlPlane *nodes.Node) error {
+	in := strings.NewReader(defaultPodSecurityPolicyManifest)
+	cmd := controlPlane.Command(
+		"kubectl",
+		"--kubeconfig=/etc/kubernetes/admin.conf", "apply", "-f", "-",
+	)
+	cmd.SetStdin(in)
+	return cmd.Run()
+}

--- a/pkg/internal/cluster/create/create.go
+++ b/pkg/internal/cluster/create/create.go
@@ -34,6 +34,7 @@ import (
 
 	configaction "sigs.k8s.io/kind/pkg/internal/cluster/create/actions/config"
 	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions/installcni"
+	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions/installpsp"
 	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions/installstorage"
 	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions/kubeadminit"
 	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions/kubeadmjoin"
@@ -93,6 +94,13 @@ func Cluster(ctx *context.Context, options ...create.ClusterOption) error {
 			kubeadminit.NewAction(), // run kubeadm init
 		)
 		// this step might be skipped, but is next after init
+		if opts.Config.EnablePodSecurityPolicy {
+			actionsToRun = append(actionsToRun,
+				installpsp.NewAction(), // install default policy
+			)
+		}
+
+		// this step might be skipped, but is next after init or PSP
 		if !opts.Config.Networking.DisableDefaultCNI {
 			actionsToRun = append(actionsToRun,
 				installcni.NewAction(), // install CNI

--- a/pkg/internal/cluster/kubeadm/config.go
+++ b/pkg/internal/cluster/kubeadm/config.go
@@ -51,6 +51,8 @@ type ConfigData struct {
 	ServiceSubnet string
 	// IPv4 values take precedence over IPv6 by default, if true set IPv6 default values
 	IPv6 bool
+	// PodSecurityPolicy enables the admission controller
+	PodSecurityPolicy bool
 	// DerivedConfigData is populated by Derive()
 	// These auto-generated fields are available to Config templates,
 	// but not meant to be set by hand
@@ -99,6 +101,11 @@ controlPlaneEndpoint: "{{ .ControlPlaneEndpoint }}"
 api:
   advertiseAddress: "{{ .NodeAddress }}"
   bindPort: {{.APIBindPort}}
+{{ if .PodSecurityPolicy -}}
+# enable PodSecurityPolicy admission controller
+apiServerExtraArgs:
+  enable-admission-plugins: PodSecurityPolicy
+{{- end }}
 # we need nsswitch.conf so we use /etc/hosts
 # https://github.com/kubernetes/kubernetes/issues/69195
 apiServerExtraVolumes:
@@ -165,6 +172,11 @@ controlPlaneEndpoint: "{{ .ControlPlaneEndpoint }}"
 networking:
   podSubnet: "{{ .PodSubnet }}"
   serviceSubnet: "{{ .ServiceSubnet }}"
+{{ if .PodSecurityPolicy -}}
+# enable PodSecurityPolicy admission controller
+apiServerExtraArgs:
+  enable-admission-plugins: PodSecurityPolicy
+{{- end }}
 # we need nsswitch.conf so we use /etc/hosts
 # https://github.com/kubernetes/kubernetes/issues/69195
 apiServerExtraVolumes:
@@ -259,6 +271,10 @@ controlPlaneEndpoint: "{{ .ControlPlaneEndpoint }}"
 # to the cluster after rewriting the kubeconfig to point to localhost
 apiServer:
   certSANs: [localhost, "{{.APIServerAddress}}"]
+  {{ if .PodSecurityPolicy -}}
+  extraArgs:
+    enable-admission-plugins:  PodSecurityPolicy
+  {{- end }}
 controllerManager:
   extraArgs:
     enable-hostpath-provisioner: "true"
@@ -356,6 +372,10 @@ controlPlaneEndpoint: "{{ .ControlPlaneEndpoint }}"
 # to the cluster after rewriting the kubeconfig to point to localhost
 apiServer:
   certSANs: [localhost, "{{.APIServerAddress}}"]
+  {{ if .PodSecurityPolicy -}}
+  extraArgs:
+    enable-admission-plugins:  PodSecurityPolicy
+  {{- end }}
 controllerManager:
   extraArgs:
     enable-hostpath-provisioner: "true"

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -268,6 +268,21 @@ nodes:
 - role: worker
 ```
 
+#### Enabling Pod Security Policy
+You can also have a cluster with [Pod Security Policy][pod security policy] enabled.
+Kind install a permissive policy by default, equivalent to not using the pod security policy admission controller.
+
+```yaml
+# a cluster with 3 control-plane nodes and 3 workers
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+enablePodSecurityPolicy: true
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+```
+
 #### Mapping ports to the host machine
 You can map extra ports from the nodes to the host machine with `extraPortMappings`:
 ```yaml
@@ -404,3 +419,4 @@ kind, the Kubernetes cluster itself, etc.
 [Private Registries]: /docs/user/private-registries
 [customize control plane with kubeadm]: https://kubernetes.io/docs/setup/independent/control-plane-flags/
 [docker enable ipv6]: https://docs.docker.com/config/daemon/ipv6/
+[pod security policy]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
To enable PodSecurityPolicy we have to configure it in kubeadm.
Main problem is that if apparmor or seccomp annotations are detected and those features are not available in the host, those pods with annotations fail to start (i.e. kindnet)