### PR TITLE
containerd 1.3 latest backports

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -23,7 +23,7 @@ FROM ubuntu:19.10
 
 # Configure containerd and runc binaries from kind-ci/containerd-nightlies repository
 # The repository contains latest stable releases and nightlies built for multiple architectures
-ARG CONTAINERD_VERSION="v1.3.0-20-g7af311b4"
+ARG CONTAINERD_VERSION="v1.3.0-27-g54658b88"
 # Configure CNI binaries from upstream
 ARG CNI_VERSION="v0.8.2"
 # Configure crictl binary from upstream

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.16.2@sha256:7687c6655c53a4be7fd710851a4958240e2cb2c8e7c661d53413f6744bceeff4"
+const Image = "kindest/node:v1.16.2@sha256:a7f326788ea117b4692965d68a802331b335b534d6c4a75d8343dff73a75d1b2"

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -42,7 +42,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20191105-ee880e9b@sha256:f4c7c8ac0d387a18ba0bd2756b17551102b7322497796e3ad3f366c3e67c01d2"
+const DefaultBaseImage = "kindest/base:v20191110-cc1be87@sha256:92a9806456d7c51fc14e3dd4c0f92080e691af16d2d6db96356c97be8f6c1855"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
Upgrades to https://github.com/containerd/containerd/commit/54658b88, after fixing the kind containerd build (bump go to match upstream, fixup the release infra to support releasing versions that are already tagged but have had the release deleted).

The notable change for us is using go1.12.13 to build.

https://github.com/containerd/containerd/compare/7af311b4...54658b88