### PR TITLE
update to go 1.13.4

### DIFF
--- a/hack/go_container.sh
+++ b/hack/go_container.sh
@@ -30,7 +30,7 @@ SOURCE_DIR="${SOURCE_DIR:-$(pwd -P)}"
 # default to disabling CGO for easier reproducible builds and cross compilation
 export CGO_ENABLED="${CGO_ENABLED:-0}"
 # the container image, by default a recent official golang image
-GOIMAGE="${GOIMAGE:-golang:1.13.3}"
+GOIMAGE="${GOIMAGE:-golang:1.13.4}"
 # docker volume name, used as a go module / build cache
 CACHE_VOLUME="${CACHE_VOLUME:-kind-build-cache}"
 # ========================== END SCRIPT SETTINGS ===============================


### PR DESCRIPTION
https://groups.google.com/d/msgid/golang-announce/CAFPZzeTNt%2BDMFyNzX8-Zs9znFj9A5CYfQqsmL5XirLxb9J_FtA%40mail.gmail.com?utm_medium=email&utm_source=footer

> Go 1.13.4 includes fixes to the net/http and syscall packages.