### PR TITLE
Cleanup Meaningless Variable Declaration

### DIFF
--- a/pkg/internal/cli/logger.go
+++ b/pkg/internal/cli/logger.go
@@ -40,8 +40,6 @@ type Logger struct {
 	isSmartWriter bool
 }
 
-var _ log.Logger = &Logger{}
-
 // NewLogger returns a new Logger with the given verbosity
 func NewLogger(writer io.Writer, verbosity log.Level) *Logger {
 	l := &Logger{


### PR DESCRIPTION
This commit cleans up meaningless variable declaration in which underscore (blank identifier) is used as
variable identifier.
And this declaration makes no effect in source code.

So this declaration can be safely removed.