### PR TITLE
Provide ability for Worker Kubeadm Config Patches

### DIFF
--- a/hack/update/generated.sh
+++ b/hack/update/generated.sh
@@ -45,13 +45,9 @@ cd "${FAKE_REPOPATH}"
 
 # run the generators
 bin/deepcopy-gen -i ./pkg/internal/apis/config/ -O zz_generated.deepcopy --go-header-file hack/tools/boilerplate.go.txt
-<<<<<<< HEAD
-bin/deepcopy-gen -i ./pkg/apis/config/v1alpha4 -O zz_generated.deepcopy --go-header-file hack/tools/boilerplate.go.txt
-=======
 bin/deepcopy-gen -i ./pkg/apis/config/v1alpha3 -O zz_generated.deepcopy --go-header-file hack/tools/boilerplate.go.txt
 bin/deepcopy-gen -i ./pkg/apis/config/v1alpha4 -O zz_generated.deepcopy --go-header-file hack/tools/boilerplate.go.txt
 
->>>>>>> master
 
 # set module mode back, return to repo root and gofmt to ensure we format generated code
 export GO111MODULE="on"

--- a/hack/update/generated.sh
+++ b/hack/update/generated.sh
@@ -45,7 +45,7 @@ cd "${FAKE_REPOPATH}"
 
 # run the generators
 bin/deepcopy-gen -i ./pkg/internal/apis/config/ -O zz_generated.deepcopy --go-header-file hack/tools/boilerplate.go.txt
-bin/deepcopy-gen -i ./pkg/apis/config/v1alpha3 -O zz_generated.deepcopy --go-header-file hack/tools/boilerplate.go.txt
+bin/deepcopy-gen -i ./pkg/apis/config/v1alpha4 -O zz_generated.deepcopy --go-header-file hack/tools/boilerplate.go.txt
 
 # set module mode back, return to repo root and gofmt to ensure we format generated code
 export GO111MODULE="on"

--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -38,6 +38,8 @@ type Cluster struct {
 	// This should be an inline yaml blob-string
 	//
 	// https://tools.ietf.org/html/rfc7386
+	//
+	// The cluster-level patches are appied before the node-level patches.
 	KubeadmConfigPatches []string `yaml:"kubeadmConfigPatches,omitempty"`
 
 	// KubeadmConfigPatchesJSON6902 are applied to the generated kubeadm config
@@ -51,6 +53,8 @@ type Cluster struct {
 	// always been a no-op.
 	//
 	// https://tools.ietf.org/html/rfc6902
+	//
+	// The cluster-level patches are appied before the node-level patches.
 	KubeadmConfigPatchesJSON6902 []PatchJSON6902 `yaml:"kubeadmConfigPatchesJson6902,omitempty"`
 }
 
@@ -93,6 +97,9 @@ type Node struct {
 	// This should be an inline yaml blob-string
 	//
 	// https://tools.ietf.org/html/rfc7386
+	//
+	// The node-level patches will be applied after the cluster-level patches
+	// have been applied. (See Cluster.KubeadmConfigPatches)
 	KubeadmConfigPatches []string `yaml:"kubeadmConfigPatches,omitempty"`
 
 	// KubeadmConfigPatchesJSON6902 are applied to the generated kubeadm config
@@ -106,6 +113,9 @@ type Node struct {
 	// always been a no-op.
 	//
 	// https://tools.ietf.org/html/rfc6902
+	//
+	// The node-level patches will be applied after the cluster-level patches
+	// have been applied. (See Cluster.KubeadmConfigPatchesJSON6902)
 	KubeadmConfigPatchesJSON6902 []PatchJSON6902 `yaml:"kubeadmConfigPatchesJson6902,omitempty"`
 }
 

--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -85,6 +85,28 @@ type Node struct {
 	// ExtraPortMappings describes additional port mappings for the node container
 	// binded to a host Port
 	ExtraPortMappings []PortMapping `yaml:"extraPortMappings,omitempty"`
+
+	// KubeadmConfigPatches are applied to the generated kubeadm config as
+	// merge patches. The `kind` field must match the target object, and
+	// if `apiVersion` is specified it will only be applied to matching objects.
+	//
+	// This should be an inline yaml blob-string
+	//
+	// https://tools.ietf.org/html/rfc7386
+	KubeadmConfigPatches []string `yaml:"kubeadmConfigPatches,omitempty"`
+
+	// KubeadmConfigPatchesJSON6902 are applied to the generated kubeadm config
+	// as JSON 6902 patches. The `kind` field must match the target object, and
+	// if group or version are specified it will only be objects matching the
+	// apiVersion: group+"/"+version
+	//
+	// Name and Namespace are now ignored, but the fields continue to exist for
+	// backwards compatibility of parsing the config. The name of the generated
+	// config was/is always fixed as as is the namespace so these fields have
+	// always been a no-op.
+	//
+	// https://tools.ietf.org/html/rfc6902
+	KubeadmConfigPatchesJSON6902 []PatchJSON6902 `yaml:"kubeadmConfigPatchesJson6902,omitempty"`
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/apis/config/v1alpha4/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha4/zz_generated.deepcopy.go
@@ -100,6 +100,16 @@ func (in *Node) DeepCopyInto(out *Node) {
 		*out = make([]PortMapping, len(*in))
 		copy(*out, *in)
 	}
+	if in.KubeadmConfigPatches != nil {
+		in, out := &in.KubeadmConfigPatches, &out.KubeadmConfigPatches
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.KubeadmConfigPatchesJSON6902 != nil {
+		in, out := &in.KubeadmConfigPatchesJSON6902, &out.KubeadmConfigPatchesJSON6902
+		*out = make([]PatchJSON6902, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/internal/apis/config/convert_v1alpha4.go
+++ b/pkg/internal/apis/config/convert_v1alpha4.go
@@ -45,6 +45,7 @@ func convertv1alpha4Node(in *v1alpha4.Node, out *Node) {
 	out.Role = NodeRole(in.Role)
 	out.Image = in.Image
 
+	out.KubeadmConfigPatches = in.KubeadmConfigPatches
 	out.ExtraMounts = make([]Mount, len(in.ExtraMounts))
 	out.ExtraPortMappings = make([]PortMapping, len(in.ExtraPortMappings))
 
@@ -54,6 +55,10 @@ func convertv1alpha4Node(in *v1alpha4.Node, out *Node) {
 
 	for i := range in.ExtraPortMappings {
 		convertv1alpha4PortMapping(&in.ExtraPortMappings[i], &out.ExtraPortMappings[i])
+	}
+
+	for i := range out.KubeadmConfigPatchesJSON6902 {
+		convertv1alpha4PatchJSON6902(&in.KubeadmConfigPatchesJSON6902[i], &out.KubeadmConfigPatchesJSON6902[i])
 	}
 }
 

--- a/pkg/internal/apis/config/convert_v1alpha4.go
+++ b/pkg/internal/apis/config/convert_v1alpha4.go
@@ -49,6 +49,7 @@ func convertv1alpha4Node(in *v1alpha4.Node, out *Node) {
 	out.KubeadmConfigPatches = in.KubeadmConfigPatches
 	out.ExtraMounts = make([]Mount, len(in.ExtraMounts))
 	out.ExtraPortMappings = make([]PortMapping, len(in.ExtraPortMappings))
+	out.KubeadmConfigPatchesJSON6902 = make([]PatchJSON6902, len(in.KubeadmConfigPatchesJSON6902))
 
 	for i := range in.ExtraMounts {
 		convertv1alpha4Mount(&in.ExtraMounts[i], &out.ExtraMounts[i])
@@ -58,7 +59,7 @@ func convertv1alpha4Node(in *v1alpha4.Node, out *Node) {
 		convertv1alpha4PortMapping(&in.ExtraPortMappings[i], &out.ExtraPortMappings[i])
 	}
 
-	for i := range out.KubeadmConfigPatchesJSON6902 {
+	for i := range in.KubeadmConfigPatchesJSON6902 {
 		convertv1alpha4PatchJSON6902(&in.KubeadmConfigPatchesJSON6902[i], &out.KubeadmConfigPatchesJSON6902[i])
 	}
 }

--- a/pkg/internal/apis/config/encoding/load_test.go
+++ b/pkg/internal/apis/config/encoding/load_test.go
@@ -98,6 +98,11 @@ func TestLoadCurrent(t *testing.T) {
 			ExpectError: false,
 		},
 		{
+			TestName:    "v1alpha4 config with workers patches",
+			Path:        "./testdata/v1alpha4/valid-kind-workers-patches.yaml",
+			ExpectError: false,
+		},
+		{
 			TestName:    "v1alpha4 non-existent field",
 			Path:        "./testdata/v1alpha4/invalid-bogus-field.yaml",
 			ExpectError: true,

--- a/pkg/internal/apis/config/encoding/testdata/v1alpha4/valid-kind-workers-patches.yaml
+++ b/pkg/internal/apis/config/encoding/testdata/v1alpha4/valid-kind-workers-patches.yaml
@@ -1,0 +1,31 @@
+# this config file contains all config fields with comments
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+
+# 1 control plane node and 3 workers
+nodes:
+# the control plane node config
+- role: control-plane
+# the three workers
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "aqua=gateway"
+        authorization-mode: "AlwaysAllow"
+- role: worker
+  kubeadmConfigPatchesJson6902:
+  - group: kubelet.config.k8s.io
+    version: v1beta1
+    kind: KubeletConfiguration
+    patch: |
+      - op: add
+        path: /authentication
+        value: {"anonymous": {"enabled": true}}
+      - op: add
+        path: /tlsCipherSuites
+        value: ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]
+- role: worker

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -63,6 +63,16 @@ type Node struct {
 	// ExtraPortMappings describes additional port mappings for the node container
 	// binded to a host Port
 	ExtraPortMappings []PortMapping
+
+	// KubeadmConfigPatches are applied to the generated kubeadm config as
+	// strategic merge patches to `kustomize build` internally
+	// https://github.com/kubernetes/community/blob/a9cf5c8f3380bb52ebe57b1e2dbdec136d8dd484/contributors/devel/sig-api-machinery/strategic-merge-patch.md
+	// This should be an inline yaml blob-string
+	KubeadmConfigPatches []string
+
+	// KubeadmConfigPatchesJSON6902 are applied to the generated kubeadm config
+	// as patchesJson6902 to `kustomize build`
+	KubeadmConfigPatchesJSON6902 []PatchJSON6902
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/internal/apis/config/zz_generated.deepcopy.go
+++ b/pkg/internal/apis/config/zz_generated.deepcopy.go
@@ -99,6 +99,16 @@ func (in *Node) DeepCopyInto(out *Node) {
 		*out = make([]PortMapping, len(*in))
 		copy(*out, *in)
 	}
+	if in.KubeadmConfigPatches != nil {
+		in, out := &in.KubeadmConfigPatches, &out.KubeadmConfigPatches
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.KubeadmConfigPatchesJSON6902 != nil {
+		in, out := &in.KubeadmConfigPatchesJSON6902, &out.KubeadmConfigPatchesJSON6902
+		*out = make([]PatchJSON6902, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Issue Reference #1084 

Hopefully this is a good approach, but I'm open to any changes.
One thing is, I wonder if it makes more sense to place **`KubeadmConfigPatches`** and **`KubeadmConfigPatchesJSON6902`** into a separate struct and embed.

TODO:
 
- Integration Testing (working on this)
