### PR TITLE
mount xtables lock file and lib/modules in kindnetd

### DIFF
--- a/pkg/build/node/cni.go
+++ b/pkg/build/node/cni.go
@@ -51,6 +51,8 @@ spec:
     - hostPath
   allowedHostPaths:
     - pathPrefix: "/etc/cni/net.d"
+    - pathPrefix: "/run"
+    - pathPrefix: "/lib"
   readOnlyRootFilesystem: false
   # Users and groups
   runAsUser:
@@ -159,6 +161,12 @@ spec:
         volumeMounts:
         - name: cni-cfg
           mountPath: /etc/cni/net.d
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+          readOnly: false
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
         resources:
           requests:
             cpu: "100m"
@@ -171,8 +179,15 @@ spec:
           capabilities:
             add: ["NET_RAW", "NET_ADMIN"]
       volumes:
-        - name: cni-cfg
-          hostPath:
-            path: /etc/cni/net.d
+      - name: cni-cfg
+        hostPath:
+          path: /etc/cni/net.d
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
 ---
 `


### PR DESCRIPTION
fixes: #976 

iptables commands with `--wait` (as used by kube-proxy and kindnetd and...) use a file based lock which is by default at `/run/xtables.lock`, we need to mount this.

We should also be mounting `/lib/modules`

See: https://git.netfilter.org/iptables/tree/configure.ac?id=55a7558bb2c86e650809610e976e9d5192fe4e7e#n72