### PR TITLE
Fix ctr image import error on ARM

### DIFF
--- a/pkg/build/node/import.go
+++ b/pkg/build/node/import.go
@@ -50,7 +50,8 @@ func (c *containerdImporter) Prepare() error {
 
 func (c *containerdImporter) LoadCommand() exec.Cmd {
 	return c.containerCmder.Command(
-		"ctr", "--namespace=k8s.io", "images", "import", "--no-unpack", "-",
+		// TODO: ideally we do not need this in the future. we have fixed at least one image
+		"ctr", "--namespace=k8s.io", "images", "import", "--all-platforms", "--no-unpack", "-",
 	)
 }
 


### PR DESCRIPTION
add --all-platforms, otherwise, when using
"ctr image import" image in kind-build
on ARM platform, would get following error:
"failed resolving platform for image"

Signed-off-by: Howard Zhang <howard.zhang@arm.com>