### PR TITLE
upgrade to go 1.13.3 (CVE-2019-17596)

### DIFF
--- a/hack/go_container.sh
+++ b/hack/go_container.sh
@@ -30,7 +30,7 @@ SOURCE_DIR="${SOURCE_DIR:-$(pwd -P)}"
 # default to disabling CGO for easier reproducible builds and cross compilation
 export CGO_ENABLED="${CGO_ENABLED:-0}"
 # the container image, by default a recent official golang image
-GOIMAGE="${GOIMAGE:-golang:1.13.1}"
+GOIMAGE="${GOIMAGE:-golang:1.13.3}"
 # docker volume name, used as a go module / build cache
 CACHE_VOLUME="${CACHE_VOLUME:-kind-build-cache}"
 # ========================== END SCRIPT SETTINGS ===============================


### PR DESCRIPTION
full diff https://github.com/golang/go/compare/go1.13.1...go1.13.3

<p>
go1.13.2 (released 2019/10/17) includes security fixes to the
<code>crypto/dsa</code> package and the compiler.
See the <a href="https://github.com/golang/go/issues?q=milestone%3AGo1.13.2">Go
1.13.2 milestone</a> on our issue tracker for details.
</p>

<p>
go1.13.3 (released 2019/10/17) includes fixes to the go command,
the toolchain, the runtime, <code>syscall</code>, <code>net</code>,
<code>net/http</code>, and <code>crypto/ecdsa</code> packages.
See the <a href="https://github.com/golang/go/issues?q=milestone%3AGo1.13.3">Go
1.13.3 milestone</a> on our issue tracker for details.
</p>