### PR TITLE
log and error reporting improvements

### DIFF
--- a/cmd/kind/create/cluster/createcluster.go
+++ b/cmd/kind/create/cluster/createcluster.go
@@ -65,7 +65,7 @@ func runE(flags *flagpole) error {
 		return err
 	}
 	if known {
-		return errors.Errorf("a cluster with the name %q already exists", flags.Name)
+		return fmt.Errorf("a cluster with the name %q already exists", flags.Name)
 	}
 
 	// create a cluster context and create the cluster

--- a/cmd/kind/delete/cluster/deletecluster.go
+++ b/cmd/kind/delete/cluster/deletecluster.go
@@ -55,7 +55,7 @@ func runE(flags *flagpole) error {
 		return err
 	}
 	if !known {
-		return errors.Errorf("unknown cluster %q", flags.Name)
+		return fmt.Errorf("unknown cluster %q", flags.Name)
 	}
 	// Delete the cluster
 	fmt.Printf("Deleting cluster %q ...\n", flags.Name)

--- a/cmd/kind/export/logs/logs.go
+++ b/cmd/kind/export/logs/logs.go
@@ -20,7 +20,6 @@ package logs
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cluster"
@@ -55,7 +54,7 @@ func runE(flags *flagpole, args []string) error {
 		return err
 	}
 	if !known {
-		return errors.Errorf("unknown cluster %q", flags.Name)
+		return fmt.Errorf("unknown cluster %q", flags.Name)
 	}
 	// get the optional directory argument, or create a tempdir
 	var dir string

--- a/cmd/kind/get/kubeconfig/kubeconfig.go
+++ b/cmd/kind/get/kubeconfig/kubeconfig.go
@@ -18,6 +18,7 @@ limitations under the License.
 package kubeconfig
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -69,7 +70,7 @@ func runE(flags *flagpole) error {
 	}
 	nodes, known := n[flags.Name]
 	if !known {
-		return errors.Errorf("unknown cluster %q", flags.Name)
+		return fmt.Errorf("unknown cluster %q", flags.Name)
 	}
 	// get the bootstrap node to get the kubeconfig
 	node, err := clusternodes.BootstrapControlPlaneNode(nodes)

--- a/cmd/kind/get/nodes/nodes.go
+++ b/cmd/kind/get/nodes/nodes.go
@@ -20,7 +20,6 @@ package nodes
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cluster"
@@ -60,7 +59,7 @@ func runE(flags *flagpole) error {
 	}
 	nodes, known := n[flags.Name]
 	if !known {
-		return errors.Errorf("unknown cluster %q", flags.Name)
+		return fmt.Errorf("unknown cluster %q", flags.Name)
 	}
 	for _, node := range nodes {
 		fmt.Println(node.String())

--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -54,8 +54,9 @@ func NewCommand() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return runE(flags, cmd)
 		},
-		SilenceUsage: true,
-		Version:      version.Version,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Version:       version.Version,
 	}
 	cmd.PersistentFlags().StringVar(
 		&flags.LogLevel,
@@ -121,8 +122,8 @@ func Run() error {
 
 // Main wraps Run and sets the log formatter
 func Main() {
-	// TODO: use default logger
 	if err := Run(); err != nil {
+		globals.GetLogger().Errorf("Failed with error: %+v", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/kind/load/docker-image/docker-image.go
+++ b/cmd/kind/load/docker-image/docker-image.go
@@ -18,6 +18,7 @@ limitations under the License.
 package load
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -74,7 +75,7 @@ func runE(flags *flagpole, args []string) error {
 	// Check that the image exists locally and gets its ID, if not return error
 	imageID, err := docker.ImageID(imageName)
 	if err != nil {
-		return errors.Errorf("Image: %q not present locally", imageName)
+		return fmt.Errorf("Image: %q not present locally", imageName)
 	}
 	// Check if the cluster name exists
 	known, err := cluster.IsKnown(flags.Name)
@@ -82,7 +83,7 @@ func runE(flags *flagpole, args []string) error {
 		return err
 	}
 	if !known {
-		return errors.Errorf("unknown cluster %q", flags.Name)
+		return fmt.Errorf("unknown cluster %q", flags.Name)
 	}
 
 	context := cluster.NewContext(flags.Name)
@@ -107,7 +108,7 @@ func runE(flags *flagpole, args []string) error {
 		for _, name := range flags.Nodes {
 			node, ok := nodesByName[name]
 			if !ok {
-				return errors.Errorf("unknown node: %q", name)
+				return fmt.Errorf("unknown node: %q", name)
 			}
 			candidateNodes = append(candidateNodes, node)
 		}

--- a/cmd/kind/load/image-archive/image-archive.go
+++ b/cmd/kind/load/image-archive/image-archive.go
@@ -18,6 +18,7 @@ limitations under the License.
 package load
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
@@ -39,7 +40,7 @@ func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errors.New("name of image archive is required")
+				return fmt.Errorf("name of image archive is required")
 			}
 			return nil
 		},
@@ -77,7 +78,7 @@ func runE(flags *flagpole, args []string) error {
 		return err
 	}
 	if !known {
-		return errors.Errorf("unknown cluster %q", flags.Name)
+		return fmt.Errorf("unknown cluster %q", flags.Name)
 	}
 
 	context := cluster.NewContext(flags.Name)
@@ -102,7 +103,7 @@ func runE(flags *flagpole, args []string) error {
 		for _, name := range flags.Nodes {
 			node, ok := nodesByName[name]
 			if !ok {
-				return errors.Errorf("unknown node: %s", name)
+				return fmt.Errorf("unknown node: %s", name)
 			}
 			selectedNodes = append(selectedNodes, node)
 		}

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -402,8 +402,7 @@ func (c *BuildContext) prePullImages(dir, containerID string) error {
 		fixedImages.Insert(registry + ":" + tag)
 	}
 	builtImages = fixedImages
-	println("built images")
-	println(strings.Join(builtImages.List(), ", "))
+	globals.GetLogger().V(0).Info("Detected built images: " + strings.Join(builtImages.List(), ", "))
 
 	// write the default CNI manifest
 	// NOTE: the paths inside the container should use the path package

--- a/pkg/container/docker/pull.go
+++ b/pkg/container/docker/pull.go
@@ -32,7 +32,7 @@ func PullIfNotPresent(image string, retries int) (pulled bool, err error) {
 	// if this did not return an error, then the image exists locally
 	cmd := exec.Command("docker", "inspect", "--type=image", image)
 	if err := cmd.Run(); err == nil {
-		globals.GetLogger().V(0).Infof("Image: %s present locally", image)
+		globals.GetLogger().V(1).Infof("Image: %s present locally", image)
 		return false, nil
 	}
 	// otherwise try to pull it
@@ -41,13 +41,13 @@ func PullIfNotPresent(image string, retries int) (pulled bool, err error) {
 
 // Pull pulls an image, retrying up to retries times
 func Pull(image string, retries int) error {
-	globals.GetLogger().V(0).Infof("Pulling image: %s ...", image)
+	globals.GetLogger().V(1).Infof("Pulling image: %s ...", image)
 	err := exec.Command("docker", "pull", image).Run()
 	// retry pulling up to retries times if necessary
 	if err != nil {
 		for i := 0; i < retries; i++ {
 			time.Sleep(time.Second * time.Duration(i+1))
-			globals.GetLogger().V(0).Infof("Trying again to pull image: %q ... %v", image, err)
+			globals.GetLogger().V(1).Infof("Trying again to pull image: %q ... %v", image, err)
 			// TODO(bentheelder): add some backoff / sleep?
 			err = exec.Command("docker", "pull", image).Run()
 			if err == nil {
@@ -56,7 +56,7 @@ func Pull(image string, retries int) error {
 		}
 	}
 	if err != nil {
-		globals.GetLogger().V(0).Infof("Failed to pull image: %q %v", image, err)
+		globals.GetLogger().V(1).Infof("Failed to pull image: %q %v", image, err)
 	}
 	return err
 }


### PR DESCRIPTION
- never use `println` to write to stderr, use our logger instead (which respects `-q`)
- increase verbosity on some log messages that are meant for debugging
- don't use cobra's error reporting, use our logger instead (which respects `-q`)
  - print errors with `"%+v"` so we get extended info (stack traces!)
- use `fmt` instead of `pkg/errors` to create errors that are:
  - in `cmd/...`
  - the result of common user issues (eg, cluster already exists), rather than internal failures