### PR TITLE
Improve load docker-image logging

### DIFF
--- a/pkg/cmd/kind/load/docker-image/docker-image.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image.go
@@ -120,7 +120,7 @@ func runE(logger log.Logger, flags *flagpole, args []string) error {
 		id, err := nodeutils.ImageID(node, imageName)
 		if err != nil || id != imageID {
 			selectedNodes = append(selectedNodes, node)
-			logger.V(0).Infof("Image: %q with ID %q not present on node %q", imageName, imageID, node.String())
+			logger.V(0).Infof("Image: %q with ID %q not yet present on node %q, loading...", imageName, imageID, node.String())
 		}
 	}
 


### PR DESCRIPTION
Fixes #1322

Changed the message logged when the image needs to be loaded so that it doesn't read like an error message and won't be confused as such.