### PR TITLE
Add internal domain to CoreDNS for IPv6

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -122,7 +122,7 @@ run_tests() {
     local fixed_coredns
     fixed_coredns=$(
       sed \
-        -e 's/^.*kubernetes cluster\.local/\& internal/'
+        -e 's/^.*kubernetes cluster\.local/\& internal/' \
         -e '/^.*upstream$/d' \
         -e '/^.*fallthrough.*$/d' \
         -e '/^.*forward . \/etc\/resolv.conf$/d' \

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -122,7 +122,7 @@ run_tests() {
     local fixed_coredns
     fixed_coredns=$(
       sed \
-        -e 's/^.*kubernetes cluster\.local/\& internal/' \
+        -e 's/^.*kubernetes cluster\.local/& internal/' \
         -e '/^.*upstream$/d' \
         -e '/^.*fallthrough.*$/d' \
         -e '/^.*forward . \/etc\/resolv.conf$/d' \

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -122,7 +122,7 @@ run_tests() {
     local fixed_coredns
     fixed_coredns=$(
       sed \
-        -e 's/^.*kubernetes cluster\.local/& internal/'
+        -e 's/^.*kubernetes cluster\.local/\& internal/'
         -e '/^.*upstream$/d' \
         -e '/^.*fallthrough.*$/d' \
         -e '/^.*forward . \/etc\/resolv.conf$/d' \

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -122,7 +122,7 @@ run_tests() {
     local fixed_coredns
     fixed_coredns=$(
       sed \
-        -e 's/^(\s)+.*cluster\.local.*$/\0kubernetes cluster.local internal in-addr.arpa ip6.arpa/' \
+        -e 's/^.*kubernetes cluster\.local/& internal/'
         -e '/^.*upstream$/d' \
         -e '/^.*fallthrough.*$/d' \
         -e '/^.*forward . \/etc\/resolv.conf$/d' \


### PR DESCRIPTION
Seems current sed regex is not adding the internal domain to the CoreDNS configmap, thus the DNS tests that run in prow with IPv6 fail

xref: https://github.com/kubernetes-sigs/kind/pull/803/files#r317355315