### PR TITLE
Include protocol specification in extraPortMappings example

### DIFF
--- a/site/content/docs/user/ingress.md
+++ b/site/content/docs/user/ingress.md
@@ -48,8 +48,10 @@ nodes:
   extraPortMappings:
   - containerPort: 80
     hostPort: 80
+    protocol: TCP
   - containerPort: 443
     hostPort: 443
+    protocol: TCP
 EOF
 {{< /codeFromInline >}}
 


### PR DESCRIPTION
Otherwise `kind create cluster --config=...` will fail with empty
protocol field complain