### PR TITLE
temporarily bypass docker hub in kubernetes CI

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -45,7 +45,8 @@ build_with_bazel() {
   fi
 
   # build the node image w/ kubernetes
-  kind build node-image --type=bazel --kube-root="$(go env GOPATH)/src/k8s.io/kubernetes"
+  # TODO(bentheelder): remove this emergency workaround (bypassing docker hub outage)
+  kind build node-image --type=bazel --kube-root="$(go env GOPATH)/src/k8s.io/kubernetes" --base-image=gcr.io/bentheelder-kind-dev/kindest/base:v20191009-d5ae74fc
   # make sure we have e2e requirements
   bazel build //cmd/kubectl //test/e2e:e2e.test //vendor/github.com/onsi/ginkgo/ginkgo
 
@@ -61,7 +62,8 @@ build_with_bazel() {
 # build kubernetes / node image, e2e binaries
 build() {
   # build the node image w/ kubernetes
-  kind build node-image --kube-root="$(go env GOPATH)/src/k8s.io/kubernetes"
+  # TODO(bentheelder): remove this emergency workaround (bypassing docker hub outage)
+  kind build node-image --kube-root="$(go env GOPATH)/src/k8s.io/kubernetes" --base-image=gcr.io/bentheelder-kind-dev/kindest/base:v20191009-d5ae74fc
   # make sure we have e2e requirements
   make all WHAT='cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo'
 }

--- a/hack/go_container.sh
+++ b/hack/go_container.sh
@@ -30,7 +30,8 @@ SOURCE_DIR="${SOURCE_DIR:-$(pwd -P)}"
 # default to disabling CGO for easier reproducible builds and cross compilation
 export CGO_ENABLED="${CGO_ENABLED:-0}"
 # the container image, by default a recent official golang image
-GOIMAGE="${GOIMAGE:-golang:1.13.1}"
+# TODO: remove temporary work around for docker hub outage in favor of long term plan
+GOIMAGE="${GOIMAGE:-gcr.io/bentheelder-kind-dev/golang:1.13.1}"
 # docker volume name, used as a go module / build cache
 CACHE_VOLUME="${CACHE_VOLUME:-kind-build-cache}"
 # ========================== END SCRIPT SETTINGS ===============================


### PR DESCRIPTION
/priority critical urgent

I mirrored the base image and golang so we can avoid breaking kubernetes CI until we work out a longer term infra solution.