### PR TITLE
Parse: apiversion and kind inverted in error output

### DIFF
--- a/pkg/internal/apis/config/encoding/load.go
+++ b/pkg/internal/apis/config/encoding/load.go
@@ -66,7 +66,7 @@ func Parse(raw []byte) (*config.Cluster, error) {
 	// handle v1alpha4
 	case "kind.x-k8s.io/v1alpha4":
 		if tm.Kind != "Cluster" {
-			return nil, errors.Errorf("unknown kind %s for apiVersion: %s", tm.APIVersion, tm.Kind)
+			return nil, errors.Errorf("unknown kind %s for apiVersion: %s", tm.Kind, tm.APIVersion)
 		}
 		// load version
 		cfg := &v1alpha4.Cluster{}
@@ -79,7 +79,7 @@ func Parse(raw []byte) (*config.Cluster, error) {
 	// handle v1alpha3
 	case "kind.sigs.k8s.io/v1alpha3":
 		if tm.Kind != "Cluster" {
-			return nil, errors.Errorf("unknown kind %s for apiVersion: %s", tm.APIVersion, tm.Kind)
+			return nil, errors.Errorf("unknown kind %s for apiVersion: %s", tm.Kind, tm.APIVersion)
 		}
 		// load version
 		cfg := &v1alpha3.Cluster{}


### PR DESCRIPTION
For example, with:

```sh
# Note: this kind and apiversion do not exist (they existed in early 2019)
% kind create cluster --name b --config - <<EOF 
kind: Node
apiVersion: kind.sigs.k8s.io/v1alpha3
role: control-plane
replicas: 3
EOF

ERROR: failed to create cluster: unknown kind kind.sigs.k8s.io/v1alpha3 for apiVersion: Node
```

(that's because I was trying to use the old API from early 2019; I realized later that I had to use `kind.x-k8s.io/v1alpha4` and `kind: Cluster` instead 🙂)

Kind version: 8643089fc


I also want to say thank you again for this absolutely fantastic project! 😁