### PR TITLE
Use stdin from streams in create cluster

### DIFF
--- a/pkg/cluster/createoption.go
+++ b/pkg/cluster/createoption.go
@@ -44,6 +44,15 @@ func CreateWithConfigFile(path string) CreateOption {
 	})
 }
 
+// CreateWithRawConfig configures the config to use from raw (yaml) bytes
+func CreateWithRawConfig(raw []byte) CreateOption {
+	return createOptionAdapter(func(o *internalcreate.ClusterOptions) error {
+		var err error
+		o.Config, err = internalencoding.Parse(raw)
+		return err
+	})
+}
+
 // CreateWithV1Alpha3Config configures the cluster with a v1alpha3 config
 func CreateWithV1Alpha3Config(config *v1alpha3.Cluster) CreateOption {
 	return createOptionAdapter(func(o *internalcreate.ClusterOptions) error {

--- a/pkg/internal/apis/config/encoding/load.go
+++ b/pkg/internal/apis/config/encoding/load.go
@@ -73,8 +73,7 @@ func Parse(raw []byte) (*config.Cluster, error) {
 			return nil, errors.Wrap(err, "unable to decode config")
 		}
 		// apply defaults for version and convert
-		v1alpha3.SetDefaultsCluster(cfg)
-		return config.Convertv1alpha3(cfg), nil
+		return V1Alpha3ToInternal(cfg), nil
 	}
 	// unknown apiVersion if we haven't already returned ...
 	return nil, errors.Errorf("unknown apiVersion: %s", tm.APIVersion)

--- a/pkg/internal/apis/config/encoding/load.go
+++ b/pkg/internal/apis/config/encoding/load.go
@@ -19,7 +19,6 @@ package encoding
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 
 	yaml "gopkg.in/yaml.v3"
 
@@ -42,12 +41,19 @@ func Load(path string) (*config.Cluster, error) {
 		return out, nil
 	}
 
-	// load the raw contents
-	raw, err := readAll(path)
+	// read in file
+	raw, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error reading file")
 	}
 
+	return Parse(raw)
+}
+
+// Parse parses a cluster config from raw (yaml) bytes
+// It will always return the current internal version after defaulting and
+// conversion from the read version
+func Parse(raw []byte) (*config.Cluster, error) {
 	// get kind & apiVersion
 	tm := typeMeta{}
 	if err := yaml.Unmarshal(raw, &tm); err != nil {
@@ -84,21 +90,4 @@ func yamlUnmarshalStrict(raw []byte, v interface{}) error {
 	d := yaml.NewDecoder(bytes.NewReader(raw))
 	d.KnownFields(true)
 	return d.Decode(v)
-}
-
-func readAll(path string) ([]byte, error) {
-	// read in stdin if -
-	if path == "-" {
-		raw, err := ioutil.ReadAll(os.Stdin)
-		if err != nil {
-			return nil, errors.Wrap(err, "error reading from stdin")
-		}
-		return raw, nil
-	}
-	// read in file
-	raw, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, errors.Wrap(err, "error reading file")
-	}
-	return raw, nil
 }


### PR DESCRIPTION
also provides another handy creation option (use a raw config), and cleans up the config loading logic slightly (brings encoding to 100% coverage!)