### PR TITLE
add `kind export kubeconfig`

### DIFF
--- a/pkg/cluster/provider.go
+++ b/pkg/cluster/provider.go
@@ -117,6 +117,14 @@ func (p *Provider) KubeConfig(name string, internal bool) (string, error) {
 	return kubeconfig.Get(p.ic(name), !internal)
 }
 
+// ExportKubeConfig exports the KUBECONFIG for the cluster, merging
+// it into the selected file, following the rules from
+// https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#config
+// where explicitPath is the --kubeconfig value.
+func (p *Provider) ExportKubeConfig(name string, explicitPath string) error {
+	return kubeconfig.Export(p.ic(name), explicitPath)
+}
+
 // ListNodes returns the list of container IDs for the "nodes" in the cluster
 func (p *Provider) ListNodes(name string) ([]nodes.Node, error) {
 	return p.ic(name).ListNodes()

--- a/pkg/cmd/kind/export/export.go
+++ b/pkg/cmd/kind/export/export.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cmd"
+	"sigs.k8s.io/kind/pkg/cmd/kind/export/kubeconfig"
 	"sigs.k8s.io/kind/pkg/cmd/kind/export/logs"
 	"sigs.k8s.io/kind/pkg/log"
 )
@@ -31,10 +32,11 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Args: cobra.NoArgs,
 		// TODO(bentheelder): more detailed usage
 		Use:   "export",
-		Short: "exports one of [logs]",
-		Long:  "exports one of [logs]",
+		Short: "exports one of [kubeconfig, logs]",
+		Long:  "exports one of [kubeconfig, logs]",
 	}
 	// add subcommands
 	cmd.AddCommand(logs.NewCommand(logger, streams))
+	cmd.AddCommand(kubeconfig.NewCommand(logger, streams))
 	return cmd
 }

--- a/pkg/cmd/kind/export/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kind/export/kubeconfig/kubeconfig.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubeconfig implements the `kubeconfig` command
+package kubeconfig
+
+import (
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kind/pkg/cluster"
+	"sigs.k8s.io/kind/pkg/cmd"
+	"sigs.k8s.io/kind/pkg/log"
+)
+
+type flagpole struct {
+	Name       string
+	Kubeconfig string
+}
+
+// NewCommand returns a new cobra.Command for exporting the kubeconfig
+func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
+	flags := &flagpole{}
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "kubeconfig",
+		Short: "exports cluster kubeconfig",
+		Long:  "exports cluster kubeconfig",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(logger, flags)
+		},
+	}
+	cmd.Flags().StringVar(
+		&flags.Name,
+		"name",
+		cluster.DefaultName,
+		"the cluster context name",
+	)
+	cmd.Flags().StringVar(
+		&flags.Kubeconfig,
+		"kubeconfig",
+		"",
+		"sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config",
+	)
+	return cmd
+}
+
+func runE(logger log.Logger, flags *flagpole) error {
+	provider := cluster.NewProvider(
+		cluster.ProviderWithLogger(logger),
+	)
+	if err := provider.ExportKubeConfig(flags.Name, flags.Kubeconfig); err != nil {
+		return err
+	}
+	// TODO: get kind-name from a method? OTOH we probably want to keep this
+	// naming scheme stable anyhow...
+	logger.V(0).Infof(`Set kubectl context to "kind-%s"`, flags.Name)
+	return nil
+}


### PR DESCRIPTION
This allows re-obtaining kind kubeconfig similar to `kind get kubeconfig`, but merging it in like `kind create cluster` instead of printing it to stdout.

xref: #850 