### PR TITLE
update containerd config

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -84,7 +84,8 @@ RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/
     && rm -rf /tmp/containerd.tgz \
     && curl -sSL --retry 5 --output /usr/local/sbin/runc "${RELEASE_BASE_URL}/runc.${ARCH}" \
     && chmod 755 /usr/local/sbin/runc \
-    && containerd --version
+    && containerd --version \
+    && mkdir -p /etc/containerd/user
 
 # Install containerd systemd unit file
 COPY containerd.service /etc/systemd/system

--- a/images/base/containerd-config.toml
+++ b/images/base/containerd-config.toml
@@ -2,10 +2,11 @@
 disabled_plugins = ["aufs", "btrfs", "zfs"]
 
 # set default runtime handler to v2, which has a per-pod shim
-[plugins.cri.containerd.default_runtime]
-  runtime_type="io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd]
+  default_runtime_name="runc"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
 
-# Setup a runtime with the magic name ("test-handler") used for Kubernetes
-# runtime class tests ...
+# Setup a runtime with the magic name ("test-handler") for runtime class tests
 [plugins.cri.containerd.runtimes.test-handler]
   runtime_type = "io.containerd.runc.v2"

--- a/images/base/containerd-config.toml
+++ b/images/base/containerd-config.toml
@@ -1,6 +1,10 @@
 # disable plugins we don't / can't support
 disabled_plugins = ["aufs", "btrfs", "zfs"]
 
+# import any additional config files written by kind, and any user written
+# config files (/etc/containerd/user-config/*.toml)
+imports = ["/kind/containerd/*.toml", "/etc/containerd/user/*.toml"]
+
 # set default runtime handler to v2, which has a per-pod shim
 [plugins."io.containerd.grpc.v1.cri".containerd]
   default_runtime_name="runc"
@@ -10,3 +14,4 @@ disabled_plugins = ["aufs", "btrfs", "zfs"]
 # Setup a runtime with the magic name ("test-handler") for runtime class tests
 [plugins.cri.containerd.runtimes.test-handler]
   runtime_type = "io.containerd.runc.v2"
+

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.16.1@sha256:1b59f5d62b2f49c439ee29a9146d012b73255169e88f9acaca9e9ba610511380"
+const Image = "kindest/node:v1.16.2@sha256:c35eed9b4bc9dc89f1fada842baeb458ed598f89d57092e15930043f24ebafea"

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -44,7 +44,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20191009-d5ae74fc@sha256:0248d03663ae29d47b2bb64fee816a0602fd461f7b93879d5451021cad529593"
+const DefaultBaseImage = "kindest/base:v20191016-28ca7e64@sha256:3726a161a9ead7a451aec58d4461cd46b9ba6ecf344c0ce43439040114caee26"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
- use non-deprecated config options for default CRI runtime (see https://github.com/containerd/containerd/releases/tag/v1.3.0)
- enable config imports (added in v1.3.0) which allow creating partial config file drop-ins that are merged with the main config file xref https://github.com/kubernetes-sigs/kind/issues/110