### PR TITLE
cmd: check if cluster exists

### DIFF
--- a/cmd/kind/delete/cluster/deletecluster.go
+++ b/cmd/kind/delete/cluster/deletecluster.go
@@ -49,6 +49,15 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole) error {
+	// Check if the cluster name exists
+	known, err := cluster.IsKnown(flags.Name)
+	if err != nil {
+		return err
+	}
+	if !known {
+		return fmt.Errorf("unknown cluster with name %q", flags.Name)
+	}
+
 	// Delete the cluster
 	fmt.Printf("Deleting cluster %q ...\n", flags.Name)
 	ctx := cluster.NewContext(flags.Name)

--- a/cmd/kind/export/logs/logs.go
+++ b/cmd/kind/export/logs/logs.go
@@ -54,7 +54,7 @@ func runE(flags *flagpole, args []string) error {
 		return err
 	}
 	if !known {
-		return fmt.Errorf("unknown cluster %q", flags.Name)
+		return fmt.Errorf("unknown cluster with name %q", flags.Name)
 	}
 	// get the optional directory argument, or create a tempdir
 	var dir string

--- a/cmd/kind/get/kubeconfig/kubeconfig.go
+++ b/cmd/kind/get/kubeconfig/kubeconfig.go
@@ -58,6 +58,15 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole) error {
+	// Check if the cluster name exists
+	known, err := cluster.IsKnown(flags.Name)
+	if err != nil {
+		return err
+	}
+	if !known {
+		return fmt.Errorf("unknown cluster with name %q", flags.Name)
+	}
+
 	// get the bootstrap node to get the kubeconfig
 	cfg, err := cluster.NewContext(flags.Name).KubeConfig(flags.Internal)
 	if err != nil {

--- a/cmd/kind/get/kubeconfigpath/kubeconfigpath.go
+++ b/cmd/kind/get/kubeconfigpath/kubeconfigpath.go
@@ -52,6 +52,15 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole) error {
+	// Check if the cluster name exists
+	known, err := cluster.IsKnown(flags.Name)
+	if err != nil {
+		return err
+	}
+	if !known {
+		return fmt.Errorf("unknown cluster with name %q", flags.Name)
+	}
+
 	// Obtain the kubeconfig path for this cluster
 	fmt.Println(cluster.NewContext(flags.Name).KubeConfigPath())
 	return nil

--- a/cmd/kind/get/nodes/nodes.go
+++ b/cmd/kind/get/nodes/nodes.go
@@ -51,6 +51,15 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(flags *flagpole) error {
+	// Check if the cluster name exists
+	known, err := cluster.IsKnown(flags.Name)
+	if err != nil {
+		return err
+	}
+	if !known {
+		return fmt.Errorf("unknown cluster with name %q", flags.Name)
+	}
+
 	// List nodes by cluster context name
 	n, err := cluster.NewContext(flags.Name).ListNodes()
 	if err != nil {

--- a/cmd/kind/load/docker-image/docker-image.go
+++ b/cmd/kind/load/docker-image/docker-image.go
@@ -84,7 +84,7 @@ func runE(flags *flagpole, args []string) error {
 		return err
 	}
 	if !known {
-		return fmt.Errorf("unknown cluster %q", flags.Name)
+		return fmt.Errorf("unknown cluster with name %q", flags.Name)
 	}
 
 	context := cluster.NewContext(flags.Name)

--- a/cmd/kind/load/image-archive/image-archive.go
+++ b/cmd/kind/load/image-archive/image-archive.go
@@ -79,7 +79,7 @@ func runE(flags *flagpole, args []string) error {
 		return err
 	}
 	if !known {
-		return fmt.Errorf("unknown cluster %q", flags.Name)
+		return fmt.Errorf("unknown cluster with name %q", flags.Name)
 	}
 
 	context := cluster.NewContext(flags.Name)


### PR DESCRIPTION
We should check before executing any command if the cluster exists.
It also improves the error message if the cluster doesn't exist

Fixes #915 