### PR TITLE
bikeshed quiet handling and add tests

### DIFF
--- a/cmd/kind/app/main.go
+++ b/cmd/kind/app/main.go
@@ -41,8 +41,7 @@ func Main() {
 // See: sigs.k8s.io/kind/pkg/cmd/kind
 func Run(logger log.Logger, streams cmd.IOStreams, args []string) error {
 	// NOTE: we handle the quiet flag here so we can fully silence cobra
-	quiet := checkQuiet(args)
-	if quiet {
+	if checkQuiet(args) {
 		// if we are in quiet mode, we want to suppress all status output
 		// only streams.Out should be written to (program output)
 		logger = log.NoopLogger{}
@@ -58,11 +57,18 @@ func Run(logger log.Logger, streams cmd.IOStreams, args []string) error {
 	return nil
 }
 
+// checkQuiet returns true if -q / --quiet was set in args
 func checkQuiet(args []string) bool {
 	flags := pflag.NewFlagSet("persistent-quiet", pflag.ContinueOnError)
 	flags.ParseErrorsWhitelist.UnknownFlags = true
 	quiet := false
-	kind.AddQuietFlag(flags, &quiet)
+	flags.BoolVarP(
+		&quiet,
+		"quiet",
+		"q",
+		false,
+		"silence all stderr output",
+	)
 	// NOTE: pflag will error if -h / --help is specified
 	// We don't care here. That will be handled downstream
 	// It will also call flags.Usage so we're making that no-op

--- a/cmd/kind/app/main_test.go
+++ b/cmd/kind/app/main_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"testing"
+)
+
+func TestCheckQuiet(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		Name        string
+		Args        []string
+		ExpectQuiet bool
+	}{
+		// normal cases, we expect it to be set
+		{
+			Name:        "simply q",
+			Args:        []string{"-q"},
+			ExpectQuiet: true,
+		},
+		{
+			Name:        "simply quiet",
+			Args:        []string{"--quiet"},
+			ExpectQuiet: true,
+		},
+		{
+			Name:        "all quiet on the cli",
+			Args:        []string{"all", "quiet", "on", "the", "cli", "--quiet"},
+			ExpectQuiet: true,
+		},
+		// pflag will throw an ErrHelp when -h / --help are in args even though
+		// we don't register these as flags, checkQuiet should ignore them
+		{
+			Name:        "with ignored help",
+			Args:        []string{"--quiet", "--help"},
+			ExpectQuiet: true,
+		},
+		{
+			Name:        "with ignored h",
+			Args:        []string{"--quiet", "-h"},
+			ExpectQuiet: true,
+		},
+		// not quiet for these cases ...
+		{
+			Name:        "no args",
+			Args:        []string{},
+			ExpectQuiet: false,
+		},
+		{
+			Name:        "loud",
+			Args:        []string{"--loud"},
+			ExpectQuiet: false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			result := checkQuiet(tc.Args)
+			if result != tc.ExpectQuiet {
+				t.Fatalf("fooo")
+			}
+		})
+	}
+}

--- a/pkg/cmd/kind/root.go
+++ b/pkg/cmd/kind/root.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kind/pkg/cmd"
 	"sigs.k8s.io/kind/pkg/cmd/kind/build"
@@ -72,7 +71,13 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		0,
 		"info log verbosity",
 	)
-	AddQuietFlag(cmd.PersistentFlags(), &flags.Quiet)
+	cmd.PersistentFlags().BoolVarP(
+		&flags.Quiet,
+		"quiet",
+		"q",
+		false,
+		"silence all stderr output",
+	)
 	// add all top level subcommands
 	cmd.AddCommand(build.NewCommand(logger, streams))
 	cmd.AddCommand(completion.NewCommand(logger, streams))
@@ -83,20 +88,6 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd.AddCommand(version.NewCommand(logger, streams))
 	cmd.AddCommand(load.NewCommand(logger, streams))
 	return cmd
-}
-
-// AddQuietFlag adds the -q / --quiet boolean flag to flags
-// with the value stored in valuePointer
-// The default value is false.
-// This is used by app.Run to handle quiet before we get to cobra
-func AddQuietFlag(flags *pflag.FlagSet, valuePointer *bool) {
-	flags.BoolVarP(
-		valuePointer,
-		"quiet",
-		"q",
-		false,
-		"silence all stderr output",
-	)
 }
 
 func runE(logger log.Logger, flags *Flags, cmd *cobra.Command) error {


### PR DESCRIPTION
mostly wanted to write some tests because this is a little strange but also eliminated a useless intermediate variable and just inlined declaring the flag.

we shouldn't change it except maybe the usage which doesn't really matter in `checkQuiet`, and having it as an exported API was kinda 👎 