### PR TITLE
Use klog for kindnetd #991

### DIFF
--- a/images/kindnetd/cmd/kindnetd/routes.go
+++ b/images/kindnetd/cmd/kindnetd/routes.go
@@ -17,11 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"net"
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
+	"k8s.io/klog"
 )
 
 func syncRoute(nodeIP, podCIDR string) error {
@@ -44,7 +44,7 @@ func syncRoute(nodeIP, podCIDR string) error {
 		if err := netlink.RouteAdd(&routeToDst); err != nil {
 			return err
 		}
-		fmt.Printf("Adding route %v \n", routeToDst)
+		klog.Infof("Adding route %v \n", routeToDst)
 	}
 
 	return nil

--- a/images/kindnetd/go.mod
+++ b/images/kindnetd/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.0+incompatible
+	k8s.io/klog v0.3.0
 	k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )


### PR DESCRIPTION
Fix #991 
I changed the logging tools `k8s.io/klog` instead of `fmt ` in `images/kindnetd`