### PR TITLE
Revert "Merge pull request #951 from BenTheElder/docker-hub-is-down"

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -45,8 +45,7 @@ build_with_bazel() {
   fi
 
   # build the node image w/ kubernetes
-  # TODO(bentheelder): remove this emergency workaround (bypassing docker hub outage)
-  kind build node-image --type=bazel --kube-root="$(go env GOPATH)/src/k8s.io/kubernetes" --base-image=gcr.io/bentheelder-kind-dev/kindest/base:v20191009-d5ae74fc
+  kind build node-image --type=bazel --kube-root="$(go env GOPATH)/src/k8s.io/kubernetes"
   # make sure we have e2e requirements
   bazel build //cmd/kubectl //test/e2e:e2e.test //vendor/github.com/onsi/ginkgo/ginkgo
 
@@ -62,8 +61,7 @@ build_with_bazel() {
 # build kubernetes / node image, e2e binaries
 build() {
   # build the node image w/ kubernetes
-  # TODO(bentheelder): remove this emergency workaround (bypassing docker hub outage)
-  kind build node-image --kube-root="$(go env GOPATH)/src/k8s.io/kubernetes" --base-image=gcr.io/bentheelder-kind-dev/kindest/base:v20191009-d5ae74fc
+  kind build node-image --kube-root="$(go env GOPATH)/src/k8s.io/kubernetes"
   # make sure we have e2e requirements
   make all WHAT='cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo'
 }

--- a/hack/go_container.sh
+++ b/hack/go_container.sh
@@ -30,8 +30,7 @@ SOURCE_DIR="${SOURCE_DIR:-$(pwd -P)}"
 # default to disabling CGO for easier reproducible builds and cross compilation
 export CGO_ENABLED="${CGO_ENABLED:-0}"
 # the container image, by default a recent official golang image
-# TODO: remove temporary work around for docker hub outage in favor of long term plan
-GOIMAGE="${GOIMAGE:-gcr.io/bentheelder-kind-dev/golang:1.13.1}"
+GOIMAGE="${GOIMAGE:-golang:1.13.1}"
 # docker volume name, used as a go module / build cache
 CACHE_VOLUME="${CACHE_VOLUME:-kind-build-cache}"
 # ========================== END SCRIPT SETTINGS ===============================


### PR DESCRIPTION
This reverts commit c151aa050a47db37694ad33f0cadd7e17893d587, reversing
changes made to 75a2bc966bb17c52234aa93aa2ddfd8c57c37ad2.

docker hub is back up, and this was a hack.

we did keep it to only one broken kubernetes presubmit run though (which I retested) :-)