### PR TITLE
tidy containerd config, make runtimeclass tests work

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -141,6 +141,10 @@ run_tests() {
 
   # setting this env prevents ginkgo e2e from trying to run provider setup
   export KUBERNETES_CONFORMANCE_TEST="y"
+  # setting these is required to make RuntimeClass tests work ...
+  export KUBE_CONTAINER_RUNTIME=remote
+  export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
+  export KUBE_CONTAINER_RUNTIME_NAME=containerd
   ./hack/ginkgo-e2e.sh \
     '--provider=skeleton' "--num-nodes=${NUM_NODES}" \
     "--ginkgo.focus=${FOCUS}" "--ginkgo.skip=${SKIP}" \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -92,9 +92,7 @@ RUN containerd --version \
     && echo '' >> /etc/containerd/config.toml \
     && echo '# Runtime handler used for runtime class test.' >> /etc/containerd/config.toml \
     && echo '[plugins.cri.containerd.runtimes.test-handler]' >> /etc/containerd/config.toml \
-    && echo '  runtime_type = "io.containerd.runtime.v1.linux"' >> /etc/containerd/config.toml \
-    && echo '' >> /etc/containerd/config.toml \
-    && containerd config default >> /etc/containerd/config.toml
+    && echo '  runtime_type = "io.containerd.runtime.v1.linux"' >> /etc/containerd/config.toml
 
 # Install CNI binaries to /opt/cni/bin
 # TODO(bentheelder): doc why / what here

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -44,7 +44,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20191001-fed614d9@sha256:43273bb2d3d8f1fd680879e216a176900073b2bbfd0297ec84048685e0e3fa00"
+const DefaultBaseImage = "kindest/base:v20191002-332e75a@sha256:56c010f61b34885e78eb4dd95823644a540d088cb2c5bd2a690dbe9ece7c5074"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
writing out the default config is pretty redundant, I think it's also interfering with the overrides we added. let's stop doing that.

also, we need to set some values for the e2e tests to make runtimeclass tests work with containerd (docker/dockershim is the assumed default)