### PR TITLE
deepcopygen for v1alpha4

### DIFF
--- a/hack/update/generated.sh
+++ b/hack/update/generated.sh
@@ -46,6 +46,8 @@ cd "${FAKE_REPOPATH}"
 # run the generators
 bin/deepcopy-gen -i ./pkg/internal/apis/config/ -O zz_generated.deepcopy --go-header-file hack/tools/boilerplate.go.txt
 bin/deepcopy-gen -i ./pkg/apis/config/v1alpha3 -O zz_generated.deepcopy --go-header-file hack/tools/boilerplate.go.txt
+bin/deepcopy-gen -i ./pkg/apis/config/v1alpha4 -O zz_generated.deepcopy --go-header-file hack/tools/boilerplate.go.txt
+
 
 # set module mode back, return to repo root and gofmt to ensure we format generated code
 export GO111MODULE="on"


### PR DESCRIPTION
xref: #1083 
I missed this when adding the v1alpha4 types