### PR TITLE
Remove virtuakube from alternatives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Some other open source projects with slightly different but overlapping use case
 - https://github.com/ubuntu/microk8s
 - https://github.com/kinvolk/kube-spawn
 - https://github.com/kubernetes/minikube
-- https://github.com/danderson/virtuakube
 - https://github.com/kubernetes-sigs/kubeadm-dind-cluster
 
 ### Code of conduct


### PR DESCRIPTION
I'm no longer developing virtuakube, and have archived the repository. There's no point in redirecting people to it any more :).