### PR TITLE
WIP Use memory to store etcd data

### DIFF
--- a/pkg/cluster/nodes/create.go
+++ b/pkg/cluster/nodes/create.go
@@ -145,6 +145,7 @@ func createNode(name, image, clusterLabel, role string, mounts []cri.Mount, port
 		// runtime temporary storage
 		"--tmpfs", "/tmp", // various things depend on working /tmp
 		"--tmpfs", "/run", // systemd wants a writable /run
+		"--tmpfs", "/var/lib/etcd", // etcd needs fast storage
 		// runtime persistent storage
 		// this ensures that E.G. pods, logs etc. are not on the container
 		// filesystem, which is not only better for performance, but allows


### PR DESCRIPTION
The /var/lib folder is to suppose to store only the data needed by programs as they run, due to the nature of containers we shouldn't need it once the containers are stopped.
This adds a boost on performance because the software using that folder, specially etcd, use memory directly instead of disks for storage  