### PR TITLE
Fix MacOS installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,15 @@ generally recommended for CI usage in particular.
 To install, download the binary for your platform from "Assets" and place this
 into your `$PATH`:
 
-On Mac & Linux:
+On Mac:
+
+```console
+curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-darwin-amd64
+chmod +x ./kind
+mv ./kind /some-dir-in-your-PATH/kind
+```
+
+On Linux:
 
 ```console
 curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-$(uname)-amd64


### PR DESCRIPTION
Update instructions to get binary from GitHub release on MacOS: `kind-Darwin-amd64 -> kind-darwin-amd64`