### PR TITLE
Remove CoreDNS hack because of k/kubeadm#1745

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -130,8 +130,6 @@ run_tests() {
     echo "Patched CoreDNS config:"
     echo "${fixed_coredns}"
     kubectl apply -f - <<< "${fixed_coredns}"
-    # restart the pods
-    kubectl -n kube-system delete pods -l k8s-app=kube-dns
   fi
 
   # ginkgo regexes


### PR DESCRIPTION
CoreDNS should be able to reload the configuration and work automatically, no need to delete the pods

Once CoreDNS 1.6.2 is merged we should verify it fixes the issue https://github.com/kubernetes/kubeadm/issues/1745
