### PR TITLE
skip restarting the containerd if the systemd is not fully up and running

### DIFF
--- a/pkg/internal/cluster/create/actions/config/config.go
+++ b/pkg/internal/cluster/create/actions/config/config.go
@@ -144,7 +144,8 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 					return errors.Wrap(err, "failed to write patched containerd config")
 				}
 				// restart containerd now that we've re-configured it
-				if err := node.Command("systemctl", "restart", "containerd").Run(); err != nil {
+				// skip if the systemd (also the containerd) is not running
+				if err := node.Command("bash", "-c", `! systemctl is-system-running || systemctl restart containerd`).Run(); err != nil {
 					return errors.Wrap(err, "failed to restart containerd after patching config")
 				}
 				return nil


### PR DESCRIPTION
hi, I use kind (0.6) in CI job (DinD) but it fails with the following error when I try to patch contained configuration.

```
 ✗ Writing configuration 📜 
ERROR: failed to create cluster: failed to restart containerd after patching config: command "docker exec --privileged tidb-operator-worker2 systemctl restart containerd" failed with error: exit status 1

Output:
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down

Stack Trace: 
sigs.k8s.io/kind/pkg/errors.WithStack
	/src/pkg/errors/errors.go:51
sigs.k8s.io/kind/pkg/exec.(*LocalCmd).Run
	/src/pkg/exec/local.go:116
sigs.k8s.io/kind/pkg/internal/cluster/providers/docker.(*nodeCmd).Run
	/src/pkg/internal/cluster/providers/docker/node.go:130
sigs.k8s.io/kind/pkg/internal/cluster/create/actions/config.(*Action).Execute.func2
	/src/pkg/internal/cluster/create/actions/config/config.go:147
sigs.k8s.io/kind/pkg/errors.UntilErrorConcurrent.func1
	/src/pkg/errors/concurrent.go:30
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1357
```

I figured out that at the bootstrap of node container, the PID 1 is not the systemd. Even if it's the systemd, we should wait for the systemd to be fully up and running.  So I patch the kind to make it work stable in CI job.

**Update**: skip restarting the containerd if the systems is not running yet

https://www.freedesktop.org/software/systemd/man/systemctl.html#is-system-running