### PR TITLE
use 3 worker nodes when testing

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -79,9 +79,10 @@ nodes:
 - role: control-plane
 - role: worker
 - role: worker
+- role: worker
 EOF
   # NOTE: must match the number of workers above
-  NUM_NODES=2
+  NUM_NODES=3
   # actually create the cluster
   # TODO(BenTheElder): settle on verbosity for this script
   KIND_CREATE_ATTEMPTED=true


### PR DESCRIPTION
some (apparently not marked `[Disruptive]`) kubernetes e2e tests taint nodes https://kubernetes.slack.com/archives/C9NK9KFFW/p1570579690028300
https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/node/wait_test.go

this can cause other tests that need two schedulable nodes available to flake.

https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/83583/pull-kubernetes-e2e-kind/1181655966865690625


the pull-kubernetes-e2e-gce presubmit appears to use 3 worker nodes

as much as I'd like to keep testing as cheap as possible, we should try upping to 3 workers to reach parity..