### PR TITLE
Set LimitNOFILE=1048576 in containerd unit file to match upstream containerd.

### DIFF
--- a/images/base/10-limits.conf
+++ b/images/base/10-limits.conf
@@ -1,0 +1,5 @@
+# The Ubuntu upstream containerd.service specifies Limit NOFILE=infinity, but this causes problems with certain applications (e.g.,
+# NFS and MySQL).
+# This brings the unit file in line with upstream containerd's configuration.
+[Service]
+LimitNOFILE=1048576

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -76,8 +76,8 @@ RUN clean-install \
     && chmod +x /usr/local/bin/ctr \
     && echo "done installing packages"
 
-# add restart override to containerd
-COPY 10-restart.conf /etc/systemd/system/containerd.service.d/
+# add overrides to containerd
+COPY 10-limits.conf 10-restart.conf /etc/systemd/system/containerd.service.d/
 
 # debug containerd version and create default config
 # additionally, disable some plugins we don't use / support


### PR DESCRIPTION
The Ubuntu containerd package sets LimitNOFILE=infinity, but this causes issues with various applications: NFS and mysql are unable to run in kind on some systems.

This fixes the containerd limit to match upstream containerd and resolves issues with NFS and mysql.

To reproduce the issue, on the host set `sudo sysctl -w fs.nr_open=1073741816` (this is the default on Arch Linux) and then follow the steps below.

Broken:

```
kind create cluster
export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
# print the default ulimit -n:
kubectl run -it --restart=Never --rm test --image=alpine -- ash -c 'ulimit -n'
# run a broken service (this will eventually be OOM killed by the kernel):
# NFS gets OOM killed:
kubectl run -it --restart=Never test --image=quay.io/kubernetes_incubator/nfs-provisioner:latest --command -- rpcinfo -p
# MySQL uses tons of memory and is extremely slow (sometimes it gets OOM killed):
kubectl run mysql -it --restart=Never --env=MYSQL_ROOT_PASSWORD=test --env=MYSQL_DATABASE=kudo --image=mysql:5.7
kind delete cluster
```

Broken output:

```
$ kind create cluster
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.15.0) 🖼
 ✓ Preparing nodes 📦 
 ✓ Creating kubeadm config 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Cluster creation complete. You can now use the cluster with:

export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
kubectl cluster-info
$ export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
$ kubectl run -it --restart=Never --rm test --image=alpine -- ash -c 'ulimit -n'
1073741816
pod "test" deleted
$ kubectl run -it --restart=Never test --image=quay.io/kubernetes_incubator/nfs-provisioner:latest --command -- rpcinfo -p
If you don't see a command prompt, try pressing enter.
pod default/test terminated (Error)
$ dmesg  |grep oom
[ 4019.292178] oom_reaper: reaped process 10173 (rpcinfo), now anon-rss:0kB, file-rss:0kB, shmem-rss:0kB
$ kubectl run mysql -it --restart=Never --env=MYSQL_ROOT_PASSWORD=test --env=MYSQL_DATABASE=kudo --image=mysql:5.7

If you don't see a command prompt, try pressing enter.
Initializing database
2019-08-07T20:20:37.948900Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
...
2019-08-07T20:21:40.875839Z 0 [Note] mysqld: ready for connections.
Version: '5.7.27'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server (GPL)
```

Fixed:

```
# Now try with the patch:
kind create cluster --image=jbarrickmesosphere/node:v1.15.0
export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
# print the default ulimit -n:
kubectl run -it --restart=Never --rm test --image=alpine -- ash -c 'ulimit -n'
# the services work now:
# NFS does not get OOM killed (the command runs - which errors, but that is expected):
kubectl run -it --restart=Never test --image=quay.io/kubernetes_incubator/nfs-provisioner:latest --command -- rpcinfo -p
# MySQL takes five seconds instead of a minute to start on my machine:
kubectl run mysql -it --restart=Never --env=MYSQL_ROOT_PASSWORD=test --env=MYSQL_DATABASE=kudo --image=mysql:5.7
```

Fixed output:

```
$ docker build -t jbarrickmesosphere/node:v1.15.0 .
Sending build context to Docker daemon  6.656kB
Step 1/2 : FROM kindest/node:v1.15.0
 ---> 1a930cac869e
Step 2/2 : COPY 10-limits.conf /etc/systemd/system/containerd.service.d/10-limits.conf
 ---> 4b3f03870e73
Successfully built 4b3f03870e73
Successfully tagged jbarrickmesosphere/node:v1.15.0
$ kind create cluster --image=jbarrickmesosphere/node:v1.15.0

Creating cluster "kind" ...
 ✓ Ensuring node image (jbarrickmesosphere/node:v1.15.0) 🖼
 ✓ Preparing nodes 📦 
 ✓ Creating kubeadm config 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Cluster creation complete. You can now use the cluster with:

export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
kubectl cluster-info
$ export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
                                                                      
$ kubectl run -it --restart=Never --rm test --image=alpine -- ash -c 'ulimit -n'

Error from server (Forbidden): pods "test" is forbidden: error looking up service account default/default: serviceaccount "default" not found
$ kubectl run -it --restart=Never --rm test --image=alpine -- ash -c 'ulimit -n'
                                                                                       
1048576
pod "test" deleted
$ kubectl run -it --restart=Never test --image=quay.io/kubernetes_incubator/nfs-provisioner:latest --command -- rpcinfo -p

rpcinfo: can't contact portmapper: RPC: Remote system error - No such file or directory
pod default/test terminated (Error)
$ kubectl run mysql -it --restart=Never --env=MYSQL_ROOT_PASSWORD=test --env=MYSQL_DATABASE=kudo --image=mysql:5.7

If you don't see a command prompt, try pressing enter.
2019-08-07T20:30:46.856020Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2019-08-07T20:30:51.285083Z 0 [Note] mysqld: ready for connections.
Version: '5.7.27'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server (GPL)
^C
```

We can see upstream's unit file here: https://github.com/containerd/containerd/blob/d57cf6f151e444d125407526bf58bb8e79c5e47a/containerd.service#L17 and the background for why it was set there is here https://github.com/containerd/containerd/issues/3201.

I believe this also fixes the issue referenced in https://github.com/kubernetes-sigs/kind/issues/118#issuecomment-440282007 when rimusz said NFS does not work in kind.