### PR TITLE
update docs to reflect removed apt build

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See also: our own [contributor guide] and the Kubernetes [community page].
 
 - kind supports multi-node (including HA) clusters
 - kind supports building Kubernetes release builds from source
-  - support for make / bash / docker, bazel, or installing from apt, in addition to pre-published builds.
+  - support for make / bash / docker or bazel, in addition to pre-published builds.
 - kind is written in go, can be used as a library, has stable releases
 - kind supports Windows in addition to MacOS and Linux
 - kind is a [CNCF certified conformant Kubernetes installer](https://landscape.cncf.io/selected=kind)

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -61,7 +61,7 @@ See also: our own [contributor guide] and the Kubernetes [community page].
 
 - kind supports multi-node (including HA) clusters
 - kind supports building Kubernetes release builds from source
-  - support for make / bash / docker, bazel, or installing from apt, in addition to pre-published builds.
+  - support for make / bash / docker, or bazel, in addition to pre-published builds.
 - kind is written in go, and can be used as a library, has stable releases
 - kind supports Windows in addition to MacOS and Linux
 - kind is a [CNCF certified conformant Kubernetes installer](https://landscape.cncf.io/selected=kind)

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -160,7 +160,7 @@ Flags:
   -h, --help                help for node-image
       --image string        name:tag of the resulting image to be built (default "kindest/node:latest")
       --kube-root string    Path to the Kubernetes source directory (if empty, the path is autodetected)
-      --type string         build type, one of [bazel, docker, apt] (default "docker")
+      --type string         build type, one of [bazel, docker] (default "docker")
 
 Global Flags:
       --loglevel string   logrus log level [panic, fatal, error, warning, info, debug] (default "warning")

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -159,8 +159,8 @@ container.
 
 See [building the base image](#building-the-base-image) for more advanced information.
 
-Currently, kind supports three different ways to build a `node-image`: via
-`apt`, or if you have the [Kubernetes][kubernetes] source in your host machine
+Currently, kind supports two different ways to build a `node-image`
+if you have the [Kubernetes][kubernetes] source in your host machine
 (`$GOPATH/src/k8s.io/kubernetes`), by using `docker` or `bazel`.
 To specify the build type use the flag `--type`.
 Note however that using `--type=bazel` on Windows or MacOS will not work
@@ -170,7 +170,7 @@ A workaround may be enabled in the future.
 kind will default to using the build type `docker` if none is specified.
 
 ```
-kind build node-image --type apt
+kind build node-image --type bazel
 ```
 
 Similarly as for the base-image command, you can specify the name and tag of


### PR DESCRIPTION
we noted this in the release notes but the docs didn't reflect it.