### PR TITLE
providers/docker: omit linked containers when listing nodes

### DIFF
--- a/pkg/internal/cluster/providers/docker/provider.go
+++ b/pkg/internal/cluster/providers/docker/provider.go
@@ -106,8 +106,9 @@ func (p *Provider) ListNodes(cluster string) ([]nodes.Node, error) {
 	}
 	// convert names to node handles
 	ret := make([]nodes.Node, 0, len(lines))
-	for _, name := range lines {
-		ret = append(ret, p.node(name))
+	for _, line := range lines {
+		names := strings.Split(line, ",") // omit linked containers
+		ret = append(ret, p.node(names[0]))
 	}
 	return ret, nil
 }


### PR DESCRIPTION
When a kind node container is linked to another container
using something like "--link kind-control-plane:target"
The output of commands such as "kind get nodes"
can include the following:

  kind-control-plane,some-container-80/target

Make ListNodes() include only the part before the first ","
as the node name.

/kind bug
/priority important-longterm

fixes https://github.com/kubernetes-sigs/kind/issues/1116
