### PR TITLE
fix base image build on macos

### DIFF
--- a/images/base/Makefile
+++ b/images/base/Makefile
@@ -1,5 +1,7 @@
 TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git describe --always --dirty)")
 IMAGE?=kindest/base:$(TAG)
+# required for buildx
+export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # build with buildx
 PLATFORMS?=linux/amd64,linux/arm64
@@ -20,7 +22,6 @@ quick: OUTPUT=--load
 quick: build
 
 # enable buildx
-DOCKER_CLI_EXPERIMENTAL=enabled
 ensure-buildx:
 	./../../hack/build/init-buildx.sh
 


### PR DESCRIPTION
we need to specify `export` in the makefile
/shrug