### PR TITLE
Remove duplicated word 'as as' in comments

### DIFF
--- a/pkg/apis/config/v1alpha3/types.go
+++ b/pkg/apis/config/v1alpha3/types.go
@@ -47,7 +47,7 @@ type Cluster struct {
 	//
 	// Name and Namespace are now ignored, but the fields continue to exist for
 	// backwards compatibility of parsing the config. The name of the generated
-	// config was/is always fixed as as is the namespace so these fields have
+	// config was/is always fixed as is the namespace so these fields have
 	// always been a no-op.
 	//
 	// https://tools.ietf.org/html/rfc6902

--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -49,7 +49,7 @@ type Cluster struct {
 	//
 	// Name and Namespace are now ignored, but the fields continue to exist for
 	// backwards compatibility of parsing the config. The name of the generated
-	// config was/is always fixed as as is the namespace so these fields have
+	// config was/is always fixed as is the namespace so these fields have
 	// always been a no-op.
 	//
 	// https://tools.ietf.org/html/rfc6902
@@ -119,7 +119,7 @@ type Node struct {
 	//
 	// Name and Namespace are now ignored, but the fields continue to exist for
 	// backwards compatibility of parsing the config. The name of the generated
-	// config was/is always fixed as as is the namespace so these fields have
+	// config was/is always fixed as is the namespace so these fields have
 	// always been a no-op.
 	//
 	// https://tools.ietf.org/html/rfc6902


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects while reading.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>