### PR TITLE
prevent pulling node image that locally exists when using only a SHA

### DIFF
--- a/pkg/cluster/internal/providers/docker/images.go
+++ b/pkg/cluster/internal/providers/docker/images.go
@@ -35,10 +35,11 @@ func ensureNodeImages(logger log.Logger, status *cli.Status, cfg *config.Cluster
 	// pull each required image
 	for _, image := range common.RequiredNodeImages(cfg).List() {
 		// prints user friendly message
+		friendlyImageName := image
 		if strings.Contains(image, "@sha256:") {
-			image = strings.Split(image, "@sha256:")[0]
+			friendlyImageName = strings.Split(image, "@sha256:")[0]
 		}
-		status.Start(fmt.Sprintf("Ensuring node image (%s) 🖼", image))
+		status.Start(fmt.Sprintf("Ensuring node image (%s) 🖼", friendlyImageName))
 
 		// attempt to explicitly pull the image if it doesn't exist locally
 		// we don't care if this errors, we'll still try to run which also pulls


### PR DESCRIPTION
Before, running `kind create cluster --image
kindest/node@sha256:70ce6ce09bee5c34ab14aec2b84d6edb260473a60638b1b095470a3a0f95ebec`
would always attempt to pull `kindest/node` which would fail. This is
happening because of the conversion of the image to a friendly image
name is stripping off the SHA portion. If a tag isn't provided then this
causes kind to erroneously attempt to re-pull the image even if the
image with the SHA exists locally.

Now, always explicitly use the original image and not the friendly
image name. This enables the `docker inspect` command to work properly.