### PR TITLE
entrypoint: fix cgroups mounts

### DIFF
--- a/images/base/entrypoint
+++ b/images/base/entrypoint
@@ -42,6 +42,31 @@ fix_mount() {
   mount --make-rshared /
 }
 
+fix_cgroup() {
+  echo 'INFO: fix cgroup mounts for all subsystems'
+  # For each cgroup subsystem, Docker does a bind mount from the current
+  # cgroup to the root of the cgroup subsystem. For instance:
+  #   /sys/fs/cgroup/memory/docker/<cid> -> /sys/fs/cgroup/memory
+  #
+  # This will confuse Kubelet and cadvisor and will dump the following error
+  # messages in kubelet log:
+  #   `summary_sys_containers.go:47] Failed to get system container stats for ".../kubelet.service"`
+  #
+  # This is because `/proc/<pid>/cgroup` is not affected by the bind mount.
+  # The following is a workaround to recreate the original cgroup
+  # environment by doing another bind mount for each subsystem.
+  MOUNT_TABLE=$(cat /proc/self/mountinfo)
+  DOCKER_CGROUP_MOUNTS=$(echo "${MOUNT_TABLE}" | grep /sys/fs/cgroup | grep docker)
+  DOCKER_CGROUP=$(echo "${DOCKER_CGROUP_MOUNTS}" | head -n 1 | cut -d' ' -f 4)
+  CGROUP_SUBSYSTEMS=$(echo "${DOCKER_CGROUP_MOUNTS}" | cut -d' ' -f 5)
+
+  echo "${CGROUP_SUBSYSTEMS}" |
+  while IFS= read -r SUBSYSTEM; do
+    mkdir -p "${SUBSYSTEM}${DOCKER_CGROUP}"
+    mount --bind "${SUBSYSTEM}" "${SUBSYSTEM}${DOCKER_CGROUP}"
+  done
+}
+
 fix_machine_id() {
   # Deletes the machine-id embedded in the node image and generates a new one.
   # This is necessary because both kubelet and other components like weave net
@@ -90,6 +115,7 @@ EOF
 # run pre-init fixups
 fix_kmsg
 fix_mount
+fix_cgroup
 fix_machine_id
 fix_product_name
 configure_proxy


### PR DESCRIPTION
For each cgroup subsystem, Docker does a bind mount from the current
cgroup to the root of the cgroup subsystem. For instance:
  `/sys/fs/cgroup/memory/docker/<cid> -> /sys/fs/cgroup/memory`

This will confuse Kubelet and cadvisor and will dump the following error
messages in kubelet log:

```
summary_sys_containers.go:47] Failed to get system container stats for
".../kubelet.service"
```

This is because `/proc/<pid>/cgroup` is not affected by the bind mount.
The following is a workaround to recreate the original cgroup
environment by doing another bind mount for each subsystem.