### PR TITLE
asssorted docs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Please see [Our Documentation](https://kind.sigs.k8s.io/docs/user/quick-start/) for more in-depth installation etc.
 
 kind is a tool for running local Kubernetes clusters using Docker container "nodes".  
-kind is primarily designed for testing Kubernetes 1.11+, initially targeting the [conformance tests].
+kind was primarily designed for testing Kubernetes itself, but may be used for local development or CI.
 
 If you have [go] ([1.11+][go-supported]) and [docker] installed `GO111MODULE="on" go get sigs.k8s.io/kind@v0.6.1 && kind create cluster` is all you need!
 
@@ -111,19 +111,8 @@ See also: our own [contributor guide] and the Kubernetes [community page].
 - kind supports multi-node (including HA) clusters
 - kind supports building Kubernetes release builds from source
   - support for make / bash / docker or bazel, in addition to pre-published builds
-- kind supports Windows in addition to MacOS and Linux
+- kind supports Linux, macOS and Windows
 - kind is a [CNCF certified conformant Kubernetes installer](https://landscape.cncf.io/selected=kind)
-
-## Alternatives
-
-Some other open source projects with slightly different but overlapping use cases, features etc.
-
-- https://github.com/bsycorp/kind
-- https://github.com/ubuntu/microk8s
-- https://github.com/kinvolk/kube-spawn
-- https://github.com/kubernetes/minikube
-- https://github.com/kubernetes-sigs/kubeadm-dind-cluster
-- https://github.com/rancher/k3d
 
 ### Code of conduct
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -4,7 +4,7 @@ tile: kind
 <p style="text-align: center; margin-top: 2em; margin-bottom: -.75em;"><img alt="kind" src="./logo/logo.png" width="300px" /></p>
 
 [kind] is a tool for running local Kubernetes clusters using Docker container "nodes".  
-kind is primarily designed for testing Kubernetes 1.11+, initially targeting the [conformance tests].
+kind was primarily designed for testing Kubernetes itself, but may be used for local development or CI.
 
 If you have [go] \([1.11+][go-supported]) and [docker] installed `GO111MODULE="on" go get sigs.k8s.io/kind@v0.6.1 && kind create cluster` is all you need!
 
@@ -82,18 +82,8 @@ See also: our own [contributor guide] and the Kubernetes [community page].
 - kind supports multi-node (including HA) clusters
 - kind supports building Kubernetes release builds from source
   - support for make / bash / docker, or bazel, in addition to pre-published builds
-- kind supports Windows in addition to MacOS and Linux
+- kind supports Linux, macOS and Windows
 - kind is a [CNCF certified conformant Kubernetes installer](https://landscape.cncf.io/selected=kind)
-
-## Alternatives
-
-Some other open source projects with slightly different but overlapping use cases, features etc.
-
-- https://github.com/bsycorp/kind
-- https://github.com/ubuntu/microk8s
-- https://github.com/kinvolk/kube-spawn
-- https://github.com/kubernetes/minikube
-- https://github.com/kubernetes-sigs/kubeadm-dind-cluster
 
 ### Code of conduct
 

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -32,7 +32,9 @@ It may additionally be helpful to:
 
 ## Failures involving mismatched kubectl versions
 
-`kind` will fail create a cluster, if the version of Kubernetes for the client and server differ.
+You may have problems interacting with your kind cluster if your client(s) are
+skewed too far from the kind node version. Kubernetes [only supports limited skew][version skew]
+between clients and the API server.
 
 This is a issue that frequently occurs when running `kind` alongside Docker For Mac.
 
@@ -74,7 +76,7 @@ And possibly other old versions of Docker.
 
 With these versions you must use Kubernetes >= 1.14, or more ideally upgrade Docker instead.
 
-kind is tested with a recent stable docker-ce release.
+kind is tested with a recent stable `docker-ce` release.
 
 ## Docker on Btrfs or ZFS
 
@@ -337,3 +339,4 @@ For previous discussion see: https://github.com/kubernetes-sigs/kind/issues/763
 [sudo with kind]: https://github.com/kubernetes-sigs/kind/issues/713#issuecomment-512665315
 [docker desktop for windows]: https://hub.docker.com/editions/community/docker-ce-desktop-windows
 [switch between windows and linux containers]: https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers
+[version skew]: https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-version-skew

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -367,9 +367,9 @@ If you are running kind in an environment that requires a proxy, you may need to
 
 You can configure kind to use a proxy using one or more of the following [environment variables][proxy environment variables] (uppercase takes precedence):
 
-* HTTP_PROXY or http_proxy
-* HTTPS_PROXY or https_proxy
-* NO_PROXY or no_proxy
+* `HTTP_PROXY` or `http_proxy`
+* `HTTPS_PROXY` or `https_proxy`
+* `NO_PROXY` or `no_proxy`
 
 **Note**: If you set a proxy it would be used for all the connection requests.
 It's important that you define what addresses doesn't need to be proxied with the NO_PROXY variable, typically you should avoid to proxy your docker network range `NO_PROXY=172.17.0.0/16`


### PR DESCRIPTION
- code snippet wrap a few environment variables for readability
- clarify kind's purpose in the README / homepage (it's not just 1.11+ conformance tests...)
- alternatives aren't real alternatives for the primary use case and some the entries are dated, just drop it..
- tidy up some wording