### PR TITLE
pick random port on host unless asked to use backend ...

### DIFF
--- a/pkg/apis/config/v1alpha3/types.go
+++ b/pkg/apis/config/v1alpha3/types.go
@@ -105,7 +105,12 @@ type Networking struct {
 	// IPFamily is the network cluster model, currently it can be ipv4 or ipv6
 	IPFamily ClusterIPFamily `yaml:"ipFamily,omitempty"`
 	// APIServerPort is the listen port on the host for the Kubernetes API Server
-	// Defaults to a random port on the host
+	// Defaults to a random port on the host obtained by kind
+	//
+	// NOTE: if you set the special value of `-1` then the node backend 
+	// (docker, podman...) will be left to pick the port instead.
+	// This is potentially useful for remote hosts, BUT it means when the container
+	// is restarted it will be randomized. Leave this unset to allow kind to pick it.
 	APIServerPort int32 `yaml:"apiServerPort,omitempty"`
 	// APIServerAddress is the listen address on the host for the Kubernetes
 	// API Server. This should be an IP address.
@@ -191,6 +196,13 @@ type PortMapping struct {
 	// Port within the container.
 	ContainerPort int32 `yaml:"containerPort,omitempty"`
 	// Port on the host.
+	//
+	// If unset, a random port will be selected.
+	//
+	// NOTE: if you set the special value of `-1` then the node backend 
+	// (docker, podman...) will be left to pick the port instead.
+	// This is potentially useful for remote hosts, BUT it means when the container
+	// is restarted it will be randomized. Leave this unset to allow kind to pick it.
 	HostPort int32 `yaml:"hostPort,omitempty"`
 	// TODO: add protocol (tcp/udp) and port-ranges
 	ListenAddress string `yaml:"listenAddress,omitempty"`

--- a/pkg/apis/config/v1alpha3/types.go
+++ b/pkg/apis/config/v1alpha3/types.go
@@ -107,7 +107,7 @@ type Networking struct {
 	// APIServerPort is the listen port on the host for the Kubernetes API Server
 	// Defaults to a random port on the host obtained by kind
 	//
-	// NOTE: if you set the special value of `-1` then the node backend 
+	// NOTE: if you set the special value of `-1` then the node backend
 	// (docker, podman...) will be left to pick the port instead.
 	// This is potentially useful for remote hosts, BUT it means when the container
 	// is restarted it will be randomized. Leave this unset to allow kind to pick it.
@@ -199,7 +199,7 @@ type PortMapping struct {
 	//
 	// If unset, a random port will be selected.
 	//
-	// NOTE: if you set the special value of `-1` then the node backend 
+	// NOTE: if you set the special value of `-1` then the node backend
 	// (docker, podman...) will be left to pick the port instead.
 	// This is potentially useful for remote hosts, BUT it means when the container
 	// is restarted it will be randomized. Leave this unset to allow kind to pick it.

--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -155,7 +155,7 @@ type Networking struct {
 	// APIServerPort is the listen port on the host for the Kubernetes API Server
 	// Defaults to a random port on the host obtained by kind
 	//
-	// NOTE: if you set the special value of `-1` then the node backend 
+	// NOTE: if you set the special value of `-1` then the node backend
 	// (docker, podman...) will be left to pick the port instead.
 	// This is potentially useful for remote hosts, BUT it means when the container
 	// is restarted it will be randomized. Leave this unset to allow kind to pick it.
@@ -243,7 +243,7 @@ type PortMapping struct {
 	//
 	// If unset, a random port will be selected.
 	//
-	// NOTE: if you set the special value of `-1` then the node backend 
+	// NOTE: if you set the special value of `-1` then the node backend
 	// (docker, podman...) will be left to pick the port instead.
 	// This is potentially useful for remote hosts, BUT it means when the container
 	// is restarted it will be randomized. Leave this unset to allow kind to pick it.

--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -153,7 +153,12 @@ type Networking struct {
 	// IPFamily is the network cluster model, currently it can be ipv4 or ipv6
 	IPFamily ClusterIPFamily `yaml:"ipFamily,omitempty"`
 	// APIServerPort is the listen port on the host for the Kubernetes API Server
-	// Defaults to a random port on the host
+	// Defaults to a random port on the host obtained by kind
+	//
+	// NOTE: if you set the special value of `-1` then the node backend 
+	// (docker, podman...) will be left to pick the port instead.
+	// This is potentially useful for remote hosts, BUT it means when the container
+	// is restarted it will be randomized. Leave this unset to allow kind to pick it.
 	APIServerPort int32 `yaml:"apiServerPort,omitempty"`
 	// APIServerAddress is the listen address on the host for the Kubernetes
 	// API Server. This should be an IP address.
@@ -235,6 +240,13 @@ type PortMapping struct {
 	// Port within the container.
 	ContainerPort int32 `yaml:"containerPort,omitempty"`
 	// Port on the host.
+	//
+	// If unset, a random port will be selected.
+	//
+	// NOTE: if you set the special value of `-1` then the node backend 
+	// (docker, podman...) will be left to pick the port instead.
+	// This is potentially useful for remote hosts, BUT it means when the container
+	// is restarted it will be randomized. Leave this unset to allow kind to pick it.
 	HostPort int32 `yaml:"hostPort,omitempty"`
 	// TODO: add protocol (tcp/udp) and port-ranges
 	ListenAddress string `yaml:"listenAddress,omitempty"`

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -326,7 +326,7 @@ func generatePortMappings(clusterIPFamily config.ClusterIPFamily, portMappings .
 			return nil, errors.Errorf("unknown port mapping protocol: %v", pm.Protocol)
 		}
 
-		// get a random port if necesary (port = 0)
+		// get a random port if necessary (port = 0)
 		hostPort, err := common.PortOrGetFreePort(pm.HostPort, pm.ListenAddress)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get random host port for port mapping")

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -44,6 +44,10 @@ func planCreation(cluster string, cfg *config.Cluster) (createContainerFuncs []f
 	apiServerPort := cfg.Networking.APIServerPort
 	apiServerAddress := cfg.Networking.APIServerAddress
 	if clusterHasImplicitLoadBalancer(cfg) {
+		// TODO: picking ports locally is less than ideal with remote docker 
+		// but this is supposed to be an implementation detail and NOT picking
+		// them breaks host reboot ...
+		// For now remote docker + multi control plane is not supported
 		apiServerPort = 0              // replaced with random ports
 		apiServerAddress = "127.0.0.1" // only the LB needs to be non-local
 		if clusterIsIPv6(cfg) {
@@ -52,7 +56,11 @@ func planCreation(cluster string, cfg *config.Cluster) (createContainerFuncs []f
 		// plan loadbalancer node
 		name := nodeNamer(constants.ExternalLoadBalancerNodeRoleValue)
 		createContainerFuncs = append(createContainerFuncs, func() error {
-			return createContainer(runArgsForLoadBalancer(cfg, name, genericArgs))
+			args, err := runArgsForLoadBalancer(cfg, name, genericArgs)
+			if err != nil {
+				return err
+			}
+			return createContainer(args)
 		})
 	}
 
@@ -82,11 +90,19 @@ func planCreation(cluster string, cfg *config.Cluster) (createContainerFuncs []f
 						ContainerPort: common.APIServerInternalPort,
 					},
 				)
-				return createContainer(runArgsForNode(node, cfg.Networking.IPFamily, name, genericArgs))
+				args, err := runArgsForNode(node, cfg.Networking.IPFamily, name, genericArgs)
+				if err != nil {
+					return err
+				}
+				return createContainer(args)
 			})
 		case config.WorkerRole:
 			createContainerFuncs = append(createContainerFuncs, func() error {
-				return createContainer(runArgsForNode(node, cfg.Networking.IPFamily, name, genericArgs))
+				args, err := runArgsForNode(node, cfg.Networking.IPFamily, name, genericArgs)
+				if err != nil {
+					return err
+				}
+				return createContainer(args)
 			})
 		default:
 			return nil, errors.Errorf("unknown node role: %q", node.Role)
@@ -148,7 +164,7 @@ func commonArgs(cluster string, cfg *config.Cluster) ([]string, error) {
 	return args, nil
 }
 
-func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, name string, args []string) []string {
+func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, name string, args []string) ([]string, error) {
 	args = append([]string{
 		"run",
 		"--hostname", name, // make hostname match container name
@@ -180,13 +196,17 @@ func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, n
 
 	// convert mounts and port mappings to container run args
 	args = append(args, generateMountBindings(node.ExtraMounts...)...)
-	args = append(args, generatePortMappings(clusterIPFamily, node.ExtraPortMappings...)...)
+	mappingArgs, err := generatePortMappings(clusterIPFamily, node.ExtraPortMappings...)
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, mappingArgs...)
 
 	// finally, specify the image to run
-	return append(args, node.Image)
+	return append(args, node.Image), nil
 }
 
-func runArgsForLoadBalancer(cfg *config.Cluster, name string, args []string) []string {
+func runArgsForLoadBalancer(cfg *config.Cluster, name string, args []string) ([]string, error) {
 	args = append([]string{
 		"run",
 		"--hostname", name, // make hostname match container name
@@ -198,16 +218,20 @@ func runArgsForLoadBalancer(cfg *config.Cluster, name string, args []string) []s
 	)
 
 	// load balancer port mapping
-	args = append(args, generatePortMappings(cfg.Networking.IPFamily,
+	mappingArgs, err := generatePortMappings(cfg.Networking.IPFamily,
 		config.PortMapping{
 			ListenAddress: cfg.Networking.APIServerAddress,
 			HostPort:      cfg.Networking.APIServerPort,
 			ContainerPort: common.APIServerInternalPort,
 		},
-	)...)
+	)
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, mappingArgs...)
 
 	// finally, specify the image to run
-	return append(args, loadbalancer.Image)
+	return append(args, loadbalancer.Image), nil
 }
 
 func getProxyEnv(cfg *config.Cluster) (map[string]string, error) {
@@ -274,7 +298,7 @@ func generateMountBindings(mounts ...config.Mount) []string {
 }
 
 // generatePortMappings converts the portMappings list to a list of args for docker
-func generatePortMappings(clusterIPFamily config.ClusterIPFamily, portMappings ...config.PortMapping) []string {
+func generatePortMappings(clusterIPFamily config.ClusterIPFamily, portMappings ...config.PortMapping) ([]string, error) {
 	args := make([]string, 0, len(portMappings))
 	for _, pm := range portMappings {
 		// do provider internal defaulting
@@ -286,8 +310,7 @@ func generatePortMappings(clusterIPFamily config.ClusterIPFamily, portMappings .
 			case config.IPv6Family:
 				pm.ListenAddress = "::"
 			default:
-				// TODO: plumb an error instead?
-				panic(errors.Errorf("unknown cluster IP family: %v", clusterIPFamily))
+				return nil, errors.Errorf("unknown cluster IP family: %v", clusterIPFamily)
 			}
 		}
 		if string(pm.Protocol) == "" {
@@ -300,14 +323,19 @@ func generatePortMappings(clusterIPFamily config.ClusterIPFamily, portMappings .
 		case config.PortMappingProtocolUDP:
 		case config.PortMappingProtocolSCTP:
 		default:
-			// TODO: plumb an error instead?
-			panic(errors.Errorf("unknown port mapping protocol: %v", pm.Protocol))
+			return nil, errors.Errorf("unknown port mapping protocol: %v", pm.Protocol)
+		}
+
+		// get a random port if necesary (port = 0)
+		hostPort, err := common.PortOrGetFreePort(pm.HostPort, pm.ListenAddress)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get random host port for port mapping")
 		}
 
 		// generate the actual mapping arg
 		protocol := string(pm.Protocol)
-		hostPortBinding := net.JoinHostPort(pm.ListenAddress, fmt.Sprintf("%d", pm.HostPort))
+		hostPortBinding := net.JoinHostPort(pm.ListenAddress, fmt.Sprintf("%d", hostPort))
 		args = append(args, fmt.Sprintf("--publish=%s:%d/%s", hostPortBinding, pm.ContainerPort, protocol))
 	}
-	return args
+	return args, nil
 }

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -44,7 +44,7 @@ func planCreation(cluster string, cfg *config.Cluster) (createContainerFuncs []f
 	apiServerPort := cfg.Networking.APIServerPort
 	apiServerAddress := cfg.Networking.APIServerAddress
 	if clusterHasImplicitLoadBalancer(cfg) {
-		// TODO: picking ports locally is less than ideal with remote docker 
+		// TODO: picking ports locally is less than ideal with remote docker
 		// but this is supposed to be an implementation detail and NOT picking
 		// them breaks host reboot ...
 		// For now remote docker + multi control plane is not supported

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -325,7 +325,7 @@ func generatePortMappings(clusterIPFamily config.ClusterIPFamily, portMappings .
 			return nil, errors.Errorf("unknown port mapping protocol: %v", pm.Protocol)
 		}
 
-		// get a random port if necesary (port = 0)
+		// get a random port if necessary (port = 0)
 		hostPort, err := common.PortOrGetFreePort(pm.HostPort, pm.ListenAddress)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get random host port for port mapping")

--- a/pkg/cluster/internal/providers/provider/common/getport.go
+++ b/pkg/cluster/internal/providers/provider/common/getport.go
@@ -23,10 +23,16 @@ import (
 // PortOrGetFreePort is a helper that either returns the provided port
 // if valid or returns a new free port on listenAddr
 func PortOrGetFreePort(port int32, listenAddr string) (int32, error) {
-	if port > 0 {
-		return port, nil
+	// in the case of -1 we actually want to pass 0 to the backend to let it pick
+	if port == -1 {
+		return 0, nil
 	}
-	return GetFreePort(listenAddr)
+	// in the case of 0 (unset) we want kind to pick one and supply it to the backend
+	if port == 0 {
+		return GetFreePort(listenAddr)
+	}
+	// otherwise keep the port
+	return port, nil
 }
 
 // GetFreePort is a helper used to get a free TCP port on the host

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -111,7 +111,7 @@ type Networking struct {
 	// APIServerPort is the listen port on the host for the Kubernetes API Server
 	// Defaults to a random port on the host obtained by kind
 	//
-	// NOTE: if you set the special value of `-1` then the node backend 
+	// NOTE: if you set the special value of `-1` then the node backend
 	// (docker, podman...) will be left to pick the port instead.
 	// This is potentially useful for remote hosts, BUT it means when the container
 	// is restarted it will be randomized. Leave this unset to allow kind to pick it.
@@ -194,7 +194,7 @@ type PortMapping struct {
 	//
 	// If unset, a random port will be selected.
 	//
-	// NOTE: if you set the special value of `-1` then the node backend 
+	// NOTE: if you set the special value of `-1` then the node backend
 	// (docker, podman...) will be left to pick the port instead.
 	// This is potentially useful for remote hosts, BUT it means when the container
 	// is restarted it will be randomized. Leave this unset to allow kind to pick it.

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -109,7 +109,12 @@ type Networking struct {
 	// IPFamily is the network cluster model, currently it can be ipv4 or ipv6
 	IPFamily ClusterIPFamily
 	// APIServerPort is the listen port on the host for the Kubernetes API Server
-	// Defaults to a random port on the host
+	// Defaults to a random port on the host obtained by kind
+	//
+	// NOTE: if you set the special value of `-1` then the node backend 
+	// (docker, podman...) will be left to pick the port instead.
+	// This is potentially useful for remote hosts, BUT it means when the container
+	// is restarted it will be randomized. Leave this unset to allow kind to pick it.
 	APIServerPort int32
 	// APIServerAddress is the listen address on the host for the Kubernetes
 	// API Server. This should be an IP address.
@@ -186,6 +191,13 @@ type PortMapping struct {
 	// Port within the container.
 	ContainerPort int32
 	// Port on the host.
+	//
+	// If unset, a random port will be selected.
+	//
+	// NOTE: if you set the special value of `-1` then the node backend 
+	// (docker, podman...) will be left to pick the port instead.
+	// This is potentially useful for remote hosts, BUT it means when the container
+	// is restarted it will be randomized. Leave this unset to allow kind to pick it.
 	HostPort int32
 	// TODO: add protocol (tcp/udp) and port-ranges
 	ListenAddress string

--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -109,7 +109,9 @@ func (n *Node) Validate() error {
 }
 
 func validatePort(port int32) error {
-	if port < 0 || port > 65535 {
+	// NOTE: -1 is a special value for auto-selecting the port in the container
+	// backend where possible as opposed to in kind itself.
+	if port < -1 || port > 65535 {
 		return errors.Errorf("invalid port number: %d", port)
 	}
 	return nil


### PR DESCRIPTION
by using magical `-1` value to signal that picking the port in the node backend is preferred.

this will help with host reboot, but still allow users of remote docker runtimes to have the port picked by the backend instead of locally.

in the future we could use a heuristic to determine which to use and maybe use a pointer for the host port fields to detect the unset case explicitly versus 0 == kind picks and -1 == prefer backend picks.

ref: https://github.com/kubernetes-sigs/kind/issues/1309 https://github.com/kubernetes-sigs/kind/issues/1173