### PR TITLE
Set a default config file (.kind.yaml)

### DIFF
--- a/pkg/cluster/constants/constants.go
+++ b/pkg/cluster/constants/constants.go
@@ -20,6 +20,9 @@ package constants
 // DefaultClusterName is the default cluster Context name
 const DefaultClusterName = "kind"
 
+// DefaultConfigPath is the default cluster config file path
+const DefaultConfigPath = ".kind.yaml"
+
 /* node role value constants */
 const (
 	// ControlPlaneNodeRoleValue identifies a node that hosts a Kubernetes

--- a/pkg/cluster/provider.go
+++ b/pkg/cluster/provider.go
@@ -35,6 +35,9 @@ import (
 // DefaultName is the default cluster name
 const DefaultName = constants.DefaultClusterName
 
+// DefaultConfig is the default config file path
+const DefaultConfig = constants.DefaultConfigPath
+
 // Provider is used to perform cluster operations
 type Provider struct {
 	provider internalprovider.Provider

--- a/pkg/cmd/kind/create/cluster/createcluster.go
+++ b/pkg/cmd/kind/create/cluster/createcluster.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -53,7 +54,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flags.Name, "name", cluster.DefaultName, "cluster context name")
-	cmd.Flags().StringVar(&flags.Config, "config", "", "path to a kind config file")
+	cmd.Flags().StringVar(&flags.Config, "config", cluster.DefaultConfig, "path to a kind config file")
 	cmd.Flags().StringVar(&flags.ImageName, "image", "", "node docker image to use for booting the cluster")
 	cmd.Flags().BoolVar(&flags.Retain, "retain", false, "retain nodes for debugging when cluster creation fails")
 	cmd.Flags().DurationVar(&flags.Wait, "wait", time.Duration(0), "Wait for control plane node to be ready (default 0s)")
@@ -110,6 +111,14 @@ func runE(logger log.Logger, streams cmd.IOStreams, flags *flagpole) error {
 func configOption(rawConfigFlag string, stdin io.Reader) (cluster.CreateOption, error) {
 	// if not - then we are using a real file
 	if rawConfigFlag != "-" {
+
+		// If the default config doesn't exist set rawConfigFlag to ""
+		if rawConfigFlag == cluster.DefaultConfig {
+			if _, err := os.Stat(rawConfigFlag); err == nil {
+				rawConfigFlag = ""
+			}
+		}
+
 		return cluster.CreateWithConfigFile(rawConfigFlag), nil
 	}
 	// otherwise read from stdin


### PR DESCRIPTION
I use kind for testing out different things against clusters and different versions. It's also a great way to bring development of kubernetes resources local and be able to clean up the cluster quickly and test configs against different versions. 

One small thing that I often forget is to type `--config .whatever.yaml ` when bringing up a cluster to develop against. This PR adds a default config file path of `.kind.yaml` and will test it's existence before trying to use it. Now I can have a .kind.yaml config at the root of my git projects and bring up a cluster for testing against without the additional `--config` flag.

Any feedback is greatly appreciated.   