### PR TITLE
Update docs to ensure that kubectl is installed

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -17,6 +17,8 @@ This guide covers getting started with the `kind` command.
 You can either install kind with `GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0` or clone this repo 
 and run `make build` from the repository.
 
+KIND does not require kubectl to function technically, but you will not be able to use the demo commands or follow most of the guide without it.
+
 **NOTE**: please use the latest Go to do this, ideally go 1.13 or greater.
 A version of Go officially [supported upstream][go-supported] by the Go project must be used.
 


### PR DESCRIPTION
Fixes #1343 
After installing `kind` binary, when you run `kind create cluster` at the end, if `kubectl` binary is not installed, it will throw an error. 

So we should specify in documentation that kubectl needs to be installed
