### PR TITLE
Add fish shell detection

### DIFF
--- a/pkg/internal/cluster/create/create.go
+++ b/pkg/internal/cluster/create/create.go
@@ -191,9 +191,15 @@ func printUsage(name string) {
 		)
 	} else {
 		fmt.Printf(
-			"Cluster creation complete. You can now use the cluster with:\n\n"+
+			"Cluster creation complete. To setup KUBECONFIG:\n\n"+
 
+				"for bash/zsh:\n"+
 				"export KUBECONFIG=\"$(kind get kubeconfig-path --name=%q)\"\n"+
+
+				"for fish:\n"+
+				"set -x KUBECONFIG (kind get kubeconfig-path --name=%q)\n\n"+
+
+				"You can now use the cluster with:\n"
 				"kubectl cluster-info\n",
 			name,
 		)

--- a/pkg/internal/util/env/shell.go
+++ b/pkg/internal/util/env/shell.go
@@ -1,0 +1,13 @@
+package env
+
+import (
+	"os"
+	"strings"
+)
+
+func GetLinuxShell() string {
+	shell := os.Getenv("SHELL")
+	parts := strings.Split(shell, "/")
+	shell = parts[len(parts)-1]
+	return shell
+}


### PR DESCRIPTION
Implement basic shell detection for Linux platforms in the `kind create` command. 

### Additions:
- Implement `GetLinuxShell()` utility function
- Add fish as a custom output whilst leaving bash/zsh under default