### PR TITLE
Mount ssl certs folder into go build container

### DIFF
--- a/hack/go_container.sh
+++ b/hack/go_container.sh
@@ -82,6 +82,8 @@ run_in_go_container() {
       -e GO111MODULE -e GOPROXY -e CGO_ENABLED -e GOOS -e GOARCH \
     `# pass through proxy settings` \
       -e HTTP_PROXY -e HTTPS_PROXY -e NO_PROXY \
+    `# use host certificates` \
+      -v "/etc/ssl/certs:/etc/ssl/certs" \
     `# run the image with the args passed to this script` \
       "${GOIMAGE}" "$@"
 }


### PR DESCRIPTION
This might be needed behind a corporate proxy that intercepts HTTPS traffic with self-generated certificates to verify the root CA.