### PR TITLE
add featuregates to config

### DIFF
--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -31,6 +31,12 @@ type Cluster struct {
 	// Networking contains cluster wide network settings
 	Networking Networking `yaml:"networking,omitempty"`
 
+	// FeatureGates contains a map of Kubernetes feature gates to whether they
+	// are enabled. The feature gates specified here are passed to all Kubernetes components as flags or in config.
+	//
+	// https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+	FeatureGates map[string]bool `yaml:"featureGates,omitempty"`
+
 	// KubeadmConfigPatches are applied to the generated kubeadm config as
 	// merge patches. The `kind` field must match the target object, and
 	// if `apiVersion` is specified it will only be applied to matching objects.

--- a/pkg/apis/config/v1alpha4/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha4/zz_generated.deepcopy.go
@@ -32,6 +32,13 @@ func (in *Cluster) DeepCopyInto(out *Cluster) {
 		}
 	}
 	out.Networking = in.Networking
+	if in.FeatureGates != nil {
+		in, out := &in.FeatureGates, &out.FeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.KubeadmConfigPatches != nil {
 		in, out := &in.KubeadmConfigPatches, &out.KubeadmConfigPatches
 		*out = make([]string, len(*in))

--- a/pkg/internal/apis/config/convert_v1alpha4.go
+++ b/pkg/internal/apis/config/convert_v1alpha4.go
@@ -25,6 +25,7 @@ func Convertv1alpha4(in *v1alpha4.Cluster) *Cluster {
 	in = in.DeepCopy() // deep copy first to avoid touching the original
 	out := &Cluster{
 		Nodes:                           make([]Node, len(in.Nodes)),
+		FeatureGates:                    in.FeatureGates,
 		KubeadmConfigPatches:            in.KubeadmConfigPatches,
 		KubeadmConfigPatchesJSON6902:    make([]PatchJSON6902, len(in.KubeadmConfigPatchesJSON6902)),
 		ContainerdConfigPatches:         in.ContainerdConfigPatches,

--- a/pkg/internal/apis/config/encoding/testdata/v1alpha4/valid-many-fields.yaml
+++ b/pkg/internal/apis/config/encoding/testdata/v1alpha4/valid-many-fields.yaml
@@ -1,5 +1,7 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  AllBeta: false
 networking:
   ipFamily: ipv6
 nodes:

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -29,6 +29,12 @@ type Cluster struct {
 	// Networking contains cluster wide network settings
 	Networking Networking
 
+	// FeatureGates contains a map of Kubernetes feature gates to whether they
+	// are enabled. The feature gates specified here are passed to all Kubernetes components as flags or in config.
+	//
+	// https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+	FeatureGates map[string]bool
+
 	// KubeadmConfigPatches are applied to the generated kubeadm config as
 	// strategic merge patches to `kustomize build` internally
 	// https://github.com/kubernetes/community/blob/a9cf5c8f3380bb52ebe57b1e2dbdec136d8dd484/contributors/devel/sig-api-machinery/strategic-merge-patch.md

--- a/pkg/internal/apis/config/zz_generated.deepcopy.go
+++ b/pkg/internal/apis/config/zz_generated.deepcopy.go
@@ -31,6 +31,13 @@ func (in *Cluster) DeepCopyInto(out *Cluster) {
 		}
 	}
 	out.Networking = in.Networking
+	if in.FeatureGates != nil {
+		in, out := &in.FeatureGates, &out.FeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.KubeadmConfigPatches != nil {
 		in, out := &in.KubeadmConfigPatches, &out.KubeadmConfigPatches
 		*out = make([]string, len(*in))


### PR DESCRIPTION
This allows doing:
```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
featureGates:
  AllBeta: true
```

instead of writing many kubeadm config patches.
featuregates are frequently toggled for testing in the broader kubernetes CI

/cc @amwat @liggitt 