### PR TITLE
go switch case doesn't have fallthrough

### DIFF
--- a/pkg/internal/build/kube/bits.go
+++ b/pkg/internal/build/kube/bits.go
@@ -71,6 +71,7 @@ func nameToImpl(name string) (func(string) (Bits, error), error) {
 	case "bazel":
 		return NewBazelBuildBits, nil
 	case "docker":
+		return NewDockerBuildBits, nil
 	case "make":
 		return NewDockerBuildBits, nil
 	default:


### PR DESCRIPTION
oof. our shiny static analysis tools didn't catch this!