### PR TITLE
Node image contains only one pulled image

### DIFF
--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -500,6 +500,7 @@ func (c *BuildContext) prePullImages(dir, containerID string) error {
 	// create a plan of image loading
 	loadFns := []func() error{}
 	for _, image := range pulled {
+		image := image // capture loop var
 		loadFns = append(loadFns, func() error {
 			f, err := os.Open(image)
 			if err != nil {


### PR DESCRIPTION
The `node` image contains only one pulled image, this is because each closure uses the same instance of the `image` variable

Not sure how to add a test but I would be happy to do that if you tell me how 😄 