### PR TITLE
Log version

### DIFF
--- a/cmd/kind/version/version.go
+++ b/cmd/kind/version/version.go
@@ -19,8 +19,11 @@ package version
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kind/pkg/globals"
 )
 
 // Version returns the kind CLI Semantic Version
@@ -38,8 +41,14 @@ func Version() string {
 	return v
 }
 
+// DisplayVersion is Version() display formatted, this is what the version
+// subcommand prints
+func DisplayVersion() string {
+	return "kind v" + Version() + " " + runtime.Version() + " " + runtime.GOOS + "/" + runtime.GOARCH
+}
+
 // VersionCore is the core portion of the kind CLI version per Semantic Versioning 2.0.0
-const VersionCore = "v0.6.0"
+const VersionCore = "0.6.0"
 
 // VersionPreRelease is the pre-release portion of the kind CLI version per
 // Semantic Versioning 2.0.0
@@ -57,7 +66,13 @@ func NewCommand() *cobra.Command {
 		Short: "prints the kind CLI version",
 		Long:  "prints the kind CLI version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println(Version())
+			// if not -q / --quiet, show lots of info
+			if globals.GetLogger().V(0).Enabled() {
+				fmt.Println(DisplayVersion())
+
+			} else { // otherwise only show semver
+				fmt.Println(Version())
+			}
 			return nil
 		},
 	}

--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -164,6 +164,9 @@ main() {
   export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
   mkdir -p "${ARTIFACTS}"
 
+  # debug kind version
+  kind version
+
   # default to bazel
   # TODO(bentheelder): remove this line once we've updated CI to explicitly choose
   BUILD_TYPE="${BUILD_TYPE:-bazel}"

--- a/hack/release/create.sh
+++ b/hack/release/create.sh
@@ -16,7 +16,7 @@
 # creates a release and following pre-release commit for `kind`
 # builds binaries between the commits
 # Use like: create.sh <release-version> <next-prerelease-version>
-# EG: create.sh v0.3.0 v0.4.0
+# EG: create.sh 0.3.0 0.4.0
 set -o errexit -o nounset -o pipefail
 
 # cd to the repo root
@@ -63,14 +63,14 @@ add_tag() {
 
 # create the first version, tag and build it
 set_version "${1}" ""
-make_commit "${1}"
-add_tag "${1}"
+make_commit "v${1}"
+add_tag "v${1}"
 echo "Building ..."
 make clean && ./hack/release/build/cross.sh
 
 # update to the second version
 set_version "${2}" "alpha"
-make_commit "${2}"
+make_commit "v${2}-alpha"
 
 # print follow-up instructions
 echo ""


### PR DESCRIPTION
- log version in e2e
- include more information by default (go version, GOOS, GOARCH)
  - support printing _only_ the semver with `-q`

```
$ kind version
kind v0.6.0-alpha+7704075f4e4f76e4194cd2298e8b348256f1d2d3 go1.13.3 linux/amd64

$ kind version -q
0.6.0-alpha+7704075f4e4f76e4194cd2298e8b348256f1d2d3
```
