### PR TITLE
Update containerd & config

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -23,7 +23,7 @@ FROM ubuntu:19.10
 
 # Configure containerd and runc binaries from kind-ci/containerd-nightlies repository
 # The repository contains latest stable releases and nightlies built for multiple architectures
-ARG CONTAINERD_VERSION="v1.3.0-7-g0b43a311"
+ARG CONTAINERD_VERSION="v1.3.0-20-g7af311b4"
 # Configure CNI binaries from upstream
 ARG CNI_VERSION="v0.8.2"
 # Configure crictl binary from upstream

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -80,6 +80,7 @@ RUN echo "Ensuring scripts are executable ..." \
     && chmod 755 /usr/local/sbin/runc \
     && containerd --version \
     && systemctl enable containerd \
+    && mkdir -p /etc/containerd/user \
  && echo "Installing crictl ..." \
     && curl -fSL "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCH}.tar.gz" | tar xzC /usr/local/bin \
  && echo "Installing CNI binaries ..." \

--- a/images/base/files/etc/containerd/config.toml
+++ b/images/base/files/etc/containerd/config.toml
@@ -1,11 +1,16 @@
 # disable plugins we don't / can't support
 disabled_plugins = ["aufs", "btrfs", "zfs"]
 
-# set default runtime handler to v2, which has a per-pod shim
-[plugins.cri.containerd.default_runtime]
-  runtime_type="io.containerd.runc.v2"
+# import any additional config files written by kind, and any user written
+# config files (/etc/containerd/user-config/*.toml)
+imports = ["/kind/containerd/*.toml", "/etc/containerd/user/*.toml"]
 
-# Setup a runtime with the magic name ("test-handler") used for Kubernetes
-# runtime class tests ...
-[plugins.cri.containerd.runtimes.test-handler]
+# set default runtime handler to v2, which has a per-pod shim
+[plugins."io.containerd.grpc.v1.cri".containerd]
+  default_runtime_name="runc"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
+
+# Setup kubernetes e2e test fixed-name ("test-handler") for runtime class tests
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
   runtime_type = "io.containerd.runc.v2"

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.16.2@sha256:0a3255e23b0d9f0465d2bcaf213dccb79b682c566a3f1df1889db21e13807b14"
+const Image = "kindest/node:v1.16.2@sha256:a01d06fa93cbd42fdf0c6dcbe3695ec8d435431a97eef6a054bc7c2b7aea77d7"

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -44,7 +44,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20191023-809ba3f@sha256:ae095293629e6d433831f8631048256f87696e3ca56de701ce490014cde36902"
+const DefaultBaseImage = "kindest/base:v20191023-fd511d8f@sha256:85c2f2a9354284ed127b0c7964358895d2d850b85ebafb91eba1987762b68625"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
- update to latest patches in release 1.3 branch (after fixing the nightly build setup)
- update and port #953, move containerd to latest config keys and support user injected partial config files
- bump the images