### PR TITLE
Fix typo in provider documentation

### DIFF
--- a/pkg/cluster/provider.go
+++ b/pkg/cluster/provider.go
@@ -112,7 +112,7 @@ func (p *Provider) List() ([]string, error) {
 
 // KubeConfig returns the KUBECONFIG for the cluster
 // If internal is true, this will contain the internal IP etc.
-// If internal is fale, this will contain the host IP etc.
+// If internal is false, this will contain the host IP etc.
 func (p *Provider) KubeConfig(name string, internal bool) (string, error) {
 	return kubeconfig.Get(p.ic(name), !internal)
 }


### PR DESCRIPTION
Just digging through some of the code, and noticed this in the comments.