### PR TITLE
make /var a runtime volume

### DIFF
--- a/images/base/entrypoint
+++ b/images/base/entrypoint
@@ -37,12 +37,9 @@ fix_mount() {
   # and this flag also happens to make /sys rw, amongst other things
   mount -o remount,ro /sys
 
-  echo 'INFO: making mounts shared for "/", "/run", "/var/lib/containerd"'
+  echo 'INFO: making mounts shared'
   # for mount propagation
-  # TODO(bentheelder): determine which exact mounts we need to do this on
-  mount --make-shared /
-  mount --make-shared /run
-  mount --make-shared /var/lib/containerd
+  mount --make-rshared /
 }
 
 fix_machine_id() {

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -320,15 +320,6 @@ func (c *BuildContext) buildImage(dir string) error {
 	// Save the image changes to a new image
 	cmd := exec.Command(
 		"docker", "commit",
-		/*
-			The snapshot storage must be a volume to avoid overlay on overlay
-
-			NOTE: we do this last because changing a volume with a docker image
-			must occur before defining it.
-
-			See: https://docs.docker.com/engine/reference/builder/#volume
-		*/
-		"--change", `VOLUME [ "/var/lib/containerd" ]`,
 		// we need to put this back after changing it when running the image
 		"--change", `ENTRYPOINT [ "/usr/local/bin/entrypoint", "/sbin/init" ]`,
 		containerID, c.image,

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -44,7 +44,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20190708-022110d@sha256:8acfd3b9b8a3a42385a761f8c6aa3bdad4241cac220c12d3309f1b7a6d70af24"
+const DefaultBaseImage = "kindest/base:v20190819-26e1eb5@sha256:e609eaa7853289ef603db647ae9568b32093b2347f839a2117d98a08bfc7ab17"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
Per the [Filesystem Hierarchy Standard](https://refspecs.linuxfoundation.org/fhs.shtml) all of `/var` is persistent runtime files. This should not be on the container filesystem.

Moving this to a runtime anonymous volume for _all_ of `/var`:
- allows us to not put any `/var/...` volumes in the base image (for container runtime storage, which must not be stacked)
  - which will allow us to potentially add pre-loaded images to an existing node image
- ensures writes to anything in `/var` goes to a volume instead of the container filesystem

The only downside is that new kind images will require a new version of kind. Images built prior to this should continue to work even with the new version.

While doing this I also normalized on long flags for node creation for clarity and consistency.