### PR TITLE
Docs cleanup

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -33,15 +33,15 @@ shown [here](https://golang.org/doc/code.html#GOPATH) if you encounter the error
 To use kind, you will also need to [install docker].  
 Once you have docker running you can create a cluster with:
 
-```
+{{< codeFromInline lang="bash" >}}
 kind create cluster
-```
+{{< /codeFromInline >}}
 
 To delete your cluster use:
 
-```
+{{< codeFromInline lang="bash" >}}
 kind delete cluster
-```
+{{< /codeFromInline >}}
 
 <!--TODO(bentheelder): improve this part of the guide-->
 To create a cluster from Kubernetes source:
@@ -49,10 +49,10 @@ To create a cluster from Kubernetes source:
 - ensure that Kubernetes is cloned in `$(go env GOPATH)/src/k8s.io/kubernetes`
 - build a node image and create a cluster with 
 
-```
+{{< codeFromInline lang="bash" >}}
 kind build node-image
 kind create cluster --image kindest/node:latest
-```
+{{< /codeFromInline >}}
 
 Multi-node clusters and other advanced features may be configured with a config
 file, for more usage see [the user guide][user guide] or run `kind [command] --help`

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -40,26 +40,26 @@ This problem is related to a bug in [docker on macOS][for-mac#3663]
 
 If you see something like the following error message:
 ```bash
-kubectl edit deploy -n kube-system kubernetes-dashboard
+$ kubectl edit deploy -n kube-system kubernetes-dashboard
 error: SchemaError(io.k8s.api.autoscaling.v2beta1.ExternalMetricStatus): invalid object doesn't have additional properties
 ```
 
 You can check your client and server versions by running:
-```bash
+{{< codeFromInline lang="bash" >}}
 kubectl version
-```
+{{< /codeFromInline >}}
 
 If there is a mismatch between the server and client versions, you should install a newer client version. 
 
 If you are using Mac, you can install kubectl via homebrew by running:
-```bash
+{{< codeFromInline lang="bash" >}}
 brew install kubernetes-cli
-```
+{{< /codeFromInline >}}
 
 And overwrite the symlinks created by Docker For Mac by running:
-```bash
+{{< codeFromInline lang="bash" >}}
 brew link --overwrite kubernetes-cli
-```
+{{< /codeFromInline >}}
 
 [for-mac#3663]: https://github.com/docker/for-mac/issues/3663
 
@@ -84,9 +84,9 @@ filesystem.
 
 This should only be relevant on Linux, on which you can check with:
 
-```
+{{< codeFromInline lang="bash" >}}
 docker info | grep -i storage
-```
+{{< /codeFromInline >}}
 
 As a workaround, you'll need to ensure that the storage driver is one that works.
 Docker's default of `overlay2` is a good choice, but `aufs` should also work.
@@ -238,14 +238,14 @@ Unable to connect to the server: EOF
 Then as in [kind#156][kind#156], you may solve this issue by claiming back some
 space on your machine by removing unused data or images left by the Docker 
 engine by running:
-```
+{{< codeFromInline lang="bash" >}}
 docker system prune
-```
+{{< /codeFromInline >}}
 
-and / or:
-```
+And / or:
+{{< codeFromInline lang="bash" >}}
 docker image prune
-```
+{{< /codeFromInline >}}
 
 You can verify the issue by exporting the logs (`kind export logs`) and looking
 at the kubelet logs, which may have something like the following:
@@ -257,7 +257,7 @@ Dec 07 00:37:53 kind-1-control-plane kubelet[688]: E1207 00:37:53.229638     688
 If on the other hand you are running kind on a btrfs partition and your logs
 show something like the following:
 ```
-an 03 17:42:41 kind-1-control-plane kubelet[3804]: F0103 17:42:41.470269 3804 kubelet.go:1359] Failed to start ContainerManager failed to get rootfs info: failed to get device for dir "/ var/lib/kubelet": could not find device with major: 0, minor: 67 in cached partitions map
+F0103 17:42:41.470269 3804 kubelet.go:1359] Failed to start ContainerManager failed to get rootfs info: failed to get device for dir "/ var/lib/kubelet": could not find device with major: 0, minor: 67 in cached partitions map
 ```
 
 This problem seems to be related to a [bug in Docker][moby#9939].
@@ -267,16 +267,16 @@ This problem seems to be related to a [bug in Docker][moby#9939].
 This may be caused by running out of [inotify](https://linux.die.net/man/7/inotify) resources. Resource limits are defined by `fs.inotify.max_user_watches` and `fs.inotify.max_user_instances` system variables. For example, in Ubuntu these default to 8192 and 128 respectively, which is not enough to create a cluster with many nodes.
 
 To increase these limits temporarily run the following commands on the host:
-```
-$ sudo sysctl fs.inotify.max_user_watches=524288
-$ sudo sysctl fs.inotify.max_user_instances=512
-```
+{{< codeFromInline lang="bash" >}}
+sudo sysctl fs.inotify.max_user_watches=524288
+sudo sysctl fs.inotify.max_user_instances=512
+{{< /codeFromInline >}}
 
 To make the changes persistent, edit the file `/etc/sysctl.conf` and add these lines:
-```
+{{< codeFromInline lang="bash" >}}
 fs.inotify.max_user_watches = 524288
 fs.inotify.max_user_instances = 512
-```
+{{< /codeFromInline >}}
 
 ## Docker permission denied
 

--- a/site/content/docs/user/private-registries.md
+++ b/site/content/docs/user/private-registries.md
@@ -43,15 +43,15 @@ you can mount it to each kind node.
 
 Assuming your file is at `/path/to/my/secret.json`, the kind config would be:
 
-```yaml
+{{< codeFromInline lang="yaml" >}}
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.sigs.k8s.io/v1alpha4
 nodes:
 - role: control-plane
   extraMounts:
   - containerPath: /var/lib/kubelet/config.json
     hostPath: /path/to/my/secret.json
-```
+{{< /codeFromInline >}}
 
 ### Use an Access Token
 

--- a/site/content/docs/user/private-registries.md
+++ b/site/content/docs/user/private-registries.md
@@ -45,7 +45,7 @@ Assuming your file is at `/path/to/my/secret.json`, the kind config would be:
 
 {{< codeFromInline lang="yaml" >}}
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha4
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   extraMounts:

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -33,29 +33,29 @@ into your `$PATH`.
 
 On macOS / Linux:
 
-```bash
+{{< codeFromInline lang="bash" >}}
 curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.6.1/kind-$(uname)-amd64
 chmod +x ./kind
 mv ./kind /some-dir-in-your-PATH/kind
-```
+{{< /codeFromInline >}}
 
 On Mac via Homebrew:
 
-```bash
+{{< codeFromInline lang="bash" >}}
 brew install kind
-```
+{{< /codeFromInline >}}
 
 On Windows:
 
-```powershell
+{{< codeFromInline lang="powershell" >}}
 curl.exe -Lo kind-windows-amd64.exe https://github.com/kubernetes-sigs/kind/releases/download/v0.6.1/kind-windows-amd64
 Move-Item .\kind-windows-amd64.exe c:\some-dir-in-your-PATH\kind.exe
-```
+{{< /codeFromInline >}}
 
 OR via Chocolatey (https://chocolatey.org/packages/kind)
-```powershell
+{{< codeFromInline lang="powershell" >}}
 choco install kind
-```
+{{< /codeFromInline >}}
 
 
 ## Creating a Cluster

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -267,7 +267,7 @@ configuration for this can be achieved with the following config file contents:
 ```yaml
 # three node (two workers) cluster config
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha4
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker
@@ -279,7 +279,7 @@ You can also have a cluster with multiple control-plane nodes:
 ```yaml
 # a cluster with 3 control-plane nodes and 3 workers
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha4
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: control-plane
@@ -293,7 +293,7 @@ nodes:
 You can map extra ports from the nodes to the host machine with `extraPortMappings`:
 ```yaml
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha4
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   extraPortMappings:
@@ -313,7 +313,7 @@ Feature gates are a set of key=value pairs that describe alpha or experimental f
 
 ```
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha4
+apiVersion: kind.x-k8s.io/v1alpha4
 # patch the generated kubeadm config with featuregates
 kubeadmConfigPatches:
 - |
@@ -357,7 +357,7 @@ Ensure you `systemctl restart docker` to pick up the changes.
 ```yaml
 # an ipv6 cluster
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha4
+apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   ipFamily: ipv6
 ```

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -267,7 +267,7 @@ configuration for this can be achieved with the following config file contents:
 ```yaml
 # three node (two workers) cluster config
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.sigs.k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker
@@ -279,7 +279,7 @@ You can also have a cluster with multiple control-plane nodes:
 ```yaml
 # a cluster with 3 control-plane nodes and 3 workers
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.sigs.k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: control-plane
@@ -293,10 +293,9 @@ nodes:
 You can map extra ports from the nodes to the host machine with `extraPortMappings`:
 ```yaml
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.sigs.k8s.io/v1alpha4
 nodes:
 - role: control-plane
-- role: worker
   extraPortMappings:
   - containerPort: 80
     hostPort: 80
@@ -313,10 +312,9 @@ Note: binding the `listenAddress` to `127.0.0.1` may affect your ability to acce
 Feature gates are a set of key=value pairs that describe alpha or experimental features. In order to enable a gate you have to [customize your kubeadm configuration][customize control plane with kubeadm], and it will depend on what gate and component you want to enable. An example kind config can be:
 
 ```
-# this config file contains all config fields with comments
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
-# patch the generated kubeadm config with some extra settings
+apiVersion: kind.sigs.k8s.io/v1alpha4
+# patch the generated kubeadm config with featuregates
 kubeadmConfigPatches:
 - |
   apiVersion: kubeadm.k8s.io/v1beta2
@@ -350,14 +348,6 @@ kubeadmConfigPatches:
   kind: KubeProxyConfiguration
   featureGates:
     FeatureGateName: true
-# 1 control plane node and 3 workers
-nodes:
-# the control plane node config
-- role: control-plane
-# the three workers
-- role: worker
-- role: worker
-- role: worker
 ```
 
 #### IPv6 clusters
@@ -367,14 +357,9 @@ Ensure you `systemctl restart docker` to pick up the changes.
 ```yaml
 # an ipv6 cluster
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.sigs.k8s.io/v1alpha4
 networking:
   ipFamily: ipv6
-nodes:
-# the control plane node
-- role: control-plane
-- role: worker
-- role: worker
 ```
 
 ### Configure kind to use a proxy

--- a/site/content/docs/user/using-wsl2.md
+++ b/site/content/docs/user/using-wsl2.md
@@ -45,12 +45,15 @@ Once your Windows Insider machine is ready, you need to do a few more steps to s
 
 1. Open a PowerShell window as an admin, then run
 
-    ```powershell
-    Enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform, Microsoft-Windows-Subsystem-Linux
-    ```
+    {{< codeFromInline lang="powershell" >}}
+Enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform, Microsoft-Windows-Subsystem-Linux
+{{< /codeFromInline >}}
 
 1. Reboot when prompted. 
-1. After the reboot, set WSL to default to WSL2. Open an admin PowerShell window and run `wsl --set-default-version 2`.
+1. After the reboot, set WSL to default to WSL2. Open an admin PowerShell window and run
+    {{< codeFromInline lang="powershell" >}}
+wsl --set-default-version 2
+{{< /codeFromInline >}}
 1. Now, you can install your Linux distro of choice by searching the Windows Store. If you don't want to use the Windows Store, then follow the steps in the WSL docs for [manual install](https://docs.microsoft.com/en-us/windows/wsl/install-manual).
 1. Start up your distro with the shortcut added to the start menu
 1. If you're on build 18941 (July 19, 2019) or earlier, then you'll need to build and update the kernel. See [Updating Kernel](#updating-kernel). Otherwise, move on to the next section.
@@ -117,7 +120,7 @@ For the latest status on this, see [issue #707](https://github.com/kubernetes-si
 
 First, clone the latest WSL2-Linux-Kernel source and build it.
 
-```bash
+{{< codeFromInline lang="bash" >}}
 # This assumes Ubuntu or Debian, a different step may be needed for RPM based distributions
 sudo apt install build-essential flex bison libssl-dev libelf-dev
 git clone --depth 1 https://github.com/microsoft/WSL2-Linux-Kernel.git
@@ -125,11 +128,11 @@ cd WSL2-Linux-Kernel
 make -j4 KCONFIG_CONFIG=Microsoft/config-wsl
 mkdir /mnt/c/linuxtemp
 cp arch/x86_x64/boot/bzImage /mnt/c/linuxtemp/
-```
+{{< /codeFromInline >}}
 
 Now, open an administrator PowerShell window and run these steps to apply the kernel:
 
-```powershell
+{{< codeFromInline lang="powershell" >}}
 wsl.exe --shutdown
 cd C:\WINDOWS\system32\lxss\tools
 $acl = Get-Acl .\kernel
@@ -137,4 +140,4 @@ $acl.AddAccessRule( ( New-Object System.Security.AccessControl.FileSystemAccessR
 $acl | Set-Acl .\kernel
 Move-Item kernel kernel.orig
 Copy-Item c:\linuxtemp\bzImage kernel
-```
+{{< /codeFromInline >}}


### PR DESCRIPTION
- v1alpha3 -> v1alpha4 in docs
- make more things copyable
- simplify config examples to focus on the relevant parts