### PR TITLE
Fix base image info in documentation.

### DIFF
--- a/site/content/docs/design/base-image.md
+++ b/site/content/docs/design/base-image.md
@@ -28,7 +28,7 @@ the container truly boots
 - we do a few tricks to minimize unnecessary services and inform systemd that it
 is in docker (see the [Dockerfile][dockerfile])
 
-This image is based on `ubuntu:18.04` image
+This image is based on `ubuntu:19.10` image
 due to high availability of tooling.
 We strive to minimize the image size where possible.
 


### PR DESCRIPTION
Base image was changed to ubuntu:19.10, so documentation should also be updated.