### PR TITLE
upgrade to go 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ kind bootstraps each "node" with [kubeadm][kubeadm]. For more details see [the d
 
 You can install kind with `GO111MODULE="on" go get sigs.k8s.io/kind@v0.5.1`.
 
-**NOTE**: please use the latest go to do this, ideally go 1.12.9 or greater.
+**NOTE**: please use the latest go to do this, ideally go 1.13 or greater.
 
 This will put `kind` in `$(go env GOPATH)/bin`. If you encounter the error
 `kind: command not found` after installation then you may need to either add that directory to your `$PATH` as

--- a/cmd/kindnetd/go.mod
+++ b/cmd/kindnetd/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kind/cmd/kindnetd
 
-go 1.12
+go 1.13
 
 require (
 	github.com/godbus/dbus v4.1.0+incompatible // indirect

--- a/hack/go_container.sh
+++ b/hack/go_container.sh
@@ -30,7 +30,7 @@ SOURCE_DIR="${SOURCE_DIR:-$(pwd -P)}"
 # default to disabling CGO for easier reproducible builds and cross compilation
 export CGO_ENABLED="${CGO_ENABLED:-0}"
 # the container image, by default a recent official golang image
-GOIMAGE="${GOIMAGE:-golang:1.13rc2}"
+GOIMAGE="${GOIMAGE:-golang:1.13}"
 # docker volume name, used as a go module / build cache
 CACHE_VOLUME="${CACHE_VOLUME:-kind-build-cache}"
 # ========================== END SCRIPT SETTINGS ===============================

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kind/hack/tools
 
-go 1.12
+go 1.13
 
 require (
 	github.com/golangci/golangci-lint v1.17.2-0.20190714145355-d2b1eea2c617

--- a/site/content/docs/contributing/getting-started.md
+++ b/site/content/docs/contributing/getting-started.md
@@ -51,7 +51,7 @@ You can check if Go is in your system with the following command:
 go version
 ```
 
-Preferably Go `1.12.9` or greater should be installed. 
+Preferably Go `1.13` or greater should be installed. 
 
 Correct automatic formatting of the source with `gofmt` requires at least
 `1.11.0`.

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -17,7 +17,7 @@ This guide covers getting started with the `kind` command.
 You can either install kind with `GO111MODULE="on" go get sigs.k8s.io/kind@v0.5.1` or clone this repo 
 and run `make build` from the repository.
 
-**NOTE**: please use the latest Go to do this, ideally go 1.12.9 or greater.
+**NOTE**: please use the latest Go to do this, ideally go 1.13 or greater.
 A version of Go officially [supported upstream][go-supported] by the Go project must be used.
 
 This will put `kind` in `$(go env GOPATH)/bin`. You may need to add that directory to your `$PATH` as


### PR DESCRIPTION
easy-peasy since we already switched to modules and tested the release candidates