### PR TITLE
Update kubelet/kube-proxy feature-gates settings via ComponentConfig

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -343,6 +343,11 @@ kubeadmConfigPatches:
   kind: KubeletConfiguration
   featureGates:
     FeatureGateName: true
+- |
+  apiVersion: kubeproxy.config.k8s.io/v1alpha1
+  kind: KubeProxyConfiguration
+  featureGates:
+    FeatureGateName: true
 # 1 control plane node and 3 workers
 nodes:
 # the control plane node config

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -338,6 +338,11 @@ kubeadmConfigPatches:
   nodeRegistration:
     kubeletExtraArgs:
       "feature-gates": "FeatureGateName=true"
+- |
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  kind: KubeletConfiguration
+  featureGates:
+    FeatureGateName: true
 # 1 control plane node and 3 workers
 nodes:
 # the control plane node config


### PR DESCRIPTION
I add kubelet/kube-proxy feature-gates settings via ComponentConfig.
I do not remove InitConfiguration for documentations, but it's kubeletExtraArgs."feature-gates" doesn't work.


