### PR TITLE
docs: ensure the sidebar stays above embedded videos

### DIFF
--- a/site/assets/css/inline.css
+++ b/site/assets/css/inline.css
@@ -109,6 +109,7 @@ body {
   width: 240px;
   border-right: 1px solid rgba(0, 0, 0, 0.1);
   background-color: #fafafa;
+  z-index: 99999;
 }
 .sidebar-collapsed #sidebar {
   display: none;


### PR DESCRIPTION
on mobile the sidebar navigation slides under the embedded videos currently because we didn't apply the same fix we applied to the header.