### PR TITLE
[WIP] get coverage data for all the things

### DIFF
--- a/hack/ci/e2e-smoke-coverage.sh
+++ b/hack/ci/e2e-smoke-coverage.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# hack script for running a kind e2e
+# must be run with a kubernetes checkout in $PWD (IE from the checkout)
+# Usage: SKIP="ginkgo skip regex" FOCUS="ginkgo focus regex" kind-e2e.sh
+
+set -o errexit -o nounset -o pipefail -o xtrace
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+# our exit handler (trap)
+cleanup() {
+  # remove our tempdir, this needs to be last, or it will prevent kind delete
+  [[ -n "${TMP_DIR:-}" ]] && rm -rf "${TMP_DIR:?}"
+}
+
+# install kind to a tempdir GOPATH from this script's kind checkout
+install_kind_with_coverage() {
+  mkdir -p "${TMP_DIR}/bin"
+  make -C "${REPO_ROOT}" install INSTALL_PATH="${TMP_DIR}/bin"
+
+  hack/go_container.sh go test -c -o /out/kind.covered -covermode count \
+    -coverpkg sigs.k8s.io/kind/... -tags=coverage ./pkg/internal/coverage
+  cp bin/kind.covered "${TMP_DIR}/bin/kind"
+
+  export PATH="${TMP_DIR}/bin:${PATH}"
+}
+
+main() {
+  # create temp dir and setup cleanup
+  TMP_DIR=$(mktemp -d)
+  trap cleanup EXIT
+
+  # install kind with coverage instrumentation
+  install_kind_with_coverage
+
+  # smoke test
+   
+}
+
+main

--- a/pkg/internal/coverage/coverage.go
+++ b/pkg/internal/coverage/coverage.go
@@ -1,0 +1,47 @@
+// +build !coverage
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"flag"
+	"testing"
+)
+
+// RunMainWithCoverage should be only once in a special TestMain to invoke
+// an app with coverage instrumentation
+// This binary must be built with go test -c -covermode -coverpkg ...
+func RunMainWithCoverage(main func(), outputPath string) {
+	defer writeCoverage(outputPath)
+	main()
+}
+
+func writeCoverage(outputPath string) {
+	// We're not actually going to run any tests, but we need Go to think we did so it writes
+	// coverage information to disk. To achieve this, we create a bunch of empty test suites and
+	// have it "run" them.
+	tests := []testing.InternalTest{}
+	benchmarks := []testing.InternalBenchmark{}
+	examples := []testing.InternalExample{}
+
+	var deps fakeTestDeps
+
+	_ = flag.CommandLine.Lookup("test.coverprofile").Value.Set(outputPath)
+	dummyRun := testing.MainStart(deps, tests, benchmarks, examples)
+	dummyRun.Run()
+}

--- a/pkg/internal/coverage/coverage_test.go
+++ b/pkg/internal/coverage/coverage_test.go
@@ -1,0 +1,31 @@
+// +build coverage
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"os"
+	"testing"
+
+	"sigs.k8s.io/kind/cmd/kind"
+)
+
+func TestMain(m *testing.M) {
+	// run the normal main, but with coverage!
+	RunMainWithCoverage(kind.Main, os.Getenv("COVERPROFILE"))
+}

--- a/pkg/internal/coverage/faketestdeps.go
+++ b/pkg/internal/coverage/faketestdeps.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"io"
+)
+
+// This is an implementation of testing.testDeps. It doesn't need to do anything, because
+// no tests are actually run. It does need a concrete implementation of at least ImportPath,
+// which is called unconditionally when running tests.
+type fakeTestDeps struct{}
+
+func (fakeTestDeps) ImportPath() string {
+	return ""
+}
+
+func (fakeTestDeps) MatchString(pat, str string) (bool, error) {
+	return false, nil
+}
+
+func (fakeTestDeps) StartCPUProfile(io.Writer) error {
+	return nil
+}
+
+func (fakeTestDeps) StopCPUProfile() {}
+
+func (fakeTestDeps) StartTestLog(io.Writer) {}
+
+func (fakeTestDeps) StopTestLog() error {
+	return nil
+}
+
+func (fakeTestDeps) WriteHeapProfile(io.Writer) error {
+	return nil
+}
+
+func (fakeTestDeps) WriteProfileTo(string, io.Writer, int) error {
+	return nil
+}

--- a/pkg/internal/coverage/faketestdeps.go
+++ b/pkg/internal/coverage/faketestdeps.go
@@ -1,3 +1,5 @@
+// +build !coverage
+
 /*
 Copyright 2018 The Kubernetes Authors.
 


### PR DESCRIPTION
- inspired by kubernetes's e2e coverage by @Katharine, implement e2e coverage for `kind`
- WIP: build and run this to collect coverage for a smoke test
- TODO: produce combined data with unit tests to get a more accurate picture
