### PR TITLE
more work on logs & errors

### DIFF
--- a/cmd/kind/errors.go
+++ b/cmd/kind/errors.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kind
+
+import (
+	"github.com/pkg/errors"
+
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+// github.com/pkg/errors errors type interfaces
+type causer interface {
+	Cause() error
+}
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+// runError returns an exec.RunError if the error chain
+// contains an exec.RunError
+func runError(err error) *exec.RunError {
+	var runError *exec.RunError
+	for {
+		if rErr, ok := err.(*exec.RunError); ok {
+			runError = rErr
+		}
+		if causerErr, ok := err.(causer); ok {
+			err = causerErr.Cause()
+		} else {
+			break
+		}
+	}
+	return runError
+}
+
+// stackTrace returns the deepest StackTrace is a Cause chain
+// https://github.com/pkg/errors/issues/173
+func stackTrace(err error) errors.StackTrace {
+	var stackErr error
+	for {
+		if _, ok := err.(stackTracer); ok {
+			stackErr = err
+		}
+		if causerErr, ok := err.(causer); ok {
+			err = causerErr.Cause()
+		} else {
+			break
+		}
+	}
+	if stackErr != nil {
+		return stackErr.(stackTracer).StackTrace()
+	}
+	return nil
+}

--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -130,9 +130,11 @@ func Main() {
 // logError logs the error and the root stacktrace if there is one
 func logError(err error) {
 	globals.GetLogger().Errorf("ERROR: %v", err)
-	// display the stack trace if any
-	if trace := stackTrace(err); trace != nil {
-		globals.GetLogger().Errorf("%+v", trace)
+	// if debugging is enabled (non-zero verbosity), display stack trace if any
+	if globals.GetLogger().V(1).Enabled() {
+		if trace := stackTrace(err); trace != nil {
+			globals.GetLogger().Errorf("%+v", trace)
+		}
 	}
 }
 

--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -20,6 +20,7 @@ package kind
 import (
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/cmd/kind/build"
@@ -118,10 +119,22 @@ func Run() error {
 	return NewCommand().Execute()
 }
 
+// logError logs the error and the root stacktrace if there is one
+func logError(err error) {
+	globals.GetLogger().Errorf("ERROR: %v", err)
+	// display stack trace if the error has one
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+	if tracer, ok := errors.Cause(err).(stackTracer); ok {
+		globals.GetLogger().Errorf("%+v", tracer)
+	}
+}
+
 // Main wraps Run and sets the log formatter
 func Main() {
 	if err := Run(); err != nil {
-		globals.GetLogger().Errorf("Failed with error: %+v", err)
+		logError(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -109,7 +109,7 @@ func runE(flags *Flags, cmd *cobra.Command) error {
 	}
 	// warn about deprecated flag if used
 	if setLogLevel {
-		globals.GetLogger().Warn("--loglevel is deprecated, please switch to -v and -q!")
+		globals.GetLogger().Warn("WARNING: --loglevel is deprecated, please switch to -v and -q!")
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/kind
 go 1.13
 
 require (
+	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053
 	github.com/google/gofuzz v1.0.0
 	github.com/google/uuid v1.1.1
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 h1:H/GMMKYPkEIC3DF/JWQz8Pdd+Feifov2EIgGfNpeogI=
+github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053/go.mod h1:xW8sBma2LE3QxFSzCnH9qe6gAE2yO9GvQaWwX89HxbE=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/cluster/nodes/node.go
+++ b/pkg/cluster/nodes/node.go
@@ -241,8 +241,7 @@ func (n *Node) Role() (role string, err error) {
 // WriteFile writes content to dest on the node
 func (n *Node) WriteFile(dest, content string) error {
 	// create destination directory
-	cmd := n.Command("mkdir", "-p", filepath.Dir(dest))
-	err := exec.RunLoggingOutputOnFail(cmd)
+	err := n.Command("mkdir", "-p", filepath.Dir(dest)).Run()
 	if err != nil {
 		return errors.Wrapf(err, "failed to create directory %s", dest)
 	}
@@ -343,14 +342,12 @@ func getSubnets(networkName string) ([]string, error) {
 // EnableIPv6 enables IPv6 inside the node container and in the inner docker daemon
 func (n *Node) EnableIPv6() error {
 	// enable ipv6
-	cmd := n.Command("sysctl", "net.ipv6.conf.all.disable_ipv6=0")
-	err := exec.RunLoggingOutputOnFail(cmd)
+	err := n.Command("sysctl", "net.ipv6.conf.all.disable_ipv6=0").Run()
 	if err != nil {
 		return errors.Wrap(err, "failed to enable ipv6")
 	}
 	// enable ipv6 forwarding
-	cmd = n.Command("sysctl", "net.ipv6.conf.all.forwarding=1")
-	err = exec.RunLoggingOutputOnFail(cmd)
+	err = n.Command("sysctl", "net.ipv6.conf.all.forwarding=1").Run()
 	if err != nil {
 		return errors.Wrap(err, "failed to enable ipv6 forwarding")
 	}

--- a/pkg/exec/default.go
+++ b/pkg/exec/default.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+// DefaultCmder is a LocalCmder instance used for convienience, packages
+// originally using os/exec.Command can instead use pkg/kind/exec.Command
+// which forwards to this instance
+// TODO(bentheelder): swap this for testing
+// TODO(bentheelder): consider not using a global for this :^)
+var DefaultCmder = &LocalCmder{}
+
+// Command is a convience wrapper over DefaultCmder.Command
+func Command(command string, args ...string) Cmd {
+	return DefaultCmder.Command(command, args...)
+}

--- a/pkg/exec/doc.go
+++ b/pkg/exec/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package exec contains an interface for executing commands, along with helpers
+// TODO(bentheelder): add standardized timeout functionality & a default timeout
+// so that commands cannot hang indefinitely (!)
+package exec

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -24,8 +24,6 @@ import (
 	"bytes"
 	"io"
 	"os"
-
-	"sigs.k8s.io/kind/pkg/globals"
 )
 
 // Cmd abstracts over running a command somewhere, this is useful for testing
@@ -90,23 +88,6 @@ func InheritOutput(cmd Cmd) Cmd {
 	cmd.SetStderr(os.Stderr)
 	cmd.SetStdout(os.Stdout)
 	return cmd
-}
-
-// RunLoggingOutputOnFail runs the cmd, logging error output if Run returns an error
-// TODO: we should just make exec capture output on error and move this to the caller
-func RunLoggingOutputOnFail(cmd Cmd) error {
-	var buff bytes.Buffer
-	cmd.SetStdout(&buff)
-	cmd.SetStderr(&buff)
-	err := cmd.Run()
-	if err != nil {
-		globals.GetLogger().Error("failed with:")
-		scanner := bufio.NewScanner(&buff)
-		for scanner.Scan() {
-			globals.GetLogger().Error(scanner.Text())
-		}
-	}
-	return err
 }
 
 // RunWithStdoutReader runs cmd with stdout piped to readerFunc

--- a/pkg/exec/helpers.go
+++ b/pkg/exec/helpers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2010 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/exec/local.go
+++ b/pkg/exec/local.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	osexec "os/exec"
 
+	"github.com/pkg/errors"
+
 	"sigs.k8s.io/kind/pkg/globals"
 )
 
@@ -70,5 +72,5 @@ func (cmd *LocalCmd) SetStderr(w io.Writer) Cmd {
 func (cmd *LocalCmd) Run() error {
 	// TODO: should be in the caller or logger should be injected somehow ...
 	globals.GetLogger().V(3).Infof("Running: %v %v", cmd.Path, cmd.Args)
-	return cmd.Cmd.Run()
+	return errors.WithStack(cmd.Cmd.Run())
 }

--- a/pkg/exec/types.go
+++ b/pkg/exec/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/exec/types.go
+++ b/pkg/exec/types.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"fmt"
+	"io"
+)
+
+// Cmd abstracts over running a command somewhere, this is useful for testing
+type Cmd interface {
+	// Run executes the command (like os/exec.Cmd.Run), it should return
+	// a *RunError if there is any error
+	Run() error
+	// Each entry should be of the form "key=value"
+	SetEnv(...string) Cmd
+	SetStdin(io.Reader) Cmd
+	SetStdout(io.Writer) Cmd
+	SetStderr(io.Writer) Cmd
+}
+
+// Cmder abstracts over creating commands
+type Cmder interface {
+	// command, args..., just like os/exec.Cmd
+	Command(string, ...string) Cmd
+}
+
+// RunError represents an error running a Cmd
+type RunError struct {
+	Command []string // [Name Args...]
+	Output  []byte   // Captured Stdout / Stderr of the command
+	Inner   error    // Underlying error if any
+}
+
+var _ error = &RunError{}
+
+func (e *RunError) Error() string {
+	// TODO(BenTheElder): implement formatter, and show output for %+v ?
+	return fmt.Sprintf("command \"%s\" failed with error: %v", e.PrettyCommand(), e.Inner)
+}
+
+// PrettyCommand pretty prints the command in a way that could be pasted
+// into a shell
+func (e *RunError) PrettyCommand() string {
+	return PrettyCommand(e.Command[0], e.Command[1:]...)
+}
+
+// Cause mimics github.com/pkg/errors's Cause pattern for errors
+func (e *RunError) Cause() error {
+	if e.Inner != nil {
+		return e.Inner
+	}
+	return e
+}

--- a/pkg/internal/util/cli/logger.go
+++ b/pkg/internal/util/cli/logger.go
@@ -28,8 +28,8 @@ import (
 // Logger is the kind cli's log.Logger implementation
 type Logger struct {
 	Verbosity log.Level
-	io.Writer
-	writeMu sync.Mutex
+	Writer    io.Writer
+	writeMu   sync.Mutex
 }
 
 var _ log.Logger = &Logger{}
@@ -42,7 +42,7 @@ func NewLogger(writer io.Writer, verbosity log.Level) *Logger {
 	}
 }
 
-func (l *Logger) Write(p []byte) (n int, err error) {
+func (l *Logger) write(p []byte) (n int, err error) {
 	// TODO: line oriented instead?
 	// For now we make a single per-message write call from the rest of the logger
 	// intentionally to effectively do this one level up
@@ -60,7 +60,7 @@ func (l *Logger) print(message string) {
 	}
 	// TODO: should we handle this somehow??
 	// Who logs for the logger? 🤔
-	_, _ = l.Write(buf.Bytes())
+	_, _ = l.write(buf.Bytes())
 }
 
 func (l *Logger) printf(format string, args ...interface{}) {
@@ -71,7 +71,7 @@ func (l *Logger) printf(format string, args ...interface{}) {
 	}
 	// TODO: should we handle this somehow??
 	// Who logs for the logger? 🤔
-	_, _ = l.Write(buf.Bytes())
+	_, _ = l.write(buf.Bytes())
 }
 
 // Warn is part of the log.Logger interface

--- a/pkg/internal/util/cli/logger.go
+++ b/pkg/internal/util/cli/logger.go
@@ -94,8 +94,8 @@ func addDebugHeader(buf *bytes.Buffer) {
 			}
 		}
 	}
-	buf.Grow(len(file) + 10) // we know at least this many bytes are needed
-	buf.WriteString("DEBUG ")
+	buf.Grow(len(file) + 11) // we know at least this many bytes are needed
+	buf.WriteString("DEBUG: ")
 	buf.WriteString(file)
 	buf.WriteByte(':')
 	fmt.Fprintf(buf, "%d", line)

--- a/pkg/internal/util/cli/logger.go
+++ b/pkg/internal/util/cli/logger.go
@@ -214,6 +214,11 @@ func (b *bufferPool) Get() *bytes.Buffer {
 
 // Put returns a buffer to the pool, reseting it first
 func (b *bufferPool) Put(x *bytes.Buffer) {
+	// only store small buffers to avoid pointless allocation
+	// avoid keeping arbitrarily large buffers
+	if x.Len() > 256 {
+		return
+	}
 	x.Reset()
 	b.Pool.Put(x)
 }

--- a/pkg/internal/util/cli/logger.go
+++ b/pkg/internal/util/cli/logger.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"runtime"
+	"strings"
 	"sync"
 
 	"sigs.k8s.io/kind/pkg/log"
@@ -27,9 +29,10 @@ import (
 
 // Logger is the kind cli's log.Logger implementation
 type Logger struct {
-	Verbosity log.Level
-	Writer    io.Writer
-	writeMu   sync.Mutex
+	writer     io.Writer
+	writerMu   sync.Mutex
+	verbosity  log.Level
+	bufferPool *bufferPool
 }
 
 var _ log.Logger = &Logger{}
@@ -37,41 +40,85 @@ var _ log.Logger = &Logger{}
 // NewLogger returns a new Logger with the given verbosity
 func NewLogger(writer io.Writer, verbosity log.Level) *Logger {
 	return &Logger{
-		Verbosity: verbosity,
-		Writer:    writer,
+		verbosity:  verbosity,
+		writer:     writer,
+		bufferPool: newBufferPool(),
 	}
 }
 
+// synchronized write to the inner writer
 func (l *Logger) write(p []byte) (n int, err error) {
-	// TODO: line oriented instead?
-	// For now we make a single per-message write call from the rest of the logger
-	// intentionally to effectively do this one level up
-	l.writeMu.Lock()
-	defer l.writeMu.Unlock()
-	return l.Writer.Write(p)
+	l.writerMu.Lock()
+	defer l.writerMu.Unlock()
+	return l.writer.Write(p)
 }
 
-// TODO: prefix log lines with metadata (log level? timestamp?)
+// writeBuffer writes buf with write, ensuring there is a trailing newline
+func (l *Logger) writeBuffer(buf *bytes.Buffer) {
+	// ensure trailing newline
+	if buf.Bytes()[buf.Len()-1] != '\n' {
+		buf.WriteByte('\n')
+	}
+	// TODO: should we handle this somehow??
+	// Who logs for the logger? 🤔
+	_, _ = l.write(buf.Bytes())
+}
 
+// print writes a simple string to the log writer
 func (l *Logger) print(message string) {
 	buf := bytes.NewBufferString(message)
-	if buf.Bytes()[buf.Len()-1] != '\n' {
-		buf.WriteByte('\n')
-	}
-	// TODO: should we handle this somehow??
-	// Who logs for the logger? 🤔
-	_, _ = l.write(buf.Bytes())
+	l.writeBuffer(buf)
 }
 
+// printf is roughly fmt.Fprintf against the log writer
 func (l *Logger) printf(format string, args ...interface{}) {
-	var buf bytes.Buffer
-	fmt.Fprintf(&buf, format, args...)
-	if buf.Bytes()[buf.Len()-1] != '\n' {
-		buf.WriteByte('\n')
+	buf := l.bufferPool.Get()
+	fmt.Fprintf(buf, format, args...)
+	l.writeBuffer(buf)
+	l.bufferPool.Put(buf)
+}
+
+// addDebugHeader inserts the debug line header to buf
+func addDebugHeader(buf *bytes.Buffer) {
+	_, file, line, ok := runtime.Caller(3)
+	// lifted from klog
+	if !ok {
+		file = "???"
+		line = 1
+	} else {
+		if slash := strings.LastIndex(file, "/"); slash >= 0 {
+			path := file
+			file = path[slash+1:]
+			if dirsep := strings.LastIndex(path[:slash], "/"); dirsep >= 0 {
+				file = path[dirsep+1:]
+			}
+		}
 	}
-	// TODO: should we handle this somehow??
-	// Who logs for the logger? 🤔
-	_, _ = l.write(buf.Bytes())
+	buf.Grow(len(file) + 10) // we know at least this many bytes are needed
+	buf.WriteString("DEBUG ")
+	buf.WriteString(file)
+	buf.WriteByte(':')
+	fmt.Fprintf(buf, "%d", line)
+	buf.WriteByte(']')
+	buf.WriteByte(' ')
+}
+
+// debug is like print but with a debug log header
+func (l *Logger) debug(message string) {
+	buf := l.bufferPool.Get()
+	addDebugHeader(buf)
+	buf.WriteString(message)
+	l.writeBuffer(buf)
+	l.bufferPool.Put(buf)
+}
+
+// debugf is like printf but with a debug log header
+func (l *Logger) debugf(format string, args ...interface{}) {
+	buf := l.bufferPool.Get()
+	addDebugHeader(buf)
+	fmt.Fprintf(buf, format, args...)
+	l.writeBuffer(buf)
+	l.bufferPool.Put(buf)
 }
 
 // Warn is part of the log.Logger interface
@@ -98,29 +145,75 @@ func (l *Logger) Errorf(format string, args ...interface{}) {
 func (l *Logger) V(level log.Level) log.InfoLogger {
 	return infoLogger{
 		logger:  l,
-		enabled: level <= l.Verbosity,
+		level:   level,
+		enabled: level <= l.verbosity,
 	}
 }
 
+// infoLogger implements log.InfoLogger for Logger
 type infoLogger struct {
 	logger  *Logger
+	level   log.Level
 	enabled bool
 }
 
+// Enabled is part of the log.InfoLogger interface
 func (i infoLogger) Enabled() bool {
 	return i.enabled
 }
 
+// Info is part of the log.InfoLogger interface
 func (i infoLogger) Info(message string) {
 	if !i.enabled {
 		return
 	}
-	i.logger.print(message)
+	// for > 0, we are writing debug messages, include extra info
+	if i.level > 0 {
+		i.logger.debug(message)
+	} else {
+		i.logger.print(message)
+	}
 }
 
+// Infof is part of the log.InfoLogger interface
 func (i infoLogger) Infof(format string, args ...interface{}) {
 	if !i.enabled {
 		return
 	}
-	i.logger.printf(format, args...)
+	// for > 0, we are writing debug messages, include extra info
+	if i.level > 0 {
+		i.logger.debugf(format, args...)
+	} else {
+		i.logger.printf(format, args...)
+	}
+}
+
+// bufferPool is a type safe sync.Pool of *byte.Buffer, guaranteed to be Reset
+type bufferPool struct {
+	sync.Pool
+}
+
+// newBufferPool returns a new bufferPool
+func newBufferPool() *bufferPool {
+	return &bufferPool{
+		sync.Pool{
+			New: func() interface{} {
+				// The Pool's New function should generally only return pointer
+				// types, since a pointer can be put into the return interface
+				// value without an allocation:
+				return new(bytes.Buffer)
+			},
+		},
+	}
+}
+
+// Get obtains a buffer from the pool
+func (b *bufferPool) Get() *bytes.Buffer {
+	return b.Pool.Get().(*bytes.Buffer)
+}
+
+// Put returns a buffer to the pool, reseting it first
+func (b *bufferPool) Put(x *bytes.Buffer) {
+	x.Reset()
+	b.Pool.Put(x)
 }

--- a/pkg/internal/util/cli/spinner.go
+++ b/pkg/internal/util/cli/spinner.go
@@ -45,13 +45,15 @@ var spinnerFrames = []string{
 // Spinner is a simple and efficient CLI loading spinner used by kind
 // It is simplistic and assumes that the line length will not change.
 type Spinner struct {
-	stop   chan struct{}
-	ticker *time.Ticker
-	writer io.Writer
-	mu     *sync.Mutex
-	// protected by mu
-	prefix string
-	suffix string
+	stop    chan struct{} // signals writer goroutine to stop from Stop()
+	stopped chan struct{} // signals Stop() that the writer goroutine stopped
+	mu      *sync.Mutex   // protects the mutable bits
+	// below are protected by mu
+	running bool
+	writer  io.Writer
+	ticker  *time.Ticker // signals that it is time to write a frame
+	prefix  string
+	suffix  string
 }
 
 // spinner implements writer
@@ -60,35 +62,49 @@ var _ io.Writer = &Spinner{}
 // NewSpinner initializes and returns a new Spinner that will write to w
 func NewSpinner(w io.Writer) *Spinner {
 	return &Spinner{
-		stop:   make(chan struct{}, 1),
-		ticker: time.NewTicker(time.Millisecond * 100),
-		mu:     &sync.Mutex{},
-		writer: w,
+		stop:    make(chan struct{}, 1),
+		stopped: make(chan struct{}, 1),
+		mu:      &sync.Mutex{},
+		writer:  w,
 	}
 }
 
 // SetPrefix sets the prefix to print before the spinner
 func (s *Spinner) SetPrefix(prefix string) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.prefix = prefix
-	s.mu.Unlock()
 }
 
 // SetSuffix sets the suffix to print after the spinner
 func (s *Spinner) SetSuffix(suffix string) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.suffix = suffix
-	s.mu.Unlock()
 }
 
 // Start starts the spinner running
 func (s *Spinner) Start() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// don't start if we've already started, also flag that we've started
+	if s.running {
+		return
+	}
+	s.running = true
+	// start / create a frame ticker
+	s.ticker = time.NewTicker(time.Millisecond * 100)
+	// spin in the background
 	go func() {
+		// write frames forever (until signaled to stop)
 		for {
 			for _, frame := range spinnerFrames {
 				select {
+				// prefer stopping, select this signal first
 				case <-s.stop:
-					return
+					s.stopped <- struct{}{} // signal that we stopped
+					return                  // ... and stop
+				// otherwise continue and write one frame
 				case <-s.ticker.C:
 					func() {
 						s.mu.Lock()
@@ -103,17 +119,35 @@ func (s *Spinner) Start() {
 
 // Stop signals the spinner to stop
 func (s *Spinner) Stop() {
+	s.mu.Lock()
+	// if there's nothing to stop, return early
+	if !s.running {
+		s.mu.Unlock()
+		return
+	}
+	// otherwise: mark not running, send the stop signal and release the ticker
 	s.stop <- struct{}{}
+	s.ticker.Stop()
+	s.running = false
+	// unlock after sending the signal to avoid deadlock
+	s.mu.Unlock()
+	// and wait for the reply
+	<-s.stopped
 }
 
 // Write implements io.Writer, interrupting the spinner and writing to
 // the inner writer
 func (s *Spinner) Write(p []byte) (n int, err error) {
-	s.Stop()
+	// lock first, so nothing else can start writing until we are done
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// it the spinner is not running, just write directly
+	if !s.running {
+		return s.writer.Write(p)
+	}
+	// otherwise: we will rewrite the line first
 	if _, err := s.writer.Write([]byte("\r")); err != nil {
 		return 0, err
 	}
-	n, err = s.writer.Write(p)
-	s.Start()
-	return n, err
+	return s.writer.Write(p)
 }

--- a/pkg/internal/util/cli/status.go
+++ b/pkg/internal/util/cli/status.go
@@ -76,7 +76,7 @@ func (s *Status) End(success bool) {
 	if success {
 		s.logger.V(0).Infof(" ✓ %s\n", s.status)
 	} else {
-		s.logger.V(0).Infof("✗ %s\n", s.status)
+		s.logger.V(0).Infof(" ✗ %s\n", s.status)
 	}
 
 	s.status = ""

--- a/pkg/internal/util/cli/status.go
+++ b/pkg/internal/util/cli/status.go
@@ -40,7 +40,7 @@ func StatusForLogger(l log.Logger) *Status {
 	// if we're using the CLI logger, check for if it has a spinner setup
 	// and wire the status to that
 	if v, ok := l.(*Logger); ok {
-		if v2, ok := v.Writer.(*Spinner); ok {
+		if v2, ok := v.writer.(*Spinner); ok {
 			s.spinner = v2
 		}
 	}

--- a/pkg/log/types.go
+++ b/pkg/log/types.go
@@ -23,17 +23,44 @@ type Level int32
 // Logger defines the logging interface kind uses
 // It is roughly a subset of github.com/kubernetes/klog
 type Logger interface {
+	// Warn should be used to write user facing warnings
 	Warn(message string)
+	// Warnf should be used to write Printf style user facing warnings
 	Warnf(format string, args ...interface{})
+	// Error may be used to write an error message when it occurs
+	// Prefer returning an error instead in most cases
 	Error(message string)
+	// Errorf may be used to write a Printf style error message when it occurs
+	// Prefer returning an error instead in most cases
 	Errorf(format string, args ...interface{})
+	// V() returns an InfoLogger for a given verbosity Level
+	//
+	// Normal verbosity levels:
+	// V(0): normal user facing messages go to V(0)
+	// V(1): debug messages start when V(N > 0), these should be high level
+	// V(2): more detailed log messages
+	// V(3+): trace level logging, in increasing "noisiness" ... allowing
+	// arbitrarily detailed logging at extremely low cost unless the
+	// logger has actually been configured to display these (E.G. via the -v
+	// command line flag)
+	//
+	// It is expected that the returned InfoLogger will be extremely cheap
+	// to interact with for a Level greater than the enabled level
 	V(Level) InfoLogger
 }
 
 // InfoLogger defines the info logging interface kind uses
 // It is roughly a subset of Verbose from github.com/kubernetes/klog
 type InfoLogger interface {
+	// Info is used to write a user facing status message
+	//
+	// See: Logger.V
 	Info(message string)
+	// Infof is used to write a Printf style user facing status message
 	Infof(format string, args ...interface{})
+	// Enabled should return true if this verbosity level is enabled
+	// on the Logger
+	//
+	// See: Logger.V
 	Enabled() bool
 }


### PR DESCRIPTION
- Document logger interface more, including expected usage
- Show stack trace and failed command output when verbosity is > 0
  - Ensure we show the deepest stack trace available
  - exec package now always collects output in returned errors and exposes this
- Add debug info (`DEBUG dir/file.go:line] ...`) to `V(1).Info(...)` and above log messages similar to klog
- Minor: Optimize the CLI logger slightly to maintain a pool of byte buffers rather than always using a new buffer
- Minor: Fix edge case in the spinner synchronization