### PR TITLE
Fix pipe closing race in kind export logs

### DIFF
--- a/pkg/internal/cluster/logs/logs.go
+++ b/pkg/internal/cluster/logs/logs.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/alessio/shellescape"
+
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/exec"


### PR DESCRIPTION
fixes #999 

Since the reader/writer are running as separate processes, closing either prematurely will result in a broken pipe until we ensure both processes have finished.

Simplified the logic to close the pipe on defer once we've aggregated both the errors.

Also reverted the rsync logic since that was a red herring workaround (and was also doubling the time).