### PR TITLE
move status out of log package

### DIFF
--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -94,17 +94,14 @@ func Run() error {
 
 // Main wraps Run and sets the log formatter
 func Main() {
-	// let's explicitly set stdout
-	log.SetOutput(os.Stdout)
+	// TODO(bentheelder): replace this with a shimmable logger
+	// let's explicitly set stderr
+	log.SetOutput(os.Stderr)
 	// this formatter is the default, but the timestamps output aren't
 	// particularly useful, they're relative to the command start
 	log.SetFormatter(&log.TextFormatter{
 		FullTimestamp:   true,
 		TimestampFormat: "15:04:05",
-		// we force colors because this only forces over the isTerminal check
-		// and this will not be accurately checkable later on when we wrap
-		// the logger output with our logutil.StatusFriendlyWriter
-		ForceColors: logutil.IsTerminal(log.StandardLogger().Out),
 	})
 	if err := Run(); err != nil {
 		os.Exit(1)

--- a/pkg/internal/cluster/create/actions/action.go
+++ b/pkg/internal/cluster/create/actions/action.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/internal/apis/config"
 	"sigs.k8s.io/kind/pkg/internal/cluster/context"
-	logutil "sigs.k8s.io/kind/pkg/log"
+	"sigs.k8s.io/kind/pkg/internal/util/cli"
 )
 
 // Action defines a step of bringing up a kind cluster after initial node
@@ -33,7 +33,7 @@ type Action interface {
 
 // ActionContext is data supplied to all actions
 type ActionContext struct {
-	Status         *logutil.Status
+	Status         *cli.Status
 	Config         *config.Cluster
 	ClusterContext *context.Context
 	cache          *cachedData
@@ -43,7 +43,7 @@ type ActionContext struct {
 func NewActionContext(
 	cfg *config.Cluster,
 	ctx *context.Context,
-	status *logutil.Status,
+	status *cli.Status,
 ) *ActionContext {
 	return &ActionContext{
 		Status:         status,

--- a/pkg/internal/cluster/create/create.go
+++ b/pkg/internal/cluster/create/create.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/kind/pkg/internal/cluster/context"
 	createtypes "sigs.k8s.io/kind/pkg/internal/cluster/create/types"
 	"sigs.k8s.io/kind/pkg/internal/cluster/delete"
-	logutil "sigs.k8s.io/kind/pkg/log"
+	"sigs.k8s.io/kind/pkg/internal/util/cli"
 
 	configaction "sigs.k8s.io/kind/pkg/internal/cluster/create/actions/config"
 	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions/installcni"
@@ -66,7 +66,7 @@ func Cluster(ctx *context.Context, options ...create.ClusterOption) error {
 	}
 
 	// setup a status object to show progress to the user
-	status := logutil.NewStatus(os.Stdout)
+	status := cli.NewStatus(os.Stdout)
 	status.MaybeWrapLogrus(log.StandardLogger())
 
 	// attempt to explicitly pull the required node images if they doesn't exist locally

--- a/pkg/internal/cluster/create/images.go
+++ b/pkg/internal/cluster/create/images.go
@@ -24,12 +24,12 @@ import (
 
 	"sigs.k8s.io/kind/pkg/container/docker"
 	"sigs.k8s.io/kind/pkg/internal/apis/config"
-	logutil "sigs.k8s.io/kind/pkg/log"
+	"sigs.k8s.io/kind/pkg/internal/util/cli"
 )
 
 // ensureNodeImages ensures that the node images used by the create
 // configuration are present
-func ensureNodeImages(status *logutil.Status, cfg *config.Cluster) {
+func ensureNodeImages(status *cli.Status, cfg *config.Cluster) {
 	// pull each required image
 	for _, image := range requiredImages(cfg).List() {
 		// prints user friendly message

--- a/pkg/internal/cluster/create/nodes.go
+++ b/pkg/internal/cluster/create/nodes.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/kind/pkg/container/cri"
 	"sigs.k8s.io/kind/pkg/internal/apis/config"
 	"sigs.k8s.io/kind/pkg/internal/cluster/loadbalancer"
-	logutil "sigs.k8s.io/kind/pkg/log"
+	"sigs.k8s.io/kind/pkg/internal/util/cli"
 	"sigs.k8s.io/kind/pkg/util/concurrent"
 )
 
@@ -76,7 +76,7 @@ func copyConfigNodes(toCopy []config.Node) []config.Node {
 // provisionNodes takes care of creating all the containers
 // that will host `kind` nodes
 func provisionNodes(
-	status *logutil.Status, cfg *config.Cluster, clusterName, clusterLabel string,
+	status *cli.Status, cfg *config.Cluster, clusterName, clusterLabel string,
 ) error {
 	defer status.End(false)
 
@@ -89,7 +89,7 @@ func provisionNodes(
 }
 
 func createNodeContainers(
-	status *logutil.Status, cfg *config.Cluster, clusterName, clusterLabel string,
+	status *cli.Status, cfg *config.Cluster, clusterName, clusterLabel string,
 ) error {
 	defer status.End(false)
 

--- a/pkg/internal/util/cli/spinner.go
+++ b/pkg/internal/util/cli/spinner.go
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package fidget implements CLI functionality for bored users waiting for results
-package fidget
+package cli
 
 import (
 	"fmt"
@@ -43,10 +42,10 @@ var spinnerFrames = []string{
 	"⠊⠁",
 }
 
-// Spinner is a simple and efficient CLI loading spinner used by kind
+// spinner is a simple and efficient CLI loading spinner used by kind
 // It is simplistic and assumes that the line length will not change.
 // It is best used indirectly via log.Status (see parent package)
-type Spinner struct {
+type spinner struct {
 	frames []string
 	stop   chan struct{}
 	ticker *time.Ticker
@@ -57,9 +56,9 @@ type Spinner struct {
 	suffix string
 }
 
-// NewSpinner initializes and returns a new Spinner that will write to
-func NewSpinner(w io.Writer) *Spinner {
-	return &Spinner{
+// Newspinner initializes and returns a new spinner that will write to
+func newSpinner(w io.Writer) *spinner {
+	return &spinner{
 		frames: spinnerFrames,
 		stop:   make(chan struct{}, 1),
 		ticker: time.NewTicker(time.Millisecond * 100),
@@ -69,21 +68,21 @@ func NewSpinner(w io.Writer) *Spinner {
 }
 
 // SetPrefix sets the prefix to print before the spinner
-func (s *Spinner) SetPrefix(prefix string) {
+func (s *spinner) SetPrefix(prefix string) {
 	s.mu.Lock()
 	s.prefix = prefix
 	s.mu.Unlock()
 }
 
 // SetSuffix sets the suffix to print after the spinner
-func (s *Spinner) SetSuffix(suffix string) {
+func (s *spinner) SetSuffix(suffix string) {
 	s.mu.Lock()
 	s.suffix = suffix
 	s.mu.Unlock()
 }
 
 // Start starts the spinner running
-func (s *Spinner) Start() {
+func (s *spinner) Start() {
 	go func() {
 		for {
 			for _, frame := range s.frames {
@@ -103,6 +102,6 @@ func (s *Spinner) Start() {
 }
 
 // Stop signals the spinner to stop
-func (s *Spinner) Stop() {
+func (s *spinner) Stop() {
 	s.stop <- struct{}{}
 }

--- a/pkg/internal/util/env/term.go
+++ b/pkg/internal/util/env/term.go
@@ -1,0 +1,16 @@
+package env
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// IsTerminal returns true if the writer w is a terminal
+func IsTerminal(w io.Writer) bool {
+	if v, ok := (w).(*os.File); ok {
+		return terminal.IsTerminal(int(v.Fd()))
+	}
+	return false
+}


### PR DESCRIPTION
breaking out a very small bit of the logging work, clearing things out of the exported log package that don't particularly belong there before adding the shiny new logging ...