### PR TITLE
Bump cni version with portmap fix

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -25,7 +25,7 @@ FROM ubuntu:19.10
 # The repository contains latest stable releases and nightlies built for multiple architectures
 ARG CONTAINERD_VERSION="v1.3.2"
 # Configure CNI binaries from upstream
-ARG CNI_VERSION="v0.8.3"
+ARG CNI_VERSION="v0.8.4"
 # Configure crictl binary from upstream
 ARG CRICTL_VERSION="v1.17.0"
 

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.17.0@sha256:190c97963ec4f4121c3f1e96ca6eb104becda5bae1df3a13f01649b2dd372f6d"
+const Image = "kindest/node:v1.17.0@sha256:d4ecb8028c5a7c33131a209241cb1aa0c7da492d15a82847bc74565d5757aa31"

--- a/pkg/build/node/node.go
+++ b/pkg/build/node/node.go
@@ -42,7 +42,7 @@ import (
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20191219-c938c251@sha256:24c797ae0cffe67c4bc26b062ae448596b59b8539331578eae8f0b101a47b2b8"
+const DefaultBaseImage = "kindest/base:v20200109-d9c81a89@sha256:3e7cbf766fa8661d879f8acc415b0c700788b6d0fdffe4505196d9d3718a3dfa"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
It includes the fix to the portmap plugin that was showing up in the k8s CI