### PR TITLE
Add invisible padding to clear navbar for heading links.

### DIFF
--- a/site/assets/css/inline.css
+++ b/site/assets/css/inline.css
@@ -284,3 +284,10 @@ h1:hover a, h2:hover a, h3:hover a, h4:hover a {
     padding-left: 1.5em;
   }
 }
+
+:target::before {
+  content: "";
+  display: block;
+  height: 2em;
+  margin: -2em 0 0;
+}


### PR DESCRIPTION
Fixes the behavior where clicking on header links hides the heading behind the fixed navbar.
