### PR TITLE
remove custom ctr binary from base image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -39,22 +39,6 @@ RUN chmod +x /usr/local/bin/clean-install
 # Then we cleanup (removing unwanted systemd services)
 # Then we disable kmsg in journald (these log entries would be confusing)
 #
-# ********************************<TEMPORARY>***********************************
-#
-# We then download a ctr binary with a tiny additional feature
-# we use that is not yet merged / packaged.
-#
-# See: https://github.com/containerd/containerd/pull/3259
-#
-# This binary is built with hack/build/ctr/run.sh
-# Sources: https://github.com/BenTheElder/containerd/tree/kind
-# Additional commit:
-# https://github.com/BenTheElder/containerd/commit/cb7c780af2394ab08d5d8a3932ca7437074ae179
-#
-# TODO(bentheelder): remove this once --no-unpack is packaged upstream.
-#
-# *******************************</TEMPORARY>***********************************
-#
 # https://developers.redhat.com/blog/2014/05/05/running-systemd-within-docker-container/
 RUN clean-install \
       systemd systemd-sysv libsystemd0 \
@@ -70,10 +54,6 @@ RUN clean-install \
     && rm -f /lib/systemd/system/basic.target.wants/* \
     && echo "ReadKMsg=no" >> /etc/systemd/journald.conf \
     && systemctl enable containerd \
-    && export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') \
-    && curl -fSL -o /usr/local/bin/ctr \
-      "https://storage.googleapis.com/bentheelder-kind-dev/containerd/linux/${ARCH}/ctr" \
-    && chmod +x /usr/local/bin/ctr \
     && echo "done installing packages"
 
 # add overrides to containerd

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -44,7 +44,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20190926-e6b6f7f0@sha256:1ec92b2910f2bfb8a4814cc90e15974a499f0c93d203b879277fa4bdb3762ce2"
+const DefaultBaseImage = "kindest/base:v20190927-b93f70800@sha256:9ffa8a5e4ae97fba5a9b6aa870a383c096de091d719a311238a42b3a541c60df"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
the upstream binaries have been released with the patch we wanted in ctr, this actually reduces the base image size slightly.