### PR TITLE
provider-docker: remove duplicate container labels

### DIFF
--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -125,7 +125,6 @@ func commonArgs(cluster string, cfg *config.Cluster) ([]string, error) {
 		"--tty",    // allocate a tty for entrypoint logs
 		// label the node with the cluster ID
 		"--label", fmt.Sprintf("%s=%s", clusterLabelKey, cluster),
-		"--label", fmt.Sprintf("%s=%s", clusterLabelKey, cluster),
 	}
 
 	// enable IPv6 if necessary
@@ -155,7 +154,6 @@ func runArgsForNode(node *config.Node, name string, args []string) []string {
 		"--hostname", name, // make hostname match container name
 		"--name", name, // ... and set the container name
 		// label the node with the role ID
-		"--label", fmt.Sprintf("%s=%s", nodeRoleLabelKey, node.Role),
 		"--label", fmt.Sprintf("%s=%s", nodeRoleLabelKey, node.Role),
 		// running containers in a container requires privileged
 		// NOTE: we could try to replicate this with --cap-add, and use less
@@ -194,7 +192,6 @@ func runArgsForLoadBalancer(cfg *config.Cluster, name string, args []string) []s
 		"--hostname", name, // make hostname match container name
 		"--name", name, // ... and set the container name
 		// label the node with the role ID
-		"--label", fmt.Sprintf("%s=%s", nodeRoleLabelKey, constants.ExternalLoadBalancerNodeRoleValue),
 		"--label", fmt.Sprintf("%s=%s", nodeRoleLabelKey, constants.ExternalLoadBalancerNodeRoleValue),
 	},
 		args...,


### PR DESCRIPTION
Remove duplicate docker labels from common, node and load balancer args.