### PR TITLE
Use text/template instead of html/template

### DIFF
--- a/pkg/cluster/internal/create/actions/installcni/cni.go
+++ b/pkg/cluster/internal/create/actions/installcni/cni.go
@@ -19,8 +19,8 @@ package installcni
 
 import (
 	"bytes"
-	"html/template"
 	"strings"
+	"text/template"
 
 	"sigs.k8s.io/kind/pkg/errors"
 


### PR DESCRIPTION
Replaces html/template package usage with text/template since we are
parsing yaml manifests, not html.