### PR TITLE
add cluster subnets to NO_PROXY, simplify loadbalancer arguments, str…

### DIFF
--- a/pkg/internal/cluster/providers/provider/common/getport.go
+++ b/pkg/internal/cluster/providers/provider/common/getport.go
@@ -20,6 +20,15 @@ import (
 	"net"
 )
 
+// PortOrGetFreePort is a helper that either returns the provided port
+// if valid or returns a new free port on listenAddr
+func PortOrGetFreePort(port int32, listenAddr string) (int32, error) {
+	if port > 0 {
+		return port, nil
+	}
+	return GetFreePort(listenAddr)
+}
+
 // GetFreePort is a helper used to get a free TCP port on the host
 func GetFreePort(listenAddr string) (int32, error) {
 	dummyListener, err := net.Listen("tcp", net.JoinHostPort(listenAddr, "0"))

--- a/pkg/internal/cluster/providers/provider/common/proxy.go
+++ b/pkg/internal/cluster/providers/provider/common/proxy.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"os"
+	"strings"
+
+	"sigs.k8s.io/kind/pkg/internal/apis/config"
+)
+
+const (
+	// HTTPProxy is the HTTP_PROXY environment variable key
+	HTTPProxy = "HTTP_PROXY"
+	// HTTPSProxy is the HTTPS_PROXY environment variable key
+	HTTPSProxy = "HTTPS_PROXY"
+	// NOProxy is the NO_PROXY environment variable key
+	NOProxy = "NO_PROXY"
+)
+
+// GetProxyEnvs returns a map of proxy environment variables to their values
+// If proxy settings are set, NO_PROXY is modified to include the cluster subnets
+func GetProxyEnvs(cfg *config.Cluster) map[string]string {
+	envs := make(map[string]string)
+	for _, name := range []string{HTTPProxy, HTTPSProxy, NOProxy} {
+		val := os.Getenv(name)
+		if val == "" {
+			val = os.Getenv(strings.ToLower(name))
+		}
+		if val != "" {
+			envs[name] = val
+			envs[strings.ToLower(name)] = val
+		}
+	}
+	// Specifically add the cluster subnets to NO_PROXY if we are using a proxy
+	if len(envs) > 0 {
+		noProxy := strings.Join([]string{envs[NOProxy], cfg.Networking.ServiceSubnet, cfg.Networking.PodSubnet}, ",")
+		envs[NOProxy] = noProxy
+		envs[strings.ToLower(NOProxy)] = noProxy
+	}
+	return envs
+}


### PR DESCRIPTION
…eamline node creation

fixes #689 

- slightly less code! 
- port creation and proxy details are more reusable for other providers
- subnets from the cluster network settings are now included in the NO_PROXY (#689)
- loadbalancer node is not privileged / doesn't overly re-use docker arguments from worker nodes
- should be more efficient (we recompute and re-query less things now)