### PR TITLE
[TESTING IPV6 CI FAILURES] Update CoreDNS config to 1.5 ?

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -159,6 +159,7 @@ apiVersion: v1
 data:
   Corefile: |
     .:53 {
+        log
         errors
         health
         kubernetes cluster.local internal in-addr.arpa ip6.arpa {

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -168,6 +168,7 @@ data:
         cache 30
         reload
         loadbalance
+        ready
     }
 kind: ConfigMap
 metadata:

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -169,7 +169,6 @@ data:
         cache 30
         reload
         loadbalance
-        ready
     }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Fix current IPv6 CI failures on DNS tests

https://testgrid.k8s.io/conformance-kind#kind%20(IPv6),%20master%20(dev)%20%5Bnon-serial%5D