### PR TITLE
Fix line wrapping in terminals.

### DIFF
--- a/pkg/internal/util/cli/spinner.go
+++ b/pkg/internal/util/cli/spinner.go
@@ -65,12 +65,12 @@ var _ io.Writer = &Spinner{}
 // NewSpinner initializes and returns a new Spinner that will write to w
 // NOTE: w should be os.Stderr or similar, and it should be a Terminal
 func NewSpinner(w io.Writer) *Spinner {
-	frameFormat := "\x1b[?7l\x1b[2K\r%s%s%s\x1b[?7h"
+	frameFormat := "\x1b[?7l\r%s%s%s\x1b[?7h"
 	// toggling wrapping seems to behave poorly on windows
 	// in general only the simplest escape codes behave well at the moment,
 	// and only in newer shells
 	if runtime.GOOS == "windows" {
-		frameFormat = "\x1b[2K\r%s%s%s"
+		frameFormat = "\r%s%s%s"
 	}
 	return &Spinner{
 		stop:        make(chan struct{}, 1),
@@ -161,7 +161,7 @@ func (s *Spinner) Write(p []byte) (n int, err error) {
 		return s.writer.Write(p)
 	}
 	// otherwise: we will rewrite the line first
-	if _, err := s.writer.Write([]byte("\x1b[2K\r")); err != nil {
+	if _, err := s.writer.Write([]byte("\r")); err != nil {
 		return 0, err
 	}
 	return s.writer.Write(p)


### PR DESCRIPTION
The ansi escape code to erase the current line adds mysterious whitespace when terminal is resized.
Just simple carriage return should be sufficient.