### PR TITLE
Capitalize Command Descriptions

### DIFF
--- a/pkg/cmd/kind/build/baseimage/baseimage.go
+++ b/pkg/cmd/kind/build/baseimage/baseimage.go
@@ -37,8 +37,8 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Args: cobra.NoArgs,
 		// TODO(bentheelder): more detailed usage
 		Use:   "base-image",
-		Short: "build the base node image",
-		Long:  `build the base node image for running nested containers, systemd, and kubernetes components.`,
+		Short: "Build the base node image",
+		Long:  `Build the base node image for running nested containers, systemd, and kubernetes components.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(logger, flags)
 		},

--- a/pkg/cmd/kind/build/nodeimage/nodeimage.go
+++ b/pkg/cmd/kind/build/nodeimage/nodeimage.go
@@ -40,8 +40,8 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Args: cobra.NoArgs,
 		// TODO(bentheelder): more detailed usage
 		Use:   "node-image",
-		Short: "build the node image",
-		Long:  "build the node image which contains kubernetes build artifacts and other kind requirements",
+		Short: "Build the node image",
+		Long:  "Build the node image which contains kubernetes build artifacts and other kind requirements",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(logger, flags)
 		},

--- a/pkg/cmd/kind/export/export.go
+++ b/pkg/cmd/kind/export/export.go
@@ -32,8 +32,8 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Args: cobra.NoArgs,
 		// TODO(bentheelder): more detailed usage
 		Use:   "export",
-		Short: "exports one of [kubeconfig, logs]",
-		Long:  "exports one of [kubeconfig, logs]",
+		Short: "Exports one of [kubeconfig, logs]",
+		Long:  "Exports one of [kubeconfig, logs]",
 	}
 	// add subcommands
 	cmd.AddCommand(logs.NewCommand(logger, streams))

--- a/pkg/cmd/kind/export/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kind/export/kubeconfig/kubeconfig.go
@@ -36,8 +36,8 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
 		Use:   "kubeconfig",
-		Short: "exports cluster kubeconfig",
-		Long:  "exports cluster kubeconfig",
+		Short: "Exports cluster kubeconfig",
+		Long:  "Exports cluster kubeconfig",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(logger, flags)
 		},

--- a/pkg/cmd/kind/export/logs/logs.go
+++ b/pkg/cmd/kind/export/logs/logs.go
@@ -39,8 +39,8 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 		// TODO(bentheelder): more detailed usage
 		Use:   "logs [output-dir]",
-		Short: "exports logs to a tempdir or [output-dir] if specified",
-		Long:  "exports logs to a tempdir or [output-dir] if specified",
+		Short: "Exports logs to a tempdir or [output-dir] if specified",
+		Long:  "Exports logs to a tempdir or [output-dir] if specified",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(logger, streams, flags, args)
 		},

--- a/pkg/cmd/kind/get/clusters/clusters.go
+++ b/pkg/cmd/kind/get/clusters/clusters.go
@@ -33,8 +33,8 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Args: cobra.NoArgs,
 		// TODO(bentheelder): more detailed usage
 		Use:   "clusters",
-		Short: "lists existing kind clusters by their name",
-		Long:  "lists existing kind clusters by their name",
+		Short: "Lists existing kind clusters by their name",
+		Long:  "Lists existing kind clusters by their name",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(logger, streams)
 		},

--- a/pkg/cmd/kind/get/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kind/get/kubeconfig/kubeconfig.go
@@ -38,8 +38,8 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
 		Use:   "kubeconfig",
-		Short: "prints cluster kubeconfig",
-		Long:  "prints cluster kubeconfig",
+		Short: "Prints cluster kubeconfig",
+		Long:  "Prints cluster kubeconfig",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(logger, streams, flags)
 		},

--- a/pkg/cmd/kind/get/nodes/nodes.go
+++ b/pkg/cmd/kind/get/nodes/nodes.go
@@ -37,8 +37,8 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
 		Use:   "nodes",
-		Short: "lists existing kind nodes by their name",
-		Long:  "lists existing kind nodes by their name",
+		Short: "Lists existing kind nodes by their name",
+		Long:  "Lists existing kind nodes by their name",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(logger, streams, flags)
 		},

--- a/pkg/cmd/kind/load/docker-image/docker-image.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image.go
@@ -50,8 +50,8 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return nil
 		},
 		Use:   "docker-image",
-		Short: "loads docker image from host into nodes",
-		Long:  "loads docker image from host into all or specified nodes by name",
+		Short: "Loads docker image from host into nodes",
+		Long:  "Loads docker image from host into all or specified nodes by name",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(logger, flags, args)
 		},

--- a/pkg/cmd/kind/load/image-archive/image-archive.go
+++ b/pkg/cmd/kind/load/image-archive/image-archive.go
@@ -47,8 +47,8 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return nil
 		},
 		Use:   "image-archive",
-		Short: "loads docker image from archive into nodes",
-		Long:  "loads docker image from archive into all or specified nodes by name",
+		Short: "Loads docker image from archive into nodes",
+		Long:  "Loads docker image from archive into all or specified nodes by name",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(logger, flags, args)
 		},

--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -65,8 +65,8 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
 		Use:   "version",
-		Short: "prints the kind CLI version",
-		Long:  "prints the kind CLI version",
+		Short: "Prints the kind CLI version",
+		Long:  "Prints the kind CLI version",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if logger.V(0).Enabled() {
 				// if not -q / --quiet, show lots of info


### PR DESCRIPTION
Currently, commands/subcommands are not consistent in terms of whether or not the beginning of the description is capitalized. This pull request changes all lower case description beginnings to capitalized. 

This inconsistency also exists for flags, and I would be happy to follow up with something to also correct those flags. Could do that in this pr too if that would be easier.