### PR TITLE
eliminate klog indirect dependency

### DIFF
--- a/pkg/internal/util/patch/patch_test.go
+++ b/pkg/internal/util/patch/patch_test.go
@@ -159,7 +159,7 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 metadata:
   name: config
-`
+---`
 
 const normalKubeadmConfigKustomized = `apiServer:
   certSANs:


### PR DESCRIPTION
The API machinery document splitter brings in klog and is pretty awkward and complex to use.

Instead, we borrow the `bufio.Scanner.Split` compatible `splitYAMLDocument` from the implementation, which gives us less code and doesn't include any `klog`.