### PR TITLE
template site baseURL

### DIFF
--- a/site/content/docs/user/ingress.md
+++ b/site/content/docs/user/ingress.md
@@ -156,7 +156,7 @@ spec:
 Apply the contents
 
 ```shell script
-kubectl apply -f https://kind.sigs.k8s.io/manifests/ingress/nginx/example.yaml
+kubectl apply -f {{< absurl "manifests/ingress/nginx/example.yaml" >}}
 ```
 
 Now verify that the ingress works

--- a/site/layouts/shortcodes/absurl.hml
+++ b/site/layouts/shortcodes/absurl.hml
@@ -1,0 +1,2 @@
+{{/* the one input should be a relative url */}}
+{{- .Get 0 | absURL }}


### PR DESCRIPTION
for use when referencing hosted content, this makes it possible to correctly use previews and handle local development properly ...