### PR TITLE
Include `golang` in the base image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -66,7 +66,7 @@ RUN echo "Ensuring scripts are executable ..." \
     && DEBIAN_FRONTEND=noninteractive clean-install \
       systemd \
       conntrack iptables iproute2 ethtool socat util-linux mount ebtables udev kmod \
-      libseccomp2 \
+      libseccomp2 golang \
       bash ca-certificates curl rsync \
     && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-tmpfiles-setup.service" -delete \
     && rm -f /lib/systemd/system/multi-user.target.wants/* \


### PR DESCRIPTION
This is important for a project written by `golang`

see the discussion here: https://github.com/kubernetes/kubernetes/pull/88399#discussion_r383107339

This has blocked the gating for the PR.