### PR TITLE
use containerd V2 runtime

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -86,23 +86,15 @@ RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/
     && rm -rf /tmp/containerd.tgz \
     && export RUNC_URL="${CONTAINERD_BASE_URL}v${CONTAINERD_VERSION}/runc.${ARCH}" \
     && curl -sSL --retry 5 --output /usr/local/sbin/runc "${RUNC_URL}" \
-    && chmod 755 /usr/local/sbin/runc
+    && chmod 755 /usr/local/sbin/runc \
+    && containerd --version
 
 # Install containerd systemd unit file
 COPY containerd.service /etc/systemd/system
 RUN systemctl enable containerd
-# debug containerd version and create default config
-# additionally:
-# - disable some plugins we don't use / support
-# - setup the "test-handler" used by kubernetes runtime class testing
-RUN containerd --version \
-    && mkdir -p /etc/containerd \
-    && echo "# disable plugins we don't / can't support" > /etc/containerd/config.toml \
-    && echo 'disabled_plugins = ["aufs", "btrfs", "zfs"]' >> /etc/containerd/config.toml \
-    && echo '' >> /etc/containerd/config.toml \
-    && echo '# Runtime handler used for runtime class test.' >> /etc/containerd/config.toml \
-    && echo '[plugins.cri.containerd.runtimes.test-handler]' >> /etc/containerd/config.toml \
-    && echo '  runtime_type = "io.containerd.runtime.v1.linux"' >> /etc/containerd/config.toml
+
+# configure containerd with some custom options
+COPY containerd-config.toml /etc/containerd/config.toml
 
 # Install CNI binaries to /opt/cni/bin
 # TODO(bentheelder): doc why / what here

--- a/images/base/containerd-config.toml
+++ b/images/base/containerd-config.toml
@@ -1,0 +1,11 @@
+# disable plugins we don't / can't support
+disabled_plugins = ["aufs", "btrfs", "zfs"]
+
+# set default runtime handler to v2, which has a per-pod shim
+[plugins.cri.containerd.default_runtime]
+  runtime_type="io.containerd.runc.v2"
+
+# Setup a runtime with the magic name ("test-handler") used for Kubernetes
+# runtime class tests ...
+[plugins.cri.containerd.runtimes.test-handler]
+  runtime_type = "io.containerd.runc.v2"

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -44,7 +44,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20191007-1cffcf6a@sha256:40be0daf06d96093badfa1c6ce028ef54dabc1bc05861ff53fa2f5d1e93b7597"
+const DefaultBaseImage = "kindest/base:v20191007-a067087@sha256:2b0845285c0b6ad517215e8338cd531de72c7962f980700808307552fd394ebe"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
- use an actual file for containerd config to make it easier to develop
- use the v2 runtime xref: https://github.com/containerd/cri/issues/1075