### PR TITLE
more logging / error cleanup

### DIFF
--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -104,7 +104,7 @@ func runE(flags *Flags, cmd *cobra.Command) error {
 	if flags.Quiet {
 		globals.SetLogger(log.NoopLogger{})
 	} else {
-		globals.UseDefaultLogger(log.Level(flags.Verbosity))
+		globals.UseCLILogger(os.Stderr, log.Level(flags.Verbosity))
 	}
 	// warn about deprecated flag if used
 	if setLogLevel {

--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -34,8 +34,6 @@ import (
 	"sigs.k8s.io/kind/pkg/log"
 )
 
-const defaultLevel = "warning"
-
 // Flags for the kind command
 type Flags struct {
 	LogLevel  string
@@ -61,7 +59,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		&flags.LogLevel,
 		"loglevel",
-		defaultLevel,
+		"",
 		"DEPRECATED: see -v instead",
 	)
 	cmd.PersistentFlags().Int32VarP(

--- a/pkg/globals/logger.go
+++ b/pkg/globals/logger.go
@@ -14,16 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// package globals will be deleted in a future commit
+// Package globals will be deleted in a future commit
 // this package contains globals that we've not yet re-worked to not be globals
 package globals
 
 import (
+	"io"
 	"sync"
 
 	"sigs.k8s.io/kind/pkg/log"
 
-	"sigs.k8s.io/kind/pkg/internal/util/logger"
+	"sigs.k8s.io/kind/pkg/internal/util/cli"
+	"sigs.k8s.io/kind/pkg/internal/util/env"
 )
 
 // TODO: consider threading through a logger instead of using a global logger
@@ -40,12 +42,15 @@ func SetLogger(l log.Logger) {
 	globalLogger = l
 }
 
-// UseDefaultLogger sets the global logger to kind's default logger
-// with SetLogger
+// UseCLILogger sets the global logger to the kind CLI's default stderr logger
+// if writer is a tty, the CLI spinner will be enabled
 //
 // Not to be confused with the default if not set of log.NoopLogger
-func UseDefaultLogger(verbosity log.Level) {
-	SetLogger(logger.NewDefault(verbosity))
+func UseCLILogger(writer io.Writer, verbosity log.Level) {
+	if env.IsTerminal(writer) {
+		writer = cli.NewSpinner(writer)
+	}
+	SetLogger(cli.NewLogger(writer, verbosity))
 }
 
 // GetLogger returns the standard logger used by this package

--- a/pkg/internal/util/env/term.go
+++ b/pkg/internal/util/env/term.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package env
 
 import (


### PR DESCRIPTION
- remove default value for deprecated `loglevel` flag
- simplify spinner to itself be the writer wrapper
- combine cli utils and default cli logger package
- create spinner once if cli logger is pointed at a tty, otherwise not at all
- explicitly pass in stderr as the writer from the cli package
- fix missing boilerplate