### PR TITLE
use normal containerd version strings, update containerd with latest patches

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -74,18 +74,15 @@ RUN clean-install \
 COPY 10-network-security.conf /etc/sysctl.d/
 
 # Install containerd and runc binaries from kind-ci/containerd-nightlies repository
-# The repository contains latest stable releases and nightlies using golang's pseudo-version
-# CONTAINERD_VERSION=0.0.0-yyyymmddhhmmss-commitid
-ARG CONTAINERD_VERSION="0.0.0-20191007143651-efd38f48"
-ARG CONTAINERD_BASE_URL="https://github.com/kind-ci/containerd-nightlies/releases/download/"
+# The repository contains latest stable releases and nightlies built for multiple architectures
+ARG CONTAINERD_VERSION="v1.3.0-7-g0b43a311"
+ARG CONTAINERD_BASE_URL="https://github.com/kind-ci/containerd-nightlies/releases/download"
 RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') \
-    && export CONTAINERD_TARBALL="v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}.linux-${ARCH}.tar.gz" \
-    && export CONTAINERD_URL="${CONTAINERD_BASE_URL}${CONTAINERD_TARBALL}" \
-    && curl -sSL --retry 5 --output /tmp/containerd.tgz "${CONTAINERD_URL}" \
+    && export RELEASE_BASE_URL="${CONTAINERD_BASE_URL}/containerd-${CONTAINERD_VERSION#v}" \
+    && curl -sSL --retry 5 --output /tmp/containerd.tgz "${RELEASE_BASE_URL}/containerd-${CONTAINERD_VERSION#v}.linux-${ARCH}.tar.gz" \
     && tar -C /usr/local -xzf /tmp/containerd.tgz \
     && rm -rf /tmp/containerd.tgz \
-    && export RUNC_URL="${CONTAINERD_BASE_URL}v${CONTAINERD_VERSION}/runc.${ARCH}" \
-    && curl -sSL --retry 5 --output /usr/local/sbin/runc "${RUNC_URL}" \
+    && curl -sSL --retry 5 --output /usr/local/sbin/runc "${RELEASE_BASE_URL}/runc.${ARCH}" \
     && chmod 755 /usr/local/sbin/runc \
     && containerd --version
 

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.16.1@sha256:fa06fad0f635401fc0822ae8ad4d81d2b79d8481fc3223c5f48b36d4369d6da6"
+const Image = "kindest/node:v1.16.1@sha256:6549b95fe2e4a110d965e0887b3344499655a50d44936aafbe170de006767e94"

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -44,7 +44,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20191007-a067087@sha256:2b0845285c0b6ad517215e8338cd531de72c7962f980700808307552fd394ebe"
+const DefaultBaseImage = "kindest/base:v20191009-d5ae74fc@sha256:0248d03663ae29d47b2bb64fee816a0602fd461f7b93879d5451021cad529593"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
containerd had a minor patch to release 1.3 since our last update.

however, I'm most interested in managing this using normal upstream version strings that we can compare to upstream.

basically these are `git describe`. we patched this in the kind-ci/containerd-nightly CI infrastructure.

i've bumped the base / node image to pick this up.