### PR TITLE
[WIP] Bump base image components

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -88,7 +88,7 @@ RUN containerd --version \
 
 # Install CNI binaries to /opt/cni/bin
 # TODO(bentheelder): doc why / what here
-ARG CNI_VERSION="0.7.5"
+ARG CNI_VERSION="0.8.2"
 ARG CNI_BASE_URL="https://storage.googleapis.com/kubernetes-release/network-plugins/"
 RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') \
     && export CNI_TARBALL="cni-plugins-${ARCH}-v${CNI_VERSION}.tgz" \
@@ -100,7 +100,7 @@ RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/
     && rm -rf /tmp/cni.tgz
 
 # Install crictl to /usr/local/bin
-ARG CRICTL_VERSION="v1.14.0"
+ARG CRICTL_VERSION="v1.16.1"
 RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') \
     && curl -fSL "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCH}.tar.gz" | tar xzC /usr/local/bin \
     && echo 'runtime-endpoint: unix:///var/run/containerd/containerd.sock' > /etc/crictl.yaml


### PR DESCRIPTION
- [x] [cniplugins latest version is 0.8.2](https://github.com/containernetworking/plugins/releases)
- [x] [cri-tools latest version is 1.16.1](https://github.com/kubernetes-sigs/cri-tools/releases)
- [ ] we need containerd 1.3 for dual-stack (pending multi-arch) release