### PR TITLE
ship a better storage solution

### DIFF
--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.16.3@sha256:70ce6ce09bee5c34ab14aec2b84d6edb260473a60638b1b095470a3a0f95ebec"
+const Image = "kindest/node:v1.17.0@sha256:c1ccbb2d2a5358a7dfba838537baeed84c2f6c0c69ae8a15df8a4915b4dc9a14"

--- a/pkg/build/node/cni.go
+++ b/pkg/build/node/cni.go
@@ -16,13 +16,6 @@ limitations under the License.
 
 package node
 
-// these are well known paths within the node image
-const (
-	// TODO: refactor kubernetesVersionLocation to a common internal package
-	kubernetesVersionLocation  = "/kind/version"
-	defaultCNIManifestLocation = "/kind/manifests/default-cni.yaml"
-)
-
 /*
 The default CNI manifest and images are our own tiny kindnet
 */

--- a/pkg/build/node/const.go
+++ b/pkg/build/node/const.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+// these are well known paths within the node image
+const (
+	// TODO: refactor kubernetesVersionLocation to a common internal package
+	kubernetesVersionLocation      = "/kind/version"
+	defaultCNIManifestLocation     = "/kind/manifests/default-cni.yaml"
+	defaultStorageManifestLocation = "/kind/manifests/default-storage.yaml"
+)

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -392,7 +392,7 @@ func (c *BuildContext) prePullImages(dir, containerID string) error {
 	// later releases use manifest list images
 	// at node boot time we retag our images to handle this where necessary,
 	// so we virtually re-tag them here.
-	ver, err := version.ParseGeneric(rawVersion[0])
+	ver, err := version.ParseSemantic(rawVersion[0])
 	if err != nil {
 		return err
 	}
@@ -431,7 +431,7 @@ func (c *BuildContext) prePullImages(dir, containerID string) error {
 	requiredImages = append(requiredImages, defaultCNIImages...)
 
 	// for v1.12.0+ we support a nicer storage driver
-	if ver.LessThan(version.MustParseGeneric("v1.12.0")) {
+	if ver.LessThan(version.MustParseSemantic("v1.12.0")) {
 		// otherwise, we must use something built in and simpler, which is
 		// also the same as what kind previously used...
 		if err := writeManifest(cmder, legacyDefaultStorage, defaultStorageManifest); err != nil {

--- a/pkg/build/node/storage.go
+++ b/pkg/build/node/storage.go
@@ -145,3 +145,16 @@ data:
                 ]
         }
 `
+
+// legacy default storage class for older than Kubernetes v1.12.0
+// we need this for e2es (StatefulSet)
+// newer kind images ship a storage driver manifest
+const legacyDefaultStorage = `# host-path based default storage class
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  namespace: kube-system
+  name: standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/host-path`

--- a/pkg/build/node/storage.go
+++ b/pkg/build/node/storage.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+/*
+The default PV driver manifest and images are provisionally rancher.io/local-path-provisioner
+NOTE: we have customized it in the following ways:
+- storage is under /var instead of /opt
+- debian-base is used as the helper image (k8s already ships this upstream as the base for many images) instead of busybox
+- schedule to "master" kubeadm nodes (control-plane host)
+- install as the default storage class
+*/
+
+var defaultStorageImages = []string{"rancher/local-path-provisioner:v0.0.11", "k8s.gcr.io/debian-base:v2.0.0"}
+
+const defaultStorageManifest = `
+# kind customized https://github.com/rancher/local-path-provisioner manifest
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner-role
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "persistentvolumeclaims"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["endpoints", "persistentvolumes", "pods"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ''
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Equal
+        effect: NoSchedule
+      serviceAccountName: local-path-provisioner-service-account
+      containers:
+      - name: local-path-provisioner
+        image: rancher/local-path-provisioner:v0.0.11
+        imagePullPolicy: IfNotPresent
+        command:
+        - local-path-provisioner
+        - --debug
+        - start
+        - --helper-image
+        - k8s.gcr.io/debian-base:v2.0.0
+        - --config
+        - /etc/config/config.json
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config/
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      volumes:
+        - name: config-volume
+          configMap:
+            name: local-path-config
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  namespace: kube-system
+  name: standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  config.json: |-
+        {
+                "nodePathMap":[
+                {
+                        "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                        "paths":["/var/local-path-provisioner"]
+                }
+                ]
+        }
+`


### PR DESCRIPTION
- install a customized rancher.io/local-host-path driver config at image build time (with preloaded images)
- when installing the default storage class, attempt to install from the node instead of from the one in the kind binary first

TODO:
- [x] handle kubernetes < 1.12
  - DONE: for less than 1.12 we will ship the old manifest.
- [x] Push an image

I'll handle those later tonight. I just want to surface progress on this.

Fixes #1151 #118 