### PR TITLE
Add Message When No Clusters Exist

### DIFF
--- a/pkg/cmd/kind/get/clusters/clusters.go
+++ b/pkg/cmd/kind/get/clusters/clusters.go
@@ -50,8 +50,12 @@ func runE(logger log.Logger, streams cmd.IOStreams) error {
 	if err != nil {
 		return err
 	}
-	for _, cluster := range clusters {
-		fmt.Fprintln(streams.Out, cluster)
+	if len(clusters) > 0 {
+		for _, cluster := range clusters {
+			fmt.Fprintln(streams.Out, cluster)
+		}
+	} else {
+		logger.Warn("No clusters available")
 	}
 	return nil
 }


### PR DESCRIPTION
This pull request adds a simple message of `No clusters available` from `kind get clusters` if no clusters have been created. I think this is more helpful to an end user than returning no message, but I would be open to changing the message if what I have is not clear.