### PR TITLE
Add setting k8s versions in config to docs

### DIFF
--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -161,7 +161,7 @@ nodes:
 - role: worker
 {{< /codeFromInline >}}
 
-You can also set a specific Kubernetes version by setting the `node`'s container image. You can find available image tags on the [releases page](https://github.com/kubernetes-sigs/kind/releases). Please use the `sha256` shasum for your desired kubernetes version, as seen in this example:
+You can also set a specific Kubernetes version by setting the `node`'s container image. You can find available image tags on the [releases page](https://github.com/kubernetes-sigs/kind/releases). Please include the `@sha256:` [image digest](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier) from the image in the release notes, as seen in this example:
 
 {{< codeFromInline lang="yaml" >}}
 kind: Cluster

--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -161,16 +161,16 @@ nodes:
 - role: worker
 {{< /codeFromInline >}}
 
-You can also set a specific Kubernetes version by setting the node image. You can find available versions on [DockerHub](https://hub.docker.com/r/kindest/node/tags):
+You can also set a specific Kubernetes version by setting the `node`'s container image. You can find available image tags on the [releases page](https://github.com/kubernetes-sigs/kind/releases). Please use the `sha256` shasum for your desired kubernetes version, as seen in this example:
+
 {{< codeFromInline lang="yaml" >}}
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker
-  image: kindest/node:v1.16.4
+  image: kindest/node:v1.16.4@sha256:b91a2c2317a000f3a783489dfb755064177dbc3a0b2f4147d50f04825d016f55
 {{< /codeFromInline >}}
-
 
 
 ## Per-Node Options

--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -161,6 +161,18 @@ nodes:
 - role: worker
 {{< /codeFromInline >}}
 
+You can also set a specific Kubernetes version by setting the node image. You can find available versions on [DockerHub](https://hub.docker.com/r/kindest/node/tags):
+{{< codeFromInline lang="yaml" >}}
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+  image: kindest/node:v1.16.4
+{{< /codeFromInline >}}
+
+
+
 ## Per-Node Options
 
 The following options are available for setting on each entry in `nodes`.

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -310,15 +310,16 @@ This can be useful if using `NodePort` services or daemonsets exposing host port
 Note: binding the `listenAddress` to `127.0.0.1` may affect your ability to access the service.
 
 #### Setting Kubernetes version
-You can set a specific Kubernetes version by finding it's associated image on [Dockerhub](https://hub.docker.com/r/kindest/node/tags), then setting the image attribute explicitly:
+You can also set a specific Kubernetes version by setting the `node`'s container image. You can find available image tags on the [releases page](https://github.com/kubernetes-sigs/kind/releases). Please use the `sha256` shasum for your desired kubernetes version, as seen in this example:
+
 ```yaml
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.16.4
+  image: kindest/node:v1.16.4@sha256:b91a2c2317a000f3a783489dfb755064177dbc3a0b2f4147d50f04825d016f55
 - role: worker
-  image: kindest/node:v1.16.4
+  image: kindest/node:v1.16.4@sha256:b91a2c2317a000f3a783489dfb755064177dbc3a0b2f4147d50f04825d016f55
 ```
 
 ### Enable Feature Gates in Your Cluster

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -309,6 +309,17 @@ This can be useful if using `NodePort` services or daemonsets exposing host port
 
 Note: binding the `listenAddress` to `127.0.0.1` may affect your ability to access the service.
 
+#### Setting Kubernetes version
+You can set a specific Kubernetes version by finding it's associated image on [Dockerhub](https://hub.docker.com/r/kindest/node/tags), then setting the image attribute explicitly:
+```yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.16.4
+- role: worker
+  image: kindest/node:v1.16.4
+```
 
 ### Enable Feature Gates in Your Cluster
 


### PR DESCRIPTION
updated the docs to add some info about how to set the node images in config files.

I needed to test against a specific version matrix, and I was unable to find how to do this in the docs. While I could do this via the command line, it wasn't sufficient when trying to use Kind for testing automation. 

This should resolve this issue as well:
https://github.com/kubernetes-sigs/kind/issues/597