### PR TITLE
docs: remove kind build base-image

### DIFF
--- a/images/base/README.md
+++ b/images/base/README.md
@@ -3,7 +3,7 @@
 
 This directory contains sources for building the `kind` base "node" image.
 
-The image can be built with `kind build base-image`.
+The image can be built with `make quick`.
 
 ## Maintenance
 

--- a/site/content/docs/design/node-image.md
+++ b/site/content/docs/design/node-image.md
@@ -15,8 +15,8 @@ nested containers, systemd, and Kubernetes components.
 
 This image is built on top of the ["base" image][base image].
 
-Logic for building both can be found in [`pkg/build`][build package],
-and they can be built with `kind build base-image` and `kind build node-image` respectively.
+Logic for building ["node" image][node image] can be found in [`pkg/build`][build package],
+and it can be built with `kind build node-image` respectively.
 
 ## Design
 

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -234,22 +234,16 @@ You may also try removing any unused data left by the Docker engine - e.g.,
 
 ### Building The Base Image
 
-To build the `base-image` we use the `build` command:
+To build the `base-image` we use the `make quick` command in `images/base` directory:
 ```
-kind build base-image
+make quick
 ```
 
-If you want to specify the path to the base image source files you can use the
-`--source` flag.
-
-If `--source` is not specified, kind will attempt to automatically locate
-the `images/base` base source directory.
-
-By default, the base image will be tagged as `kindest/base:latest`.
-If you want to change this, you can use the `--image` flag.
+By default, the base image will be tagged as `kindest/base:$(date +v%Y%m%d)-$(git describe --always --dirty)` format.
+If you want to change this, you can set `TAG` environment variable.
 
 ```
-kind build base-image --image base:v0.1.0
+TAG=v0.1.0 make quick
 ```
 
 


### PR DESCRIPTION
As a follow-up to #1376 , remove the obvious related content from the documentation