### PR TITLE
add colors to error and warning

### DIFF
--- a/cmd/kind/app/main.go
+++ b/cmd/kind/app/main.go
@@ -79,7 +79,11 @@ func checkQuiet(args []string) bool {
 
 // logError logs the error and the root stacktrace if there is one
 func logError(logger log.Logger, err error) {
-	logger.Errorf("ERROR: %v", err)
+	if cmd.ColorEnabled(logger) {
+		logger.Errorf("\x1b[31mERROR\x1b[0m: %v", err)
+	} else {
+		logger.Errorf("ERROR: %v", err)
+	}
 	// If debugging is enabled (non-zero verbosity), display more info
 	if logger.V(1).Enabled() {
 		// Display Output if the error was running a command ...

--- a/pkg/cmd/kind/root.go
+++ b/pkg/cmd/kind/root.go
@@ -89,10 +89,10 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	return cmd
 }
 
-func runE(logger log.Logger, flags *flagpole, cmd *cobra.Command) error {
+func runE(logger log.Logger, flags *flagpole, command *cobra.Command) error {
 	// handle limited migration for --loglevel
-	setLogLevel := cmd.Flag("loglevel").Changed
-	setVerbosity := cmd.Flag("verbosity").Changed
+	setLogLevel := command.Flag("loglevel").Changed
+	setVerbosity := command.Flag("verbosity").Changed
 	if setLogLevel && !setVerbosity {
 		switch flags.LogLevel {
 		case "debug":
@@ -110,7 +110,11 @@ func runE(logger log.Logger, flags *flagpole, cmd *cobra.Command) error {
 	maybeSetVerbosity(logger, log.Level(flags.Verbosity))
 	// warn about deprecated flag if used
 	if setLogLevel {
-		logger.Warn("WARNING: --loglevel is deprecated, please switch to -v and -q!")
+		if cmd.ColorEnabled(logger) {
+			logger.Warn("\x1b[93mWARNING\x1b[0m: --loglevel is deprecated, please switch to -v and -q!")
+		} else {
+			logger.Warn("WARNING: --loglevel is deprecated, please switch to -v and -q!")
+		}
 	}
 	return nil
 }

--- a/pkg/cmd/logger.go
+++ b/pkg/cmd/logger.go
@@ -35,3 +35,13 @@ func NewLogger() log.Logger {
 	}
 	return cli.NewLogger(writer, 0)
 }
+
+// ColorEnabled returns true if color is enabled for the logger
+// this should be used to control output
+func ColorEnabled(logger log.Logger) bool {
+	type maybeColorer interface {
+		ColorEnabled() bool
+	}
+	v, ok := logger.(maybeColorer)
+	return ok && v.ColorEnabled()
+}


### PR DESCRIPTION
red for `ERROR`, yellow for `WARNING` when not using a "dumb" terminal

one last bit of shine for v0.6 because why not, I was waiting for other tests to run :-)