### PR TITLE
upgrade to go 1.13.5

### DIFF
--- a/hack/go_container.sh
+++ b/hack/go_container.sh
@@ -30,7 +30,7 @@ SOURCE_DIR="${SOURCE_DIR:-$(pwd -P)}"
 # default to disabling CGO for easier reproducible builds and cross compilation
 export CGO_ENABLED="${CGO_ENABLED:-0}"
 # the container image, by default a recent official golang image
-GOIMAGE="${GOIMAGE:-golang:1.13.4}"
+GOIMAGE="${GOIMAGE:-golang:1.13.5}"
 # docker volume name, used as a go module / build cache
 CACHE_VOLUME="${CACHE_VOLUME:-kind-build-cache}"
 # ========================== END SCRIPT SETTINGS ===============================


### PR DESCRIPTION
The docker image is not available yet, but CI won't pass until it is.