### PR TITLE
doc: Fix minor issue with kernel output path

### DIFF
--- a/site/content/docs/user/using-wsl2.md
+++ b/site/content/docs/user/using-wsl2.md
@@ -129,7 +129,7 @@ git clone --depth 1 https://github.com/microsoft/WSL2-Linux-Kernel.git
 cd WSL2-Linux-Kernel
 make -j4 KCONFIG_CONFIG=Microsoft/config-wsl
 mkdir /mnt/c/linuxtemp
-cp arch/x86/boot/bzImage /mnt/c/linuxtemp/
+cp arch/x86_x64/boot/bzImage /mnt/c/linuxtemp/
 ```
 
 Now, open an administrator PowerShell window and run these steps to apply the kernel:


### PR DESCRIPTION
I had a small mistake in the WSL2 kernel build steps. On my setup the same file gets placed in both `arch/x86/boot/bzImage` and `arch/x86_64/boot/bzImage`. Using either worked, but technically `x86_64` is correct so this fixes the doc to use it.