### PR TITLE
Upgrade containerd to v1.3.0-20-g7af311b4

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -23,7 +23,7 @@ FROM ubuntu:19.10
 
 # Configure containerd and runc binaries from kind-ci/containerd-nightlies repository
 # The repository contains latest stable releases and nightlies built for multiple architectures
-ARG CONTAINERD_VERSION="v1.3.0-7-g0b43a311"
+ARG CONTAINERD_VERSION="v1.3.0-20-g7af311b4"
 # Configure CNI binaries from upstream
 ARG CNI_VERSION="v0.8.2"
 # Configure crictl binary from upstream

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.16.2@sha256:0a3255e23b0d9f0465d2bcaf213dccb79b682c566a3f1df1889db21e13807b14"
+const Image = "kindest/node:v1.16.2@sha256:146ffa1427f3995abdfb710981da4e67637e6f50cffdeea29b207f098300a1f4"

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -44,7 +44,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20191023-809ba3f@sha256:ae095293629e6d433831f8631048256f87696e3ca56de701ce490014cde36902"
+const DefaultBaseImage = "kindest/base:v20191023-6aac5da9@sha256:9ab8037e7b42ef68acb7384a78f84e3faf363aeb01b5b5b0b657bd026a55b527"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
- update to latest patches in release 1.3 branch (after fixing the nightly build setup)