### PR TITLE
BUG: fix finding the provider when links are present

### DIFF
--- a/pkg/cluster/internal/providers/docker/provider.go
+++ b/pkg/cluster/internal/providers/docker/provider.go
@@ -77,7 +77,7 @@ func (p *Provider) Provision(status *cli.Status, cluster string, cfg *config.Clu
 func (p *Provider) ListClusters() ([]string, error) {
 	cmd := exec.Command("docker",
 		"ps",
-		"-a",         // show stopped nodes
+		"-a", // show stopped nodes
 		// filter for nodes with the cluster label
 		"--filter", "label="+clusterLabelKey,
 		// format to include the cluster name
@@ -94,7 +94,7 @@ func (p *Provider) ListClusters() ([]string, error) {
 func (p *Provider) ListNodes(cluster string) ([]nodes.Node, error) {
 	cmd := exec.Command("docker",
 		"ps",
-		"-a",         // show stopped nodes
+		"-a", // show stopped nodes
 		// filter for nodes with the cluster label
 		"--filter", fmt.Sprintf("label=%s=%s", clusterLabelKey, cluster),
 		// format to include the cluster name

--- a/pkg/cluster/internal/providers/docker/provider.go
+++ b/pkg/cluster/internal/providers/docker/provider.go
@@ -78,7 +78,6 @@ func (p *Provider) ListClusters() ([]string, error) {
 	cmd := exec.Command("docker",
 		"ps",
 		"-a",         // show stopped nodes
-		"--no-trunc", // don't truncate
 		// filter for nodes with the cluster label
 		"--filter", "label="+clusterLabelKey,
 		// format to include the cluster name
@@ -96,7 +95,6 @@ func (p *Provider) ListNodes(cluster string) ([]nodes.Node, error) {
 	cmd := exec.Command("docker",
 		"ps",
 		"-a",         // show stopped nodes
-		"--no-trunc", // don't truncate
 		// filter for nodes with the cluster label
 		"--filter", fmt.Sprintf("label=%s=%s", clusterLabelKey, cluster),
 		// format to include the cluster name

--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -90,7 +90,7 @@ func (p *Provider) Provision(status *cli.Status, cluster string, cfg *config.Clu
 func (p *Provider) ListClusters() ([]string, error) {
 	cmd := exec.Command("podman",
 		"ps",
-		"-a",         // show stopped nodes
+		"-a", // show stopped nodes
 		// filter for nodes with the cluster label
 		"--filter", "label="+clusterLabelKey,
 		// format to include the cluster name
@@ -107,7 +107,7 @@ func (p *Provider) ListClusters() ([]string, error) {
 func (p *Provider) ListNodes(cluster string) ([]nodes.Node, error) {
 	cmd := exec.Command("podman",
 		"ps",
-		"-a",         // show stopped nodes
+		"-a", // show stopped nodes
 		// filter for nodes with the cluster label
 		"--filter", fmt.Sprintf("label=%s=%s", clusterLabelKey, cluster),
 		// format to include the cluster name

--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -91,7 +91,6 @@ func (p *Provider) ListClusters() ([]string, error) {
 	cmd := exec.Command("podman",
 		"ps",
 		"-a",         // show stopped nodes
-		"--no-trunc", // don't truncate
 		// filter for nodes with the cluster label
 		"--filter", "label="+clusterLabelKey,
 		// format to include the cluster name
@@ -109,7 +108,6 @@ func (p *Provider) ListNodes(cluster string) ([]nodes.Node, error) {
 	cmd := exec.Command("podman",
 		"ps",
 		"-a",         // show stopped nodes
-		"--no-trunc", // don't truncate
 		// filter for nodes with the cluster label
 		"--filter", fmt.Sprintf("label=%s=%s", clusterLabelKey, cluster),
 		// format to include the cluster name


### PR DESCRIPTION
when running an ingress on KIND, like the one documented here: https://banzaicloud.com/blog/kind-ingress/

when you run
```
docker run -d --name banzai-kind-proxy-${port} \
      --publish 127.0.0.1:${port}:${port} \
      --link banzai-control-plane:target \
      alpine/socat -dd \
      tcp-listen:${port},fork,reuseaddr tcp-connect:target:${node_port}
```
it adds a link to the control-plane.     

Once this control-plane link exists, you can no longer get information from kind for nodes and can not load images. 
```
kind load docker-image ubuntu --name kind
ERROR: failed to get role for node: command "docker inspect --format '{{ index .Config.Labels "io.x-k8s.kind.role"}}' ingress-proxy-443/target,ingress-proxy-80/target,kind-control-plane" failed with error: exit status 1
```

This is caused by the --no-trunc option which in the docker ps command because it includes linked containers.  Removing the no-trunc option resolves the issue.    

I have tested several different setups to confirm resolution and couldn't find why the --no-trunc was added initially.   