### PR TITLE
allow to add extraArgs for containers

### DIFF
--- a/pkg/apis/config/v1alpha3/types.go
+++ b/pkg/apis/config/v1alpha3/types.go
@@ -74,6 +74,9 @@ type Node struct {
 	// ExtraPortMappings describes additional port mappings for the node container
 	// binded to a host Port
 	ExtraPortMappings []cri.PortMapping `json:"extraPortMappings,omitempty"`
+
+	// ExtraArgs describes additional flags for the node container
+	ExtraArgs []string `json:"extraArgs,omitempty"`
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -49,7 +49,7 @@ func getPort() (int32, error) {
 
 // CreateControlPlaneNode creates a control-plane node
 // and gets ready for exposing the the API server
-func CreateControlPlaneNode(name, image, clusterLabel, listenAddress string, port int32, mounts []cri.Mount, portMappings []cri.PortMapping) (node *Node, err error) {
+func CreateControlPlaneNode(name, image, clusterLabel, listenAddress string, port int32, mounts []cri.Mount, portMappings []cri.PortMapping, extraArgs []string) (node *Node, err error) {
 	// gets a random host port for the API server
 	if port == 0 {
 		p, err := getPort()
@@ -68,7 +68,7 @@ func CreateControlPlaneNode(name, image, clusterLabel, listenAddress string, por
 	node, err = createNode(
 		name, image, clusterLabel, constants.ControlPlaneNodeRoleValue, mounts, portMappingsWithAPIServer,
 		// publish selected port for the API server
-		"--expose", fmt.Sprintf("%d", port),
+		append([]string{"--expose", fmt.Sprintf("%d", port)}, extraArgs...)...,
 	)
 	if err != nil {
 		return node, err
@@ -84,7 +84,7 @@ func CreateControlPlaneNode(name, image, clusterLabel, listenAddress string, por
 
 // CreateExternalLoadBalancerNode creates an external load balancer node
 // and gets ready for exposing the the API server and the load balancer admin console
-func CreateExternalLoadBalancerNode(name, image, clusterLabel, listenAddress string, port int32) (node *Node, err error) {
+func CreateExternalLoadBalancerNode(name, image, clusterLabel, listenAddress string, port int32, extraArgs []string) (node *Node, err error) {
 	// gets a random host port for control-plane load balancer
 	// gets a random host port for the API server
 	if port == 0 {
@@ -104,7 +104,7 @@ func CreateExternalLoadBalancerNode(name, image, clusterLabel, listenAddress str
 	node, err = createNode(name, image, clusterLabel, constants.ExternalLoadBalancerNodeRoleValue,
 		nil, portMappings,
 		// publish selected port for the control plane
-		"--expose", fmt.Sprintf("%d", port),
+		append([]string{"--expose", fmt.Sprintf("%d", port)}, extraArgs...)...,
 	)
 	if err != nil {
 		return node, err
@@ -119,8 +119,8 @@ func CreateExternalLoadBalancerNode(name, image, clusterLabel, listenAddress str
 }
 
 // CreateWorkerNode creates a worker node
-func CreateWorkerNode(name, image, clusterLabel string, mounts []cri.Mount, portMappings []cri.PortMapping) (node *Node, err error) {
-	node, err = createNode(name, image, clusterLabel, constants.WorkerNodeRoleValue, mounts, portMappings)
+func CreateWorkerNode(name, image, clusterLabel string, mounts []cri.Mount, portMappings []cri.PortMapping, extraArgs []string) (node *Node, err error) {
+	node, err = createNode(name, image, clusterLabel, constants.WorkerNodeRoleValue, mounts, portMappings, extraArgs...)
 	if err != nil {
 		return node, err
 	}

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -74,6 +74,9 @@ type Node struct {
 	// ExtraPortMappings describes additional port mappings for the node container
 	// binded to a host Port
 	ExtraPortMappings []cri.PortMapping
+
+	// ExtraArgs describes additional flags for the node container
+	ExtraArgs []string
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/internal/cluster/create/nodes.go
+++ b/pkg/internal/cluster/create/nodes.go
@@ -129,6 +129,7 @@ type nodeSpec struct {
 	Role              string
 	Image             string
 	ExtraMounts       []cri.Mount
+	ExtraArgs         []string
 	ExtraPortMappings []cri.PortMapping
 	// TODO(bentheelder): replace with a cri.PortMapping when we have that
 	APIServerPort    int32
@@ -185,6 +186,7 @@ func nodesToCreate(cfg *config.Cluster, clusterName string) []nodeSpec {
 			Image:             configNode.Image,
 			Role:              role,
 			ExtraMounts:       configNode.ExtraMounts,
+			ExtraArgs:         configNode.ExtraArgs,
 			ExtraPortMappings: configNode.ExtraPortMappings,
 			APIServerAddress:  apiServerAddress,
 			APIServerPort:     apiServerPort,
@@ -200,6 +202,7 @@ func nodesToCreate(cfg *config.Cluster, clusterName string) []nodeSpec {
 			Image:            loadbalancer.Image, // TODO(bentheelder): get from config instead
 			Role:             role,
 			ExtraMounts:      []cri.Mount{},
+			ExtraArgs:        []string{},
 			APIServerAddress: cfg.Networking.APIServerAddress,
 			APIServerPort:    cfg.Networking.APIServerPort,
 			IPv6:             ipv6,
@@ -215,11 +218,11 @@ func (d *nodeSpec) Create(clusterLabel string) (node *nodes.Node, err error) {
 	// TODO(bentheelder): decouple from config objects further
 	switch d.Role {
 	case constants.ExternalLoadBalancerNodeRoleValue:
-		node, err = nodes.CreateExternalLoadBalancerNode(d.Name, d.Image, clusterLabel, d.APIServerAddress, d.APIServerPort)
+		node, err = nodes.CreateExternalLoadBalancerNode(d.Name, d.Image, clusterLabel, d.APIServerAddress, d.APIServerPort, d.ExtraArgs)
 	case constants.ControlPlaneNodeRoleValue:
-		node, err = nodes.CreateControlPlaneNode(d.Name, d.Image, clusterLabel, d.APIServerAddress, d.APIServerPort, d.ExtraMounts, d.ExtraPortMappings)
+		node, err = nodes.CreateControlPlaneNode(d.Name, d.Image, clusterLabel, d.APIServerAddress, d.APIServerPort, d.ExtraMounts, d.ExtraPortMappings, d.ExtraArgs)
 	case constants.WorkerNodeRoleValue:
-		node, err = nodes.CreateWorkerNode(d.Name, d.Image, clusterLabel, d.ExtraMounts, d.ExtraPortMappings)
+		node, err = nodes.CreateWorkerNode(d.Name, d.Image, clusterLabel, d.ExtraMounts, d.ExtraPortMappings, d.ExtraArgs)
 	default:
 		return nil, errors.Errorf("unknown node role: %s", d.Role)
 	}


### PR DESCRIPTION
Hi, 

We need to give static IPs for the control node, with docker this is only possible when adding a container to a docker network, like already metioned in #273. 

My current solution is allowing extra args in the config for a node, which are passed to the docker run command. Of couse the solution discussed in #273 for static ips is better, but adding the possibility to give extraArgs still makes sense to me. It would give users more flexibilty. 

Since I needed this quickly I did an implementation, I am not used to program in go-lang, but for us this works well. But commends are welcome.

Cheers,

Jannis