### PR TITLE
Add OIDC configuration to docs

### DIFF
--- a/site/static/examples/config-with-oidc.yaml
+++ b/site/static/examples/config-with-oidc.yaml
@@ -1,0 +1,20 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        oidc-issuer-url: https://dex-server:10443/dex
+        oidc-client-id: YOUR_CLIENT_ID
+        oidc-username-claim: email
+        oidc-ca-file: /usr/local/share/ca-certificates/dex-ca.crt
+nodes:
+  - role: control-plane
+    extraMounts:
+      # mount the CA cerfiticate for HTTPS
+      - hostPath: /tmp/dex-ca.crt
+        containerPath: /usr/local/share/ca-certificates/dex-ca.crt

--- a/site/static/examples/oidc/dex.yaml
+++ b/site/static/examples/oidc/dex.yaml
@@ -1,0 +1,22 @@
+issuer: https://dex-server:10443/dex
+web:
+  https: 0.0.0.0:10443
+  tlsCert: /cfg/dex-server.crt
+  tlsKey: /cfg/dex-server.key
+storage:
+  type: sqlite3
+  config:
+    file: /tmp/dex.db
+staticClients:
+  - id: YOUR_CLIENT_ID
+    redirectURIs:
+      - http://localhost:8000
+    name: kubelogin
+    secret: YOUR_CLIENT_SECRET
+staticPasswords:
+  - email: "admin@example.com"
+    # bcrypt hash of the string "password"
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    username: "admin"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+enablePasswordDB: true


### PR DESCRIPTION
This will add the OpenID Connect configuration to the document. It helps testing Kubernetes OIDC authentication. All example files are based on [the acceptance test of kubelogin](https://github.com/int128/kubelogin/tree/master/acceptance_test).