### PR TITLE
entrypoint: fix cgroups mounts + nits

### DIFF
--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -55,16 +55,18 @@ fix_cgroup() {
   # This is because `/proc/<pid>/cgroup` is not affected by the bind mount.
   # The following is a workaround to recreate the original cgroup
   # environment by doing another bind mount for each subsystem.
-  MOUNT_TABLE=$(cat /proc/self/mountinfo)
-  DOCKER_CGROUP_MOUNTS=$(echo "${MOUNT_TABLE}" | grep /sys/fs/cgroup | grep docker)
-  DOCKER_CGROUP=$(echo "${DOCKER_CGROUP_MOUNTS}" | head -n 1 | cut -d' ' -f 4)
-  CGROUP_SUBSYSTEMS=$(echo "${DOCKER_CGROUP_MOUNTS}" | cut -d' ' -f 5)
-
-  echo "${CGROUP_SUBSYSTEMS}" |
-  while IFS= read -r SUBSYSTEM; do
-    mkdir -p "${SUBSYSTEM}${DOCKER_CGROUP}"
-    mount --bind "${SUBSYSTEM}" "${SUBSYSTEM}${DOCKER_CGROUP}"
-  done
+  local docker_cgroup_mounts
+  docker_cgroup_mounts=$(grep /sys/fs/cgroup /proc/self/mountinfo | grep docker || true)
+  if [[ -n "${docker_cgroup_mounts}" ]]; then
+    local docker_cgroup cgroup_subsystems subsystem
+    docker_cgroup=$(echo "${docker_cgroup_mounts}" | head -n 1 | cut -d' ' -f 4)
+    cgroup_subsystems=$(echo "${docker_cgroup_mounts}" | cut -d' ' -f 5)
+    echo "${cgroup_subsystems}" |
+    while IFS= read -r subsystem; do
+      mkdir -p "${subsystem}${docker_cgroup}"
+      mount --bind "${subsystem}" "${subsystem}${docker_cgroup}"
+    done
+  fi
 }
 
 fix_machine_id() {

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -42,6 +42,31 @@ fix_mount() {
   mount --make-rshared /
 }
 
+fix_cgroup() {
+  echo 'INFO: fix cgroup mounts for all subsystems'
+  # For each cgroup subsystem, Docker does a bind mount from the current
+  # cgroup to the root of the cgroup subsystem. For instance:
+  #   /sys/fs/cgroup/memory/docker/<cid> -> /sys/fs/cgroup/memory
+  #
+  # This will confuse Kubelet and cadvisor and will dump the following error
+  # messages in kubelet log:
+  #   `summary_sys_containers.go:47] Failed to get system container stats for ".../kubelet.service"`
+  #
+  # This is because `/proc/<pid>/cgroup` is not affected by the bind mount.
+  # The following is a workaround to recreate the original cgroup
+  # environment by doing another bind mount for each subsystem.
+  MOUNT_TABLE=$(cat /proc/self/mountinfo)
+  DOCKER_CGROUP_MOUNTS=$(echo "${MOUNT_TABLE}" | grep /sys/fs/cgroup | grep docker)
+  DOCKER_CGROUP=$(echo "${DOCKER_CGROUP_MOUNTS}" | head -n 1 | cut -d' ' -f 4)
+  CGROUP_SUBSYSTEMS=$(echo "${DOCKER_CGROUP_MOUNTS}" | cut -d' ' -f 5)
+
+  echo "${CGROUP_SUBSYSTEMS}" |
+  while IFS= read -r SUBSYSTEM; do
+    mkdir -p "${SUBSYSTEM}${DOCKER_CGROUP}"
+    mount --bind "${SUBSYSTEM}" "${SUBSYSTEM}${DOCKER_CGROUP}"
+  done
+}
+
 fix_machine_id() {
   # Deletes the machine-id embedded in the node image and generates a new one.
   # This is necessary because both kubelet and other components like weave net
@@ -90,6 +115,7 @@ EOF
 # run pre-init fixups
 fix_kmsg
 fix_mount
+fix_cgroup
 fix_machine_id
 fix_product_name
 configure_proxy

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.16.2@sha256:146ffa1427f3995abdfb710981da4e67637e6f50cffdeea29b207f098300a1f4"
+const Image = "kindest/node:v1.16.2@sha256:490e066d9b30a50584aa77c20e67edcceb2d97276112200b223dd8a3d718c973"

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -44,7 +44,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20191023-6aac5da9@sha256:9ab8037e7b42ef68acb7384a78f84e3faf363aeb01b5b5b0b657bd026a55b527"
+const DefaultBaseImage = "kindest/base:v20191025-0fae556c@sha256:6c1479d05220704be6c0a69692c1525338381fd8e27093f1268fe747b536360c"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
this PR https://github.com/kubernetes-sigs/kind/pull/993 plus:
- rebased against HEAD before building an image
- tweaked the bash a bit, notably to guard on if we found the docker cgroups before proceeding
- built and bumped the base image for testing
- build and bumped node image