### PR TITLE
site: Add Contour Ingress Controller as example in /docs/user/ingress

### DIFF
--- a/site/static/examples/ingress/contour/patch.json
+++ b/site/static/examples/ingress/contour/patch.json
@@ -1,0 +1,18 @@
+{
+  "spec": {
+    "template": {
+      "spec": {
+        "nodeSelector": {
+          "ingress-ready": "true"
+        },
+        "tolerations": [
+        {
+          "key": "node-role.kubernetes.io/master",
+          "operator": "Equal",
+          "effect": "NoSchedule"
+        }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds to the Ingress examples by showing how to deploy with Contour (projectcontour.io). 

Signed-off-by: Steve Sloka <steve@stevesloka.com>