### PR TITLE
CLI fun

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ kind create cluster --image kindest/node:latest
 Multi-node clusters and other advanced features may be configured with a config
 file, for more usage see [the docs][user guide] or run `kind [command] --help`
 
-## Community, discussion, contribution, and support
+## Community
 
 Please reach out for bugs, feature requests, and other issues!  
 The maintainers of this project are reachable via:
@@ -90,7 +90,10 @@ Current maintainers are [@BenTheElder] and [@munnerz] - feel free to
 reach out if you have any questions!
 
 Pull Requests are very welcome!  
-See the [issue tracker] if you're unsure where to start, or feel free to reach out to discuss.
+If you're planning a new feature, please file an issue to discuss first.
+
+Check the [issue tracker] for `help wanted` issues if you're unsure where to
+start, or feel free to reach out to discuss. 🙂
 
 See also: our own [contributor guide] and the Kubernetes [community page].
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053
 	github.com/evanphx/json-patch v4.5.0+incompatible
+	github.com/mattn/go-colorable v0.1.4
 	github.com/mattn/go-isatty v0.0.10
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,9 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -98,6 +101,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191105231009-c1f44814a5cd h1:3x5uuvBgE6oaXJjCOvpCC1IpgJogqQ+PqGGU3ZxAgII=

--- a/pkg/cluster/createoption.go
+++ b/pkg/cluster/createoption.go
@@ -107,3 +107,20 @@ func CreateWithStopBeforeSettingUpKubernetes(stopBeforeSettingUpKubernetes bool)
 		return nil
 	})
 }
+
+// CreateWithDisplayUsage enables displaying usage if displayUsage is true
+func CreateWithDisplayUsage(displayUsage bool) CreateOption {
+	return createOptionAdapter(func(o *internalcreate.ClusterOptions) error {
+		o.DisplayUsage = displayUsage
+		return nil
+	})
+}
+
+// CreateWithDisplaySalutation enables display a salutation t the end of create
+// cluster if displaySalutation is true
+func CreateWithDisplaySalutation(displaySalutation bool) CreateOption {
+	return createOptionAdapter(func(o *internalcreate.ClusterOptions) error {
+		o.DisplaySalutation = displaySalutation
+		return nil
+	})
+}

--- a/pkg/cmd/kind/create/cluster/createcluster.go
+++ b/pkg/cmd/kind/create/cluster/createcluster.go
@@ -90,6 +90,8 @@ func runE(logger log.Logger, streams cmd.IOStreams, flags *flagpole) error {
 		cluster.CreateWithRetain(flags.Retain),
 		cluster.CreateWithWaitForReady(flags.Wait),
 		cluster.CreateWithKubeconfigPath(flags.Kubeconfig),
+		cluster.CreateWithDisplayUsage(true),
+		cluster.CreateWithDisplaySalutation(true),
 	); err != nil {
 		if errs := errors.Errors(err); errs != nil {
 			for _, problem := range errs {

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -54,7 +54,7 @@ kind create cluster --image kindest/node:latest
 Multi-node clusters and other advanced features may be configured with a config
 file, for more usage see [the user guide][user guide] or run `kind [command] --help`
 
-## Community, discussion, contribution, and support
+## Community
 
 Please reach out for bugs, feature requests, and other issues!  
 The maintainers of this project are reachable via:
@@ -67,7 +67,10 @@ Current maintainers are [@BenTheElder] and [@munnerz] - feel free to
 reach out if you have any questions!
 
 Pull Requests are very welcome!  
-See the [issue tracker] if you're unsure where to start, or feel free to reach out to discuss.
+If you're planning a new feature, please file an issue to discuss first.
+
+Check the [issue tracker] for `help wanted` issues if you're unsure where to
+start, or feel free to reach out to discuss. 🙂
 
 See also: our own [contributor guide] and the Kubernetes [community page]. 
 


### PR DESCRIPTION
Hacked up a few minor nice-to-haves this weekend:
- Make the spinner handle longer lines better (by toggling line wrapping)
  - Use github.com/mattn/go-colorable to handle the ANSI codes on Windows
- Add colors to the statuses when using a spinner (green check, red X)
- Update the readme / site slightly (mostly unrelated, but we want to link to this...)
- Add a random salutation to `kind create cluster`

Example:
<img width="509" alt="Screen Shot 2019-11-10 at 6 49 36 PM" src="https://user-images.githubusercontent.com/917931/68558198-4819bc00-03ed-11ea-90dc-a69edc00a7b7.png">
