### PR TITLE
add a 📦 icon for each node that will be provisioned

### DIFF
--- a/pkg/cluster/internal/providers/docker/provider.go
+++ b/pkg/cluster/internal/providers/docker/provider.go
@@ -55,8 +55,8 @@ func (p *Provider) Provision(status *cli.Status, cluster string, cfg *config.Clu
 	ensureNodeImages(p.logger, status, cfg)
 
 	// actually provision the cluster
-	// TODO: strings.Repeat("📦", len(desiredNodes))
-	status.Start("Preparing nodes 📦")
+	icons := strings.Repeat("📦 ", len(cfg.Nodes))
+	status.Start(fmt.Sprintf("Preparing nodes %s", icons))
 	defer func() { status.End(err == nil) }()
 
 	// plan creating the containers


### PR DESCRIPTION
this PR adds prints icons based on the number of the nodes to provision as suggested in this comment inside the code

`TODO: strings.Repeat("📦", len(desiredNodes))`

## Result

### 3 nodes
<img width="606" alt="Screenshot 2019-12-21 at 12 22 39" src="https://user-images.githubusercontent.com/4562878/71307370-9b6c2a80-23ed-11ea-980a-ca6d5c5f3be7.png">

### single node
<img width="439" alt="Screenshot 2019-12-21 at 12 23 21" src="https://user-images.githubusercontent.com/4562878/71307371-9dce8480-23ed-11ea-9758-4315f147239e.png">


done @ [![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/) Milano