### PR TITLE
Add Clusters Type to Delete More Than One or All Clusters

### DIFF
--- a/pkg/cmd/kind/delete/delete.go
+++ b/pkg/cmd/kind/delete/delete.go
@@ -22,6 +22,7 @@ import (
 
 	"sigs.k8s.io/kind/pkg/cmd"
 	deletecluster "sigs.k8s.io/kind/pkg/cmd/kind/delete/cluster"
+	deleteclusters "sigs.k8s.io/kind/pkg/cmd/kind/delete/clusters"
 	"sigs.k8s.io/kind/pkg/log"
 )
 
@@ -35,5 +36,6 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Long:  "Deletes one of [cluster]",
 	}
 	cmd.AddCommand(deletecluster.NewCommand(logger, streams))
+	cmd.AddCommand(deleteclusters.NewCommand(logger, streams))
 	return cmd
 }


### PR DESCRIPTION
This pull request is an attempt to address an idea proposed in #958. The idea is to be able to delete all clusters created by `kind` with an `--all` flag. In addition to deleting all clusters, a user can delete more than one cluster by specifying cluster names as arguments. Examples of these scenarios are shown below:

**Delete two clusters. One with name kind1 and the other with name kind2:**
`kind delete clusters kind1 kind2`

**Delete all clusters:**
`kind delete clusters --all`
