### PR TITLE
[WIP][TEST]: use etcd in memory

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -131,6 +131,9 @@ kubeadmConfigPatches:
   kind: ClusterConfiguration
   metadata:
     name: config
+  etcd:
+    local:
+      dataDir: "/tmp/lib/etcd"
   apiServer:
     extraArgs:
       "runtime-config": "${runtime_config}"


### PR DESCRIPTION
kind mounts /tmp in memory

```
		// runtime temporary storage
		"--tmpfs", "/tmp", // various things depend on working /tmp
		"--tmpfs", "/run", // systemd wants a writable /run
```
use that to provide the etcd storage and avoid writing to disk