### PR TITLE
Add an option to update kubeconfig

### DIFF
--- a/cmd/kind/create/cluster/createcluster.go
+++ b/cmd/kind/create/cluster/createcluster.go
@@ -31,11 +31,12 @@ import (
 )
 
 type flagpole struct {
-	Name      string
-	Config    string
-	ImageName string
-	Retain    bool
-	Wait      time.Duration
+	Name       string
+	Config     string
+	ImageName  string
+	Retain     bool
+	Wait       time.Duration
+	SetContext bool
 }
 
 // NewCommand returns a new cobra.Command for cluster creation
@@ -55,6 +56,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&flags.ImageName, "image", "", "node docker image to use for booting the cluster")
 	cmd.Flags().BoolVar(&flags.Retain, "retain", false, "retain nodes for debugging when cluster creation fails")
 	cmd.Flags().DurationVar(&flags.Wait, "wait", time.Duration(0), "Wait for control plane node to be ready (default 0s)")
+	cmd.Flags().BoolVar(&flags.SetContext, "set-context", false, "update KUBECONFIG to the configuration of this cluster and set it as the current context")
 	return cmd
 }
 
@@ -76,6 +78,7 @@ func runE(flags *flagpole, cmd *cobra.Command, args []string) error {
 		create.WithNodeImage(flags.ImageName),
 		create.Retain(flags.Retain),
 		create.WaitForReady(flags.Wait),
+		create.SetContext(flags.SetContext),
 	); err != nil {
 		if utilErrors, ok := err.(util.Errors); ok {
 			for _, problem := range utilErrors.Errors() {

--- a/pkg/cluster/context.go
+++ b/pkg/cluster/context.go
@@ -68,6 +68,11 @@ func (c *Context) KubeConfigPath() string {
 	return c.ic.KubeConfigPath()
 }
 
+// KubeConfig returns the content of Kubeconfig on the node
+func (c *Context) KubeConfig() ([]byte, error) {
+	return c.ic.ReadKubeConfigFromNode()
+}
+
 // Create provisions and starts a kubernetes-in-docker cluster
 func (c *Context) Create(options ...create.ClusterOption) error {
 	return internalcreate.Cluster(c.ic, options...)

--- a/pkg/cluster/create/cluster.go
+++ b/pkg/cluster/create/cluster.go
@@ -78,3 +78,11 @@ func SetupKubernetes(setupKubernetes bool) ClusterOption {
 		return o, nil
 	}
 }
+
+// SetContext configures the cluster created to be active cluster after its creation
+func SetContext(setContext bool) ClusterOption {
+	return func(o *internaltypes.ClusterOptions) (*internaltypes.ClusterOptions, error) {
+		o.SetContext = setContext
+		return o, nil
+	}
+}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -107,10 +107,14 @@ func RunWithStdoutReader(cmd Cmd, readerFunc func(io.Reader) error) error {
 	errChan := make(chan error, 1)
 	go func() {
 		errChan <- readerFunc(pr)
-		pr.Close()
 	}()
 
 	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+	// Close the write file to let the reader knows that we are done
+	err = pw.Close()
 	if err != nil {
 		return err
 	}

--- a/pkg/internal/cluster/context/context.go
+++ b/pkg/internal/cluster/context/context.go
@@ -20,14 +20,12 @@ package context
 
 import (
 	"fmt"
-	"path/filepath"
 	"regexp"
 
 	"github.com/pkg/errors"
 
 	"sigs.k8s.io/kind/pkg/cluster/constants"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
-	"sigs.k8s.io/kind/pkg/internal/util/env"
 )
 
 // Context is the private shared context underlying pkg/cluster.Context
@@ -76,17 +74,6 @@ func (c *Context) Validate() error {
 		)
 	}
 	return nil
-}
-
-// KubeConfigPath returns the path to where the Kubeconfig would be placed
-// by kind based on the configuration.
-func (c *Context) KubeConfigPath() string {
-	// configDir matches the standard directory expected by kubectl etc
-	configDir := filepath.Join(env.HomeDir(), ".kube")
-	// note that the file name however does not, we do not want to overwrite
-	// the standard config, though in the future we may (?) merge them
-	fileName := fmt.Sprintf("kind-config-%s", c.Name())
-	return filepath.Join(configDir, fileName)
 }
 
 // ClusterLabel returns the docker object label that will be applied

--- a/pkg/internal/cluster/context/kubeconfig.go
+++ b/pkg/internal/cluster/context/kubeconfig.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package context
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/kind/pkg/cluster/nodes"
+	"sigs.k8s.io/kind/pkg/exec"
+	"sigs.k8s.io/kind/pkg/internal/cluster/kubeadm"
+	"sigs.k8s.io/kind/pkg/internal/cluster/loadbalancer"
+	"sigs.k8s.io/kind/pkg/internal/util/env"
+)
+
+// KubeConfigPath returns the path to where the Kubeconfig would be placed
+// by kind based on the configuration.
+func (c *Context) KubeConfigPath() string {
+	// configDir matches the standard directory expected by kubectl etc
+	configDir := filepath.Join(env.HomeDir(), ".kube")
+	// note that the file name however does not, we do not want to overwrite
+	// the standard config, though in the future we may (?) merge them
+	fileName := fmt.Sprintf("kind-config-%s", c.Name())
+	return filepath.Join(configDir, fileName)
+}
+
+// ReadKubeConfigFromNode returns the configuration as it is stored on the node
+func (c *Context) ReadKubeConfigFromNode() ([]byte, error) {
+	allNodes, err := c.ListNodes()
+	if err != nil {
+		return nil, err
+	}
+	node, err := nodes.BootstrapControlPlaneNode(allNodes)
+	if err != nil {
+		return nil, err
+	}
+
+	// get the kubeconfig from the bootstrap node
+	var bytes []byte
+	cmd := node.Command("cat", "/etc/kubernetes/admin.conf")
+	err = exec.RunWithStdoutReader(cmd, func(outReader io.Reader) error {
+		bytes, err = ioutil.ReadAll(outReader)
+		if err != nil {
+			return err
+		}
+		return err
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get kubeconfig from node")
+	}
+	return bytes, nil
+}
+
+// ReadKubeConfig returns the configuration as it is stored and
+// update the context so it can be used from an external host.
+// The kubeconfig file created by kubeadm internally to the node
+// must be modified in order to use the random host port reserved
+// for the API server and exposed by the node.
+func (c *Context) ReadKubeConfig(apiServerAddress string) (*clientcmdapi.Config, error) {
+	return c.readKubeConfig(&apiServerAddress)
+}
+
+func (c *Context) readKubeConfig(apiServerAddress *string) (*clientcmdapi.Config, error) {
+	bytes, err := c.ReadKubeConfigFromNode()
+	if err != nil {
+		return nil, err
+	}
+	kubeconfig, err := clientcmd.Load(bytes)
+	if err != nil {
+		return nil, err
+	}
+	if apiServerAddress != nil {
+		allNodes, err := c.ListNodes()
+		if err != nil {
+			return nil, err
+		}
+		hostPort, err := getAPIServerPort(allNodes)
+		if err != nil {
+			return nil, err
+		}
+		authInfoName := c.getAuthInfoName()
+		// fix the config file, swapping out the server for the forwarded localhost:port
+		kubeconfig.Clusters[c.name].Server = fmt.Sprintf("https://%s:%d", *apiServerAddress, hostPort)
+		// rename authentication info to include the cluster name in the auth. infos
+		kubeconfig.AuthInfos[authInfoName] = kubeconfig.AuthInfos["kubernetes-admin"]
+		delete(kubeconfig.AuthInfos, "kubernetes-admin")
+		// update the current context
+		kubeconfig.Contexts[kubeconfig.CurrentContext].AuthInfo = authInfoName
+	}
+	return kubeconfig, err
+}
+
+// WriteKubeConfig writes the kubeconfig file to be used from an external host.
+// If setContext is true then the context is added to the current user configuration file.
+func (c *Context) WriteKubeConfig(apiServerAddress string, setContext bool) error {
+	kubeconfig, err := c.readKubeConfig(&apiServerAddress)
+	if err != nil {
+		return err
+	}
+	if setContext {
+		// ReUse the loading rules from go-client to get the current context file
+		configLoadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		// Take the file with first precedence
+		configFile := configLoadingRules.GetLoadingPrecedence()[0]
+
+		// load the current configuration or create an empty one
+		config, err := clientcmd.LoadFromFile(configFile)
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if config == nil {
+			config = clientcmdapi.NewConfig()
+		}
+
+		// Import configuration
+		authInfoName := c.getAuthInfoName()
+		config.Clusters[c.name] = kubeconfig.Clusters[c.name]
+		config.AuthInfos[authInfoName] = kubeconfig.AuthInfos[authInfoName]
+		config.Contexts["kubernetes-admin@"+c.name] = kubeconfig.Contexts["kubernetes-admin@"+c.name]
+		config.CurrentContext = "kubernetes-admin@" + c.name
+
+		return clientcmd.WriteToFile(*config, configFile)
+	}
+	return clientcmd.WriteToFile(*kubeconfig, c.KubeConfigPath())
+}
+
+func (c *Context) getAuthInfoName() string {
+	return "kubernetes-admin-" + c.name
+}
+
+// getAPIServerPort returns the port on the host on which the APIServer
+// is exposed
+func getAPIServerPort(allNodes []nodes.Node) (int32, error) {
+	// select the external loadbalancer first
+	node, err := nodes.ExternalLoadBalancerNode(allNodes)
+	if err != nil {
+		return 0, err
+	}
+	// node will be nil if there is no load balancer
+	if node != nil {
+		return node.Ports(loadbalancer.ControlPlanePort)
+	}
+
+	// fallback to the bootstrap control plane
+	node, err = nodes.BootstrapControlPlaneNode(allNodes)
+	if err != nil {
+		return 0, err
+	}
+
+	return node.Ports(kubeadm.APIServerPort)
+}

--- a/pkg/internal/cluster/create/create.go
+++ b/pkg/internal/cluster/create/create.go
@@ -90,7 +90,7 @@ func Cluster(ctx *context.Context, options ...create.ClusterOption) error {
 	}
 	if opts.SetupKubernetes {
 		actionsToRun = append(actionsToRun,
-			kubeadminit.NewAction(), // run kubeadm init
+			kubeadminit.NewAction(opts.SetContext), // run kubeadm init
 		)
 		// this step might be skipped, but is next after init
 		if !opts.Config.Networking.DisableDefaultCNI {
@@ -124,7 +124,9 @@ func Cluster(ctx *context.Context, options ...create.ClusterOption) error {
 	}
 
 	// print how to set KUBECONFIG to point to the cluster etc.
-	printUsage(ctx.Name())
+	if !opts.SetContext {
+		printUsage(ctx.Name())
+	}
 
 	return nil
 }

--- a/pkg/internal/cluster/create/types/types.go
+++ b/pkg/internal/cluster/create/types/types.go
@@ -34,6 +34,7 @@ type ClusterOptions struct {
 	NodeImage    string
 	Retain       bool
 	WaitForReady time.Duration
+	SetContext   bool
 	//TODO: Refactor this. It is a temporary solution for a phased breakdown of different
 	//      operations, specifically create. see https://github.com/kubernetes-sigs/kind/issues/324
 	SetupKubernetes bool // if kind should setup kubernetes after creating nodes


### PR DESCRIPTION
This feature is motivated by the fact that most of our current deployments _(minikube, gke ...)_ are managed through the default kubeconfig file.
It might also be convenient for people that use tools like [kubecxt](https://github.com/ahmetb/kubectx).
With this PR user can add `--set-context` when a cluster is created to import the new context to its kubeconfig.

Note that it does not remove the context when the cluster is deleted, but it can be done in an other PR _(I wanted to keep this one small)_.
Also I'm not sure about the unit test policy, I can add some of them to at least cover the merge with the current kubeconfig _(could also be done in an other PR)_

Let me know your thoughts.

This PR supersedes:
* https://github.com/kubernetes-sigs/kind/pull/512
* https://github.com/kubernetes-sigs/kind/pull/520
* https://github.com/kubernetes-sigs/kind/pull/517