### PR TITLE
cleanup registry examples

### DIFF
--- a/site/assets/css/inline.css
+++ b/site/assets/css/inline.css
@@ -173,7 +173,9 @@ pre code {
 
 /* inline copyable code snippet styling */
 table.includecode {
+  max-width: 100%;
   width: 100%;
+  table-layout: fixed;
   background: #f3f4f4;
   border: 1px solid black;
   border-spacing: 0;

--- a/site/content/docs/user/local-registry.md
+++ b/site/content/docs/user/local-registry.md
@@ -17,7 +17,7 @@ The following recipe leverages this to enable a local registry.
 The following shell script will create a local docker registry and a kind cluster
 with it enabled.
 
-{{< codefromfile "static/examples/kind-with-registry.sh" >}}
+{{< codefromfile file="static/examples/kind-with-registry.sh" >}}
 
 ## Using The Registry
 

--- a/site/content/docs/user/local-registry.md
+++ b/site/content/docs/user/local-registry.md
@@ -17,33 +17,7 @@ The following recipe leverages this to enable a local registry.
 The following shell script will create a local docker registry and a kind cluster
 with it enabled.
 
-```bash
-#!/bin/sh
-set -o errexit
-
-# create registry container unless it already exists 
-CLUSTER_NAME="my-cluster"   # desired cluster name; default is "kind"
-REGISTRY_CONTAINER_NAME='kind-registry'
-REGISTRY_PORT='5000'
-if [ "$(docker inspect -f '{{.State.Running}}' "${REGISTRY_CONTAINER_NAME}")" != 'true' ]; then
-  docker run -d -p "${REGISTRY_PORT}:5000" --restart=always --name "${REGISTRY_CONTAINER_NAME}" registry:2
-fi
-
-# create a cluster with the local registry enabled in containerd
-cat <<EOF | kind create cluster --config=-
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-containerdConfigPatches: 
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry:${REGISTRY_PORT}"]
-    endpoint = ["http://registry:${REGISTRY_PORT}"]
-EOF
-
-# add the registry to /etc/hosts on each node
-for node in $(kind get nodes --name ${CLUSTER_NAME}); do
-  docker exec "${node}" sh -c "echo $(docker inspect --format '{{.NetworkSettings.IPAddress }}' "${REGISTRY_CONTAINER_NAME}") registry >> /etc/hosts"
-done
-```
+{{< codefromfile "static/examples/kind-with-registry.sh" >}}
 
 ## Using The Registry
 

--- a/site/content/docs/user/private-registries.md
+++ b/site/content/docs/user/private-registries.md
@@ -59,37 +59,10 @@ A credential can be programmatically added to the nodes at runtime.
 
 If you do this then kubelet must be restarted on each node to pick up the new credentials.
 
-An example bash snippet for generating a [gcr.io][GCR] cred file on your host machine
+An example shell snippet for generating a [gcr.io][GCR] cred file on your host machine
 using Access Tokens:
 
-```bash
-# login to GCR on all your kind nodes
-
-# KUBECONFIG should point to your kind cluster
-kind export kubeconfig --name="kind"
-
-# move the host config out of the way if it exists
-[ -f $HOME/.docker/config.json ] && mv $HOME/.docker/config.json $HOME/.docker/config.json.host
-
-# https://cloud.google.com/container-registry/docs/advanced-authentication#access_token
-gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://gcr.io
-
-# setup credentials on each node
-for node in $(kubectl get nodes -oname); do
-    # the -oname format is kind/name (so node/name) we just want name
-    node_name=${node#node/}
-    # copy the config to where kubelet will look
-    docker cp $HOME/.docker/config.json ${node_name}:/var/lib/kubelet/config.json
-    # restart kubelet to pick up the config
-    docker exec ${node_name} systemctl restart kubelet.service
-done
-
-# delete the temporary config
-rm $HOME/.docker/config.json
-
-# move the original, host config back if it exists
-[-f $HOME/.docker/config.json.host] && mv $HOME/.docker/config.json.host $HOME/.docker/config.json
-```
+{{< codefromfile file="static/examples/kind-gcr.sh" >}}
 
 ### Use a Service Account
 

--- a/site/static/examples/kind-gcr.sh
+++ b/site/static/examples/kind-gcr.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -o errexit
+
+# desired cluster name; default is "kind"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+
+# create a temp file for the docker config
+echo "Creating temporary docker client config directory ..."
+DOCKER_CONFIG=$(mktemp -d)
+export DOCKER_CONFIG
+trap 'echo "Removing ${DOCKER_CONFIG}/*" && rm -rf ${DOCKER_CONFIG:?}' EXIT
+
+# login to gcr in DOCKER_CONFIG using an access token
+# https://cloud.google.com/container-registry/docs/advanced-authentication#access_token
+echo "Logging in to GCR in temporary docker client config directory ..."
+gcloud auth print-access-token | \
+  docker login -u oauth2accesstoken --password-stdin https://gcr.io
+
+# setup credentials on each node
+echo "Moving credentials to kind cluster name='${KIND_CLUSTER_NAME}' nodes ..."
+for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
+  # the -oname format is kind/name (so node/name) we just want name
+  node_name=${node#node/}
+  # copy the config to where kubelet will look
+  docker cp "${DOCKER_CONFIG}/config.json" "${node_name}:/var/lib/kubelet/config.json"
+  # restart kubelet to pick up the config
+  docker exec ${node_name} systemctl restart kubelet.service
+done
+
+echo "Done!"

--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -o errexit
+
+# desired cluster name; default is "kind"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+REGISTRY_CONTAINER_NAME='kind-registry'
+REGISTRY_PORT='5000'
+
+# create registry container unless it already exists
+if [ "$(docker inspect -f '{{.State.Running}}' "${REGISTRY_CONTAINER_NAME}")" != 'true' ]; then
+  docker run -d -p "${REGISTRY_PORT}:5000" --restart=always --name "${REGISTRY_CONTAINER_NAME}" registry:2
+fi
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches: 
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry:${REGISTRY_PORT}"]
+    endpoint = ["http://registry:${REGISTRY_PORT}"]
+EOF
+
+# add the registry to /etc/hosts on each node
+for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
+  docker exec "${node}" sh -c "echo $(docker inspect --format '{{.NetworkSettings.IPAddress }}' "${REGISTRY_CONTAINER_NAME}") registry >> /etc/hosts"
+done

--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -3,12 +3,15 @@ set -o errexit
 
 # desired cluster name; default is "kind"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
-REGISTRY_CONTAINER_NAME='kind-registry'
-REGISTRY_PORT='5000'
 
 # create registry container unless it already exists
-if [ "$(docker inspect -f '{{.State.Running}}' "${REGISTRY_CONTAINER_NAME}")" != 'true' ]; then
-  docker run -d -p "${REGISTRY_PORT}:5000" --restart=always --name "${REGISTRY_CONTAINER_NAME}" registry:2
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}")"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    registry:2
 fi
 
 # create a cluster with the local registry enabled in containerd
@@ -17,11 +20,13 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches: 
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry:${REGISTRY_PORT}"]
-    endpoint = ["http://registry:${REGISTRY_PORT}"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry:${reg_port}"]
+    endpoint = ["http://registry:${reg_port}"]
 EOF
 
 # add the registry to /etc/hosts on each node
+ip_fmt='{{.NetworkSettings.IPAddress}}'
+cmd="echo $(docker inspect -f "${ip_fmt}" "${reg_name}") registry >> /etc/hosts"
 for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
-  docker exec "${node}" sh -c "echo $(docker inspect --format '{{.NetworkSettings.IPAddress }}' "${REGISTRY_CONTAINER_NAME}") registry >> /etc/hosts"
+  docker exec "${node}" sh -c "${cmd}"
 done


### PR DESCRIPTION
- use a file for the shell script
- fix inline code snippet layout for wide files
- reformat the script with shorter lines to read more easily
- reformat private registry script and move it out to an inlined file
- rework private registry script to not touch the normal host docker config, use a temp config