### PR TITLE
Allow additional images when building the node image

### DIFF
--- a/cmd/kind/build/nodeimage/nodeimage.go
+++ b/cmd/kind/build/nodeimage/nodeimage.go
@@ -24,11 +24,12 @@ import (
 )
 
 type flagpole struct {
-	Source    string
-	BuildType string
-	Image     string
-	BaseImage string
-	KubeRoot  string
+	Source           string
+	BuildType        string
+	Image            string
+	BaseImage        string
+	AdditionalImages string
+	KubeRoot         string
 }
 
 // NewCommand returns a new cobra.Command for building the node image
@@ -63,6 +64,11 @@ func NewCommand() *cobra.Command {
 		node.DefaultBaseImage,
 		"name:tag of the base image to use for the build",
 	)
+	cmd.Flags().StringVar(
+		&flags.AdditionalImages, "additional-images",
+		node.DefaultBaseImage,
+		"comma separated list of additional images to load into the node image",
+	)
 	return cmd
 }
 
@@ -71,6 +77,7 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 	ctx, err := node.NewBuildContext(
 		node.WithMode(flags.BuildType),
 		node.WithImage(flags.Image),
+		node.WithAdditionalImages(flags.AdditionalImages),
 		node.WithBaseImage(flags.BaseImage),
 		node.WithKuberoot(flags.KubeRoot),
 	)

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -67,6 +67,13 @@ func WithBaseImage(image string) Option {
 	}
 }
 
+// WithAdditionalImages configures additional images to load into the node image
+func WithAdditionalImages(images string) Option {
+	return func(b *BuildContext) {
+		b.additionalImages = strings.Split(images, ",")
+	}
+}
+
 // WithMode sets the kubernetes build mode for the build context
 func WithMode(mode string) Option {
 	return func(b *BuildContext) {
@@ -85,9 +92,10 @@ func WithKuberoot(root string) Option {
 // build configuration
 type BuildContext struct {
 	// option fields
-	mode      string
-	image     string
-	baseImage string
+	mode             string
+	image            string
+	baseImage        string
+	additionalImages []string
 	// non-option fields
 	arch     string // TODO(bentheelder): this should be an option
 	kubeRoot string
@@ -443,6 +451,9 @@ func (c *BuildContext) prePullImages(dir, containerID string) error {
 
 	// all builds should isntall the default CNI images currently
 	requiredImages = append(requiredImages, defaultCNIImages...)
+
+	// add additional images
+	requiredImages = append(requiredImages, c.additionalImages...)
 
 	// Create "images" subdir.
 	imagesDir := path.Join(dir, "bits", "images")


### PR DESCRIPTION
Hi,

I'm trying to use Kind to run some tests on the Elastic Stack, in order to do that I have to pull several large images in every node container.
I have tried to let the node download them through the network, or load them via the `load` command but none of these solutions is ideal because they all involve a lot of I/O (either on network or on the disk of the host)
I would like to have your thoughts on allowing the user to add some additional images in the node image.
In addition to speeding up the startup of the application containers it would be the only way to add some images because `/var/lib/container` is a `VOLUME` and layers can't be added once the node image has been built.

Thank you !