### PR TITLE
updates rp_filter to 1

### DIFF
--- a/images/base/10-network-security.conf
+++ b/images/base/10-network-security.conf
@@ -1,0 +1,4 @@
+# Turn on Source Address Verification in all interfaces to
+# prevent some spoofing attacks.
+net.ipv4.conf.default.rp_filter=1
+net.ipv4.conf.all.rp_filter=1

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -76,9 +76,11 @@ RUN clean-install \
     && chmod +x /usr/local/bin/ctr \
     && echo "done installing packages"
 
+# override the rp_filter settings to enable calico cni to "just work"
+COPY 10-network-security.conf /etc/sysctl.d/
+
 # add overrides to containerd
 COPY 10-limits.conf 10-restart.conf /etc/systemd/system/containerd.service.d/
-
 # debug containerd version and create default config
 # additionally:
 # - disable some plugins we don't use / support

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -44,7 +44,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20190930-9e021be@sha256:80af283eb8c335a8a3a2bc65d12befc4f97e0aed48ea3847c320d51ffac20bf2"
+const DefaultBaseImage = "kindest/base:v20191001-fed614d9@sha256:43273bb2d3d8f1fd680879e216a176900073b2bbfd0297ec84048685e0e3fa00"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
This fixes #891 and changes the default rpfilter to 1 from 2 enabling folks to install calico without requiring any change to the node.

Signed-off-by: Duffie Cooley <cooleyd@vmware.com>