### PR TITLE
Lowercase Flag Descriptions

### DIFF
--- a/pkg/cmd/kind/build/nodeimage/nodeimage.go
+++ b/pkg/cmd/kind/build/nodeimage/nodeimage.go
@@ -58,7 +58,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(
 		&flags.KubeRoot, "kube-root",
 		"",
-		"Path to the Kubernetes source directory (if empty, the path is autodetected)",
+		"path to the Kubernetes source directory (if empty, the path is autodetected)",
 	)
 	cmd.Flags().StringVar(
 		&flags.BaseImage, "base-image",

--- a/pkg/cmd/kind/create/cluster/createcluster.go
+++ b/pkg/cmd/kind/create/cluster/createcluster.go
@@ -56,7 +56,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(&flags.Config, "config", "", "path to a kind config file")
 	cmd.Flags().StringVar(&flags.ImageName, "image", "", "node docker image to use for booting the cluster")
 	cmd.Flags().BoolVar(&flags.Retain, "retain", false, "retain nodes for debugging when cluster creation fails")
-	cmd.Flags().DurationVar(&flags.Wait, "wait", time.Duration(0), "Wait for control plane node to be ready (default 0s)")
+	cmd.Flags().DurationVar(&flags.Wait, "wait", time.Duration(0), "wait for control plane node to be ready (default 0s)")
 	cmd.Flags().StringVar(&flags.Kubeconfig, "kubeconfig", "", "sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config")
 	return cmd
 }


### PR DESCRIPTION
Similar to #1222 

This pull request makes all flag description beginnings lowercase to keep it consistent across the CLI. If capitalization is preferred similar to what `kubectl` does, I can change this pull request to capitalize them. However, I thought to keep it similar to what has been done so far for flag descriptions by using lowercase. 