### PR TITLE
Added notes on loading images to named clusters

### DIFF
--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -17,19 +17,17 @@ It may additionally be helpful to:
 - reach out and ask for help in [#kind] on the [kubernetes slack]
 
 ## Contents
-- [Known Issues](#known-issues)
-  - [Contents](#contents)
-  - [Failures involving mismatched kubectl versions](#failures-involving-mismatched-kubectl-versions)
-  - [Older Docker Installations](#older-docker-installations)
-  - [Docker on Btrfs](#docker-on-btrfs)
-    - [Docker Installed with Snap](#docker-installed-with-snap)
-  - [Failing to apply overlay network](#failing-to-apply-overlay-network)
-  - [Failure to build node image](#failure-to-build-node-image)
-  - [Failing to properly start cluster](#failing-to-properly-start-cluster)
-  - [Pod errors due to "too many open files"](#pod-errors-due-to-%22too-many-open-files%22)
-  - [Docker permission denied](#docker-permission-denied)
-  - [Docker on Windows](#docker-on-windows)
-  - [Unable to pull images](#unable-to-pull-images)
+* [Failures involving mismatched kubectl versions](#failures-involving-mismatched-kubectl-version)
+* [Older Docker Installations](#older-docker-installations)
+* [Docker on Btrfs](#docker-on-btrfs)
+* [Docker installed with Snap](#docker-installed-with-snap)
+* [Failing to apply overlay network](#failing-to-apply-overlay-network)
+* [Failure to build node image](#failure-to-build-node-image)
+* [Failure for cluster to properly start](#failure-for-cluster-to-properly-start)
+* [Pod errors due to "too many open files"](#pod-errors-due-to-too-many-open-files)
+* [Docker permission denied](#docker-permission-denied)
+* [Docker on Windows](#docker-on-windows)
+* [Unable to pull images](#unable-to-pull-images)
 
 ## Failures involving mismatched kubectl versions
 

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -17,16 +17,19 @@ It may additionally be helpful to:
 - reach out and ask for help in [#kind] on the [kubernetes slack]
 
 ## Contents
-* [Failures involving mismatched kubectl versions](#failures-involving-mismatched-kubectl-version)
-* [Older Docker Installations](#older-docker-installations)
-* [Docker on Btrfs](#docker-on-btrfs)
-* [Docker installed with Snap](#docker-installed-with-snap)
-* [Failing to apply overlay network](#failing-to-apply-overlay-network)
-* [Failure to build node image](#failure-to-build-node-image)
-* [Failure for cluster to properly start](#failure-for-cluster-to-properly-start)
-* [Pod errors due to "too many open files"](#pod-errors-due-to-too-many-open-files)
-* [Docker permission denied](#docker-permission-denied)
-* [Docker on Windows](#docker-on-windows)
+- [Known Issues](#known-issues)
+  - [Contents](#contents)
+  - [Failures involving mismatched kubectl versions](#failures-involving-mismatched-kubectl-versions)
+  - [Older Docker Installations](#older-docker-installations)
+  - [Docker on Btrfs](#docker-on-btrfs)
+    - [Docker Installed with Snap](#docker-installed-with-snap)
+  - [Failing to apply overlay network](#failing-to-apply-overlay-network)
+  - [Failure to build node image](#failure-to-build-node-image)
+  - [Failing to properly start cluster](#failing-to-properly-start-cluster)
+  - [Pod errors due to "too many open files"](#pod-errors-due-to-%22too-many-open-files%22)
+  - [Docker permission denied](#docker-permission-denied)
+  - [Docker on Windows](#docker-on-windows)
+  - [Unable to pull images](#unable-to-pull-images)
 
 ## Failures involving mismatched kubectl versions
 
@@ -286,6 +289,19 @@ or try to use `sudo` before your commands (if you get `command not found` please
 
 `kind` for Windows requires Linux containers. To switch between Linux and Windows containers see [this page][switch between windows and linux containers].
 
+## Unable to pull images
+
+When using named Kind instances you may sometimes see your images failing to pull correctly on pods. This will usually manifest itself with the following output when doing a `kubectl describe pod my-pod`
+
+```
+Failed to pull image "docker.io/my-custom-image:tag": rpc error: code = Unknown desc = failed to resolve image "docker.io/library/my-custom-image:tag": no available registry endpoint: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
+```
+
+If this image has been loaded onto your kind cluster using the command `kind load docker-image my-custom-image` then you have likely not provided the name parameter. 
+
+Re-run the command this time adding the `--name my-cluster-name` param:
+
+`kind load docker-image my-custom-image --name my-cluster-name`
 
 [issue tracker]: https://github.com/kubernetes-sigs/kind/issues
 [file an issue]: https://github.com/kubernetes-sigs/kind/issues/new

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -129,6 +129,10 @@ context name `kind` and delete that cluster.
 Docker images can be loaded into your cluster nodes with:
 `kind load docker-image my-custom-image`
 
+**Note**: If using a named cluster you will need to specify the name of the 
+cluster you wish to load the image into:
+`kind load docker-image my-custom-image --name kind-2`
+
 Additionally, image archives can be loaded with:
 `kind load image-archive /my-image-archive.tar`
 


### PR DESCRIPTION
I got very confused trying to load images onto named instances of Kind, seemed nowhere documented that I had to specify the name of the cluster i wanted to load the image into.

Have updated the docs as appropriate to hopefully save confusion for people in future