### PR TITLE
Add k3d to alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Some other open source projects with slightly different but overlapping use case
 - https://github.com/kinvolk/kube-spawn
 - https://github.com/kubernetes/minikube
 - https://github.com/kubernetes-sigs/kubeadm-dind-cluster
+- https://github.com/rancher/k3d
 
 ### Code of conduct
 


### PR DESCRIPTION
k3d is a community project that fulfills a similar role to kind.

k3d currently has 678 stars and is featured in the documentation for tools such as Tilt. 

Signed-off-by: Dax McDonald <dax@rancher.com>