### PR TITLE
Upgrade containerd with runc backport

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -76,7 +76,7 @@ COPY 10-network-security.conf /etc/sysctl.d/
 # Install containerd and runc binaries from kind-ci/containerd-nightlies repository
 # The repository contains latest stable releases and nightlies using golang's pseudo-version
 # CONTAINERD_VERSION=0.0.0-yyyymmddhhmmss-commitid
-ARG CONTAINERD_VERSION="1.3.0"
+ARG CONTAINERD_VERSION="0.0.0-20191007143651-efd38f48"
 ARG CONTAINERD_BASE_URL="https://github.com/kind-ci/containerd-nightlies/releases/download/"
 RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') \
     && export CONTAINERD_TARBALL="v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}.linux-${ARCH}.tar.gz" \

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -44,7 +44,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20191005-c339e13@sha256:e6724afe8d9eeba7f20003d33caa57e03e1bfaee8080b34aa08e336cb67779e7"
+const DefaultBaseImage = "kindest/base:v20191007-1cffcf6a@sha256:40be0daf06d96093badfa1c6ce028ef54dabc1bc05861ff53fa2f5d1e93b7597"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
this is containerd 1.3.0 + backports, built from the release/1.3 branch.

see https://github.com/containerd/containerd/commit/efd38f48