### PR TITLE
fix kindnetd preloading

### DIFF
--- a/pkg/build/node/cni.go
+++ b/pkg/build/node/cni.go
@@ -27,7 +27,7 @@ const (
 The default CNI manifest and images are our own tiny kindnet
 */
 
-var defaultCNIImages = []string{"kindest/kindnetd:0.5.3@sha256:bc1833b3da442bb639008dd5a62861a0419d3f64b58fce6fb38b749105232555"}
+var defaultCNIImages = []string{"kindest/kindnetd:0.5.3"}
 
 const defaultCNIManifest = `
 # kindnetd networking manifest


### PR DESCRIPTION
we don't actually need the hash right now

I'm going to write a more complete fix, but would prefer to get a patch release out with fixed images first.