### PR TITLE
RFC - Attaching cluster nodes to complex upstream networks

### DIFF
--- a/pkg/apis/config/v1alpha3/types.go
+++ b/pkg/apis/config/v1alpha3/types.go
@@ -81,6 +81,8 @@ type Node struct {
 
 	// Loopback IP.
 	Loopback string `json:"loopback,omitempty"`
+
+	Routes []string `json:"routes,omitempty"`
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/apis/config/v1alpha3/types.go
+++ b/pkg/apis/config/v1alpha3/types.go
@@ -75,6 +75,9 @@ type Node struct {
 	// ExtraPortMappings describes additional port mappings for the node container
 	// binded to a host Port
 	ExtraPortMappings []cri.PortMapping `json:"extraPortMappings,omitempty"`
+
+	// Docker networks to attach to.  Defaults to the Docker default ("bridge").
+	Networks []string `json:"networks,omitempty"`
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/apis/config/v1alpha3/types.go
+++ b/pkg/apis/config/v1alpha3/types.go
@@ -78,6 +78,9 @@ type Node struct {
 
 	// Docker networks to attach to.  Defaults to the Docker default ("bridge").
 	Networks []string `json:"networks,omitempty"`
+
+	// Loopback IP.
+	Loopback string `json:"loopback,omitempty"`
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/apis/config/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha3/zz_generated.deepcopy.go
@@ -102,6 +102,11 @@ func (in *Node) DeepCopyInto(out *Node) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Routes != nil {
+		in, out := &in.Routes, &out.Routes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/config/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha3/zz_generated.deepcopy.go
@@ -97,6 +97,11 @@ func (in *Node) DeepCopyInto(out *Node) {
 		*out = make([]cri.PortMapping, len(*in))
 		copy(*out, *in)
 	}
+	if in.Networks != nil {
+		in, out := &in.Networks, &out.Networks
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/cluster/constants/constants.go
+++ b/pkg/cluster/constants/constants.go
@@ -27,6 +27,7 @@ const ClusterLabelKey = "io.k8s.sigs.kind.cluster"
 // of nodes by role
 const NodeRoleKey = "io.k8s.sigs.kind.role"
 const NodeLoopbackKey = "io.k8s.sigs.kind.loopback"
+const NodeRoutesKey = "io.k8s.sigs.kind.routes"
 
 /* node role value constants */
 const (

--- a/pkg/cluster/constants/constants.go
+++ b/pkg/cluster/constants/constants.go
@@ -26,6 +26,7 @@ const ClusterLabelKey = "io.k8s.sigs.kind.cluster"
 // NodeRoleKey is applied to each "node" docker container for categorization
 // of nodes by role
 const NodeRoleKey = "io.k8s.sigs.kind.role"
+const NodeLoopbackKey = "io.k8s.sigs.kind.loopback"
 
 /* node role value constants */
 const (

--- a/pkg/cluster/nodes/types.go
+++ b/pkg/cluster/nodes/types.go
@@ -29,6 +29,7 @@ type Node interface {
 	String() string // see also: fmt.Stringer
 	// Role should return the node's role
 	Role() (string, error) // see also: pkg/cluster/constants
+	Loopback() (string, error) // see also: pkg/cluster/constants
 	// TODO(bentheelder): should return node addresses more generally
 	// Possibly remove this method in favor of obtaining this detail with
 	// exec or from the provider

--- a/pkg/cluster/nodes/types.go
+++ b/pkg/cluster/nodes/types.go
@@ -28,8 +28,9 @@ type Node interface {
 	// String should return the node name
 	String() string // see also: fmt.Stringer
 	// Role should return the node's role
-	Role() (string, error) // see also: pkg/cluster/constants
+	Role() (string, error)     // see also: pkg/cluster/constants
 	Loopback() (string, error) // see also: pkg/cluster/constants
+	Routes() (string, error)   // see also: pkg/cluster/constants
 	// TODO(bentheelder): should return node addresses more generally
 	// Possibly remove this method in favor of obtaining this detail with
 	// exec or from the provider

--- a/pkg/internal/apis/config/encoding/scheme.go
+++ b/pkg/internal/apis/config/encoding/scheme.go
@@ -17,6 +17,7 @@ limitations under the License.
 package encoding
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -82,6 +83,7 @@ func Load(path string) (*config.Cluster, error) {
 		if err != nil {
 			return nil, err
 		}
+		fmt.Printf("cfg: \n%v\n", string(contents))
 
 		// decode data into a internal api Config object because
 		// to leverage on conversion functions for all the api versions
@@ -92,6 +94,7 @@ func Load(path string) (*config.Cluster, error) {
 		}
 
 		// converts back to the latest API version to apply defaults
+		fmt.Printf("cfg: %v\n", *cfg)
 		if err := Scheme.Convert(cfg, latestPublicConfig, nil); err != nil {
 			return nil, err
 		}

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -77,6 +77,9 @@ type Node struct {
 
 	// Docker networks to attach to.  Defaults to the Docker default ("bridge").
 	Networks []string
+
+	// Loopback IP.
+	Loopback string
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -80,6 +80,8 @@ type Node struct {
 
 	// Loopback IP.
 	Loopback string
+
+	Routes []string
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -74,6 +74,9 @@ type Node struct {
 	// ExtraPortMappings describes additional port mappings for the node container
 	// binded to a host Port
 	ExtraPortMappings []cri.PortMapping
+
+	// Docker networks to attach to.  Defaults to the Docker default ("bridge").
+	Networks []string
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/internal/apis/config/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/config/v1alpha3/zz_generated.conversion.go
@@ -146,6 +146,7 @@ func autoConvert_v1alpha3_Node_To_config_Node(in *v1alpha3.Node, out *config.Nod
 	out.ExtraMounts = *(*[]cri.Mount)(unsafe.Pointer(&in.ExtraMounts))
 	out.ExtraPortMappings = *(*[]cri.PortMapping)(unsafe.Pointer(&in.ExtraPortMappings))
 	out.Networks = *(*[]string)(unsafe.Pointer(&in.Networks))
+	out.Loopback = in.Loopback
 	return nil
 }
 
@@ -160,6 +161,7 @@ func autoConvert_config_Node_To_v1alpha3_Node(in *config.Node, out *v1alpha3.Nod
 	out.ExtraMounts = *(*[]cri.Mount)(unsafe.Pointer(&in.ExtraMounts))
 	out.ExtraPortMappings = *(*[]cri.PortMapping)(unsafe.Pointer(&in.ExtraPortMappings))
 	out.Networks = *(*[]string)(unsafe.Pointer(&in.Networks))
+	out.Loopback = in.Loopback
 	return nil
 }
 

--- a/pkg/internal/apis/config/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/config/v1alpha3/zz_generated.conversion.go
@@ -145,6 +145,7 @@ func autoConvert_v1alpha3_Node_To_config_Node(in *v1alpha3.Node, out *config.Nod
 	out.Image = in.Image
 	out.ExtraMounts = *(*[]cri.Mount)(unsafe.Pointer(&in.ExtraMounts))
 	out.ExtraPortMappings = *(*[]cri.PortMapping)(unsafe.Pointer(&in.ExtraPortMappings))
+	out.Networks = *(*[]string)(unsafe.Pointer(&in.Networks))
 	return nil
 }
 
@@ -158,6 +159,7 @@ func autoConvert_config_Node_To_v1alpha3_Node(in *config.Node, out *v1alpha3.Nod
 	out.Image = in.Image
 	out.ExtraMounts = *(*[]cri.Mount)(unsafe.Pointer(&in.ExtraMounts))
 	out.ExtraPortMappings = *(*[]cri.PortMapping)(unsafe.Pointer(&in.ExtraPortMappings))
+	out.Networks = *(*[]string)(unsafe.Pointer(&in.Networks))
 	return nil
 }
 

--- a/pkg/internal/apis/config/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/config/v1alpha3/zz_generated.conversion.go
@@ -147,6 +147,7 @@ func autoConvert_v1alpha3_Node_To_config_Node(in *v1alpha3.Node, out *config.Nod
 	out.ExtraPortMappings = *(*[]cri.PortMapping)(unsafe.Pointer(&in.ExtraPortMappings))
 	out.Networks = *(*[]string)(unsafe.Pointer(&in.Networks))
 	out.Loopback = in.Loopback
+	out.Routes = *(*[]string)(unsafe.Pointer(&in.Routes))
 	return nil
 }
 
@@ -162,6 +163,7 @@ func autoConvert_config_Node_To_v1alpha3_Node(in *config.Node, out *v1alpha3.Nod
 	out.ExtraPortMappings = *(*[]cri.PortMapping)(unsafe.Pointer(&in.ExtraPortMappings))
 	out.Networks = *(*[]string)(unsafe.Pointer(&in.Networks))
 	out.Loopback = in.Loopback
+	out.Routes = *(*[]string)(unsafe.Pointer(&in.Routes))
 	return nil
 }
 

--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"net"
 
 	"sigs.k8s.io/kind/pkg/errors"
@@ -49,6 +50,7 @@ func (c *Cluster) Validate() error {
 	numByRole := make(map[NodeRole]int32)
 	// All nodes in the config should be valid
 	for i, n := range c.Nodes {
+		fmt.Printf("Node %d: %v\n", i, n)
 		// validate the node
 		if err := n.Validate(); err != nil {
 			errs = append(errs, errors.Errorf("invalid configuration for node %d: %v", i, err))

--- a/pkg/internal/apis/config/zz_generated.deepcopy.go
+++ b/pkg/internal/apis/config/zz_generated.deepcopy.go
@@ -102,6 +102,11 @@ func (in *Node) DeepCopyInto(out *Node) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Routes != nil {
+		in, out := &in.Routes, &out.Routes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/internal/apis/config/zz_generated.deepcopy.go
+++ b/pkg/internal/apis/config/zz_generated.deepcopy.go
@@ -97,6 +97,11 @@ func (in *Node) DeepCopyInto(out *Node) {
 		*out = make([]cri.PortMapping, len(*in))
 		copy(*out, *in)
 	}
+	if in.Networks != nil {
+		in, out := &in.Networks, &out.Networks
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/internal/cluster/create/actions/loopback/loopback.go
+++ b/pkg/internal/cluster/create/actions/loopback/loopback.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubeadminit implements the kubeadm init action
+package loopback
+
+import (
+	"fmt"
+	"sigs.k8s.io/kind/pkg/errors"
+	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions"
+)
+
+// kubeadmInitAction implements action for executing the kubadm init
+// and a set of default post init operations like e.g. install the
+// CNI network plugin.
+type action struct{}
+
+// NewAction returns a new action for kubeadm init
+func NewAction() actions.Action {
+	return &action{}
+}
+
+// Execute runs the action
+func (a *action) Execute(ctx *actions.ActionContext) error {
+	allNodes, err := ctx.Nodes()
+	if err != nil {
+		return err
+	}
+
+	for _, node := range allNodes {
+		loopAddress, err := node.Loopback()
+		if err != nil {
+			fmt.Printf("Loopback action error: %v\n", err)
+			continue
+		}
+		if loopAddress != "" {
+			fmt.Printf("Add loopback %v for node %v\n", loopAddress, node)
+			cmd := node.Command(
+				"ip",
+				"a",
+				"a",
+				loopAddress + "/32",
+				"dev",
+				"lo",
+			)
+			err := cmd.Run()
+			if err != nil {
+				return errors.Wrap(err, "failed to set loopback address")
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/internal/cluster/create/create.go
+++ b/pkg/internal/cluster/create/create.go
@@ -95,7 +95,7 @@ func Cluster(ctx *context.Context, options ...create.ClusterOption) error {
 	// TODO(bentheelder): make this controllable from the command line?
 	actionsToRun := []actions.Action{
 		loadbalancer.NewAction(), // setup external loadbalancer
-		loopback.NewAction(),	  // add loopback addresses
+		loopback.NewAction(),     // add loopback addresses
 		configaction.NewAction(), // setup kubeadm config
 	}
 	if opts.SetupKubernetes {

--- a/pkg/internal/cluster/create/create.go
+++ b/pkg/internal/cluster/create/create.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions/kubeadminit"
 	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions/kubeadmjoin"
 	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions/loadbalancer"
+	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions/loopback"
 	"sigs.k8s.io/kind/pkg/internal/cluster/create/actions/waitforready"
 )
 
@@ -94,6 +95,7 @@ func Cluster(ctx *context.Context, options ...create.ClusterOption) error {
 	// TODO(bentheelder): make this controllable from the command line?
 	actionsToRun := []actions.Action{
 		loadbalancer.NewAction(), // setup external loadbalancer
+		loopback.NewAction(),	  // add loopback addresses
 		configaction.NewAction(), // setup kubeadm config
 	}
 	if opts.SetupKubernetes {

--- a/pkg/internal/cluster/providers/docker/node.go
+++ b/pkg/internal/cluster/providers/docker/node.go
@@ -65,7 +65,9 @@ func (n *node) IP() (ipv4 string, ipv6 string, err error) {
 	}
 	ips := strings.Split(lines[0], ",")
 	if len(ips) != 2 {
-		return "", "", errors.Errorf("container addresses should have 2 values, got %d values", len(ips))
+		//return "", "", errors.Errorf("container addresses should have 2 values, got %d values", len(ips))
+		fmt.Printf("%v: %#v\n", n.name, ips)
+		return ips[0], "", nil
 	}
 	return ips[0], ips[1], nil
 }

--- a/pkg/internal/cluster/providers/docker/node.go
+++ b/pkg/internal/cluster/providers/docker/node.go
@@ -57,10 +57,25 @@ func (n *node) Loopback() (string, error) {
 	)
 	lines, err := exec.OutputLines(cmd)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get role for node")
+		return "", errors.Wrap(err, "failed to get loopback for node")
 	}
 	if len(lines) != 1 {
-		return "", errors.Errorf("failed to get role for node: output lines %d != 1", len(lines))
+		return "", errors.Errorf("failed to get loopback for node: output lines %d != 1", len(lines))
+	}
+	return lines[0], nil
+}
+
+func (n *node) Routes() (string, error) {
+	cmd := exec.Command("docker", "inspect",
+		"--format", fmt.Sprintf(`{{ index .Config.Labels "%s"}}`, constants.NodeRoutesKey),
+		n.name,
+	)
+	lines, err := exec.OutputLines(cmd)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get routes for node")
+	}
+	if len(lines) != 1 {
+		return "", errors.Errorf("failed to get routes for node: output lines %d != 1", len(lines))
 	}
 	return lines[0], nil
 }

--- a/pkg/internal/cluster/providers/docker/provision.go
+++ b/pkg/internal/cluster/providers/docker/provision.go
@@ -177,6 +177,10 @@ func runArgsForNode(node *config.Node, name string, args []string) []string {
 	args = append(args, generateMountBindings(node.ExtraMounts...)...)
 	args = append(args, generatePortMappings(node.ExtraPortMappings...)...)
 
+	if len(node.Networks) > 0 {
+		args = append(args, "--network", node.Networks[0])
+	}
+
 	// finally, specify the image to run
 	return append(args, node.Image)
 }

--- a/pkg/internal/cluster/providers/docker/provision.go
+++ b/pkg/internal/cluster/providers/docker/provision.go
@@ -170,8 +170,9 @@ func runArgsForNode(node *config.Node, name string, args []string) []string {
 		"run",
 		"--hostname", name, // make hostname match container name
 		"--name", name, // ... and set the container name
-		// label the node with the role ID
+		// label the node with the role ID and loopback
 		"--label", fmt.Sprintf("%s=%s", constants.NodeRoleKey, node.Role),
+		"--label", fmt.Sprintf("%s=%s", constants.NodeLoopbackKey, node.Loopback),
 		// running containers in a container requires privileged
 		// NOTE: we could try to replicate this with --cap-add, and use less
 		// privileges, but this flag also changes some mounts that are necessary

--- a/pkg/internal/cluster/providers/docker/provision.go
+++ b/pkg/internal/cluster/providers/docker/provision.go
@@ -173,6 +173,7 @@ func runArgsForNode(node *config.Node, name string, args []string) []string {
 		// label the node with the role ID and loopback
 		"--label", fmt.Sprintf("%s=%s", constants.NodeRoleKey, node.Role),
 		"--label", fmt.Sprintf("%s=%s", constants.NodeLoopbackKey, node.Loopback),
+		"--label", fmt.Sprintf("%s=%s", constants.NodeRoutesKey, strings.Join(node.Routes, ",")),
 		// running containers in a container requires privileged
 		// NOTE: we could try to replicate this with --cap-add, and use less
 		// privileges, but this flag also changes some mounts that are necessary


### PR DESCRIPTION
Hi - this is a collection of hackery that I've developed in order to model a Kubernetes cluster that is split across racks, and with redundant planes of connectivity between all the nodes.

- Splitting across racks means we need to be able to specify a Docker network to attach each node to, instead of assuming the default 'bridge'.

- Redundant planes of connectivity means:
  - We want to be able to attach each node to multiple specified Docker networks.
  - We want to configure a loopback address for each node (i.e. an address that is not tied to a particular network) and arrange for those addresses to be used as source and destination IPs by Kubernetes, instead of interface-specific addresses.
  - As part of the previous point, we need to add routing for the loopback addresses, after the node containers have been created and before kubeadm starts running.

Here's an example config with the new fields I've added support for:
```
kind: Cluster
apiVersion: kind.sigs.k8s.io/v1alpha3
networking:
  disableDefaultCNI: true
nodes:
- role: control-plane
  networks: [ra1, ra2]
  loopback: 172.31.10.3
  routes:
  - "172.31.10.0/24 src 172.31.10.3 nexthop dev eth0 nexthop dev eth1"
  - "172.31.20.0/24 src 172.31.10.3 nexthop via 172.31.11.1 nexthop via 172.31.12.1"
- role: worker
  networks: [ra1, ra2]
  loopback: 172.31.10.4
  routes:
  - "172.31.10.0/24 src 172.31.10.4 nexthop dev eth0 nexthop dev eth1"
  - "172.31.20.0/24 src 172.31.10.4 nexthop via 172.31.11.1 nexthop via 172.31.12.1"
- role: worker
  networks: [rb1, rb2]
  loopback: 172.31.20.3
  routes:
  - "172.31.20.0/24 src 172.31.20.3 nexthop dev eth0 nexthop dev eth1"
  - "172.31.10.0/24 src 172.31.20.3 nexthop via 172.31.21.1 nexthop via 172.31.22.1"
- role: worker
  networks: [rb1, rb2]
  loopback: 172.31.20.4
  routes:
  - "172.31.20.0/24 src 172.31.20.4 nexthop dev eth0 nexthop dev eth1"
  - "172.31.10.0/24 src 172.31.20.4 nexthop via 172.31.21.1 nexthop via 172.31.22.1"
```

I'm sure I haven't done this all right first time, but I guess that enhancements like these will be of wider interest than just for me.  Hence I'm posting this as an RFC to ask if it would make sense to upstream this kind of support, and if so to get your advice on how to put into a potentially mergeable form.