### PR TITLE
tweak get clusters message, add message to get nodes

### DIFF
--- a/pkg/cmd/kind/get/clusters/clusters.go
+++ b/pkg/cmd/kind/get/clusters/clusters.go
@@ -50,12 +50,12 @@ func runE(logger log.Logger, streams cmd.IOStreams) error {
 	if err != nil {
 		return err
 	}
-	if len(clusters) > 0 {
-		for _, cluster := range clusters {
-			fmt.Fprintln(streams.Out, cluster)
-		}
-	} else {
-		logger.Warn("No clusters available")
+	if len(clusters) == 0 {
+		logger.V(0).Info("No kind clusters found.")
+		return nil
+	}
+	for _, cluster := range clusters {
+		fmt.Fprintln(streams.Out, cluster)
 	}
 	return nil
 }

--- a/pkg/cmd/kind/get/nodes/nodes.go
+++ b/pkg/cmd/kind/get/nodes/nodes.go
@@ -61,6 +61,10 @@ func runE(logger log.Logger, streams cmd.IOStreams, flags *flagpole) error {
 	if err != nil {
 		return err
 	}
+	if len(n) == 0 {
+		logger.V(0).Infof("No kind nodes found for cluster %q.", flags.Name)
+		return nil
+	}
 	for _, node := range n {
 		fmt.Fprintln(streams.Out, node.String())
 	}


### PR DESCRIPTION
this is a common complaint, finally fixing this to ~match kubectl:
```
$ kubectl get po
No resources found in default namespace.
```