### PR TITLE
WIP: Added kind get images subcommand

### DIFF
--- a/cmd/kind/get/get.go
+++ b/cmd/kind/get/get.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/cmd/kind/get/clusters"
+	"sigs.k8s.io/kind/cmd/kind/get/images"
 	"sigs.k8s.io/kind/cmd/kind/get/kubeconfig"
 	"sigs.k8s.io/kind/cmd/kind/get/kubeconfigpath"
 	"sigs.k8s.io/kind/cmd/kind/get/nodes"
@@ -37,8 +38,9 @@ func NewCommand() *cobra.Command {
 	}
 	// add subcommands
 	cmd.AddCommand(clusters.NewCommand())
-	cmd.AddCommand(nodes.NewCommand())
+	cmd.AddCommand(images.NewCommand())
 	cmd.AddCommand(kubeconfig.NewCommand())
 	cmd.AddCommand(kubeconfigpath.NewCommand())
+	cmd.AddCommand(nodes.NewCommand())
 	return cmd
 }

--- a/cmd/kind/get/images/dockerhub.go
+++ b/cmd/kind/get/images/dockerhub.go
@@ -1,0 +1,108 @@
+package images
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+)
+
+const DockerHubAuthURLBase = "https://auth.docker.io/token"
+const DockerHubAPIURLBase = "https://registry.hub.docker.com/v2/"
+
+type DockerHubAuthResponse struct {
+	Token       string `json:"token"`
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"` // It's always 300 (sec) at this moment
+}
+
+type DockerHubTagsResponse struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+func constructDockerHubAuthURL(image string) (string, error) {
+	u, err := url.Parse(DockerHubAuthURLBase)
+	if err != nil {
+		return "", err
+	}
+
+	q := u.Query()
+	q.Set("service", "registry.docker.io")
+	q.Set("scope", fmt.Sprintf("repository:%s:pull", image))
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}
+
+func constructDockerHubAPIURL(image string) (string, error) {
+	u, err := url.Parse(DockerHubAPIURLBase)
+	if err != nil {
+		return "", err
+	}
+
+	u.Path = path.Join(u.Path, image, "tags/list")
+
+	return u.String(), nil
+}
+
+func retrieveDockerHubAuthToken(image string) (string, error) {
+	url, err := constructDockerHubAuthURL(image)
+	if err != nil {
+		return "", err
+	}
+
+	var body string
+	if os.Getenv("DOCKERHUB_USERNAME") != "" && os.Getenv("DOCKERHUB_PASSWORD") != "" {
+		body, err = httpGet(url, "", &BasicAuthInfo{
+			Username: os.Getenv("DOCKERHUB_USERNAME"),
+			Password: os.Getenv("DOCKERHUB_PASSWORD"),
+		})
+	} else {
+		body, err = httpGet(url, "", nil)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	var resp DockerHubAuthResponse
+
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		return "", err
+	}
+
+	return resp.AccessToken, nil
+}
+
+func retrieveFromDockerHub(image string) ([]string, error) {
+	dockerHubAccessToken, err := retrieveDockerHubAuthToken(image)
+	if err != nil {
+		return nil, err
+	}
+
+	dockerHubAPIURL, err := constructDockerHubAPIURL(image)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := httpGet(dockerHubAPIURL, dockerHubAccessToken, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp DockerHubTagsResponse
+
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		return nil, err
+	}
+
+	tags := resp.Tags
+
+	// Reverse the order of the tags to make it ordered as: "latest => oldest"
+	for i, j := 0, len(tags)-1; i < j; i, j = i+1, j-1 {
+		tags[i], tags[j] = tags[j], tags[i]
+	}
+
+	return tags, nil
+}

--- a/cmd/kind/get/images/images.go
+++ b/cmd/kind/get/images/images.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package images implements the `images` command
+package images
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type flagpole struct {
+	Name string
+}
+
+// NewCommand returns a new cobra.Command for getting the list of nodes for a given cluster
+func NewCommand() *cobra.Command {
+	flags := &flagpole{}
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "images",
+		Short: "lists official kind node images by tag",
+		Long:  "lists official kind node images by tag",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(flags)
+		},
+	}
+	return cmd
+}
+
+func runE(flags *flagpole) error {
+	// List images available in dockerhub.
+	image := "kindest/node"
+	i, err := retrieveFromDockerHub(image)
+	if err != nil {
+		return err
+	}
+	for _, tag := range i {
+		fmt.Printf("%s:%s\n", image, tag)
+	}
+	return nil
+}

--- a/cmd/kind/get/images/util.go
+++ b/cmd/kind/get/images/util.go
@@ -1,0 +1,41 @@
+package images
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type BasicAuthInfo struct {
+	Username string
+	Password string
+}
+
+func httpGet(url, apiToken string, basicAuth *BasicAuthInfo) (string, error) {
+	req, _ := http.NewRequest("GET", url, nil)
+	if apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+apiToken)
+	}
+
+	if basicAuth != nil {
+		req.SetBasicAuth(basicAuth.Username, basicAuth.Password)
+	}
+
+	client := new(http.Client)
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP error!\nURL: %s\nstatus code: %d\nbody:\n%s\n", url, resp.StatusCode, string(b))
+	}
+
+	return string(b), nil
+}


### PR DESCRIPTION
This code is heavily borrowed from: https://github.com/wantedly/dockertags/
The use case here is to list available official image versions hosted at
https://hub.docker.com/r/kindest/node/tags from the cli so that folks
can determine what images are available.

Signed-off-by: Duffie Cooley <cooleyd@vmware.com>