### PR TITLE
ensure we get a combined status from the cross build

### DIFF
--- a/hack/release/build/cross.sh
+++ b/hack/release/build/cross.sh
@@ -15,31 +15,35 @@
 
 # simple script to build binaries for release
 
-set -o errexit
-set -o nounset
-set -o pipefail
+set -o errexit -o nounset -o pipefail
 
 # cd to the repo root
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
-build() {
-    GOOS="${1}"
-    GOARCH="${2}"
-    export GOOS
-    export GOARCH
-    KIND_BINARY_NAME="kind-${GOOS}-${GOARCH}"
-    export KIND_BINARY_NAME
-    make build
-}
+# controls the number of concurrent builds
+PRALLELISM=${PRALLELISM:-6}
 
 echo "Building in parallel for:"
-build "linux" "amd64" & \
-build "linux" "arm" & \
-build "linux" "arm64" & \
-build "linux" "ppc64le" & \
-build "darwin" "amd64" & \
-build "windows" "amd64" & \
-# we want each pid to be an argument
-# shellcheck disable=SC2046
-wait $(jobs -p)
+# What we do here:
+# - use xargs to build in parallel (-P) while collecting a combined exit code
+# - use cat to supply the individual args to xargs (one line each)
+# - use env -S to split the line into environment variables and execute
+# - ... the build
+# NOTE: the binary name needs to in single quotes so we delay evaluating
+# GOOS / GOARCH
+if xargs -n1 -P "${PRALLELISM}" -I{} \
+    env -S {} make build 'KIND_BINARY_NAME=kind-${GOOS}-${GOARCH}'; then
+    echo "Cross build passed!" 1>&2
+else
+    echo "Cross build failed!" 1>&2
+    exit 1
+fi < <(cat <<EOF
+GOOS=windows GOARCH=amd64
+GOOS=darwin GOARCH=amd64
+GOOS=linux GOARCH=amd64
+GOOS=linux GOARCH=arm
+GOOS=linux GOARCH=arm64
+GOOS=linux GOARCH=ppc64le
+EOF
+)


### PR DESCRIPTION
GNU `parallel` is another option but may not be installed.
`xargs` is widely installed and returns a combined status.

xref: https://github.com/kubernetes-sigs/kind/issues/792#issuecomment-523647231