### PR TITLE
use output lines when getting IPs

### DIFF
--- a/pkg/cluster/internal/providers/docker/node.go
+++ b/pkg/cluster/internal/providers/docker/node.go
@@ -56,7 +56,7 @@ func (n *node) IP() (ipv4 string, ipv6 string, err error) {
 		"-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}",
 		n.name, // ... against the "node" container
 	)
-	lines, err := exec.CombinedOutputLines(cmd)
+	lines, err := exec.OutputLines(cmd)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to get container details")
 	}

--- a/pkg/cluster/internal/providers/podman/node.go
+++ b/pkg/cluster/internal/providers/podman/node.go
@@ -56,7 +56,7 @@ func (n *node) IP() (ipv4 string, ipv6 string, err error) {
 		"-f", "{{.NetworkSettings.IPAddress}},{{.NetworkSettings.GlobalIPv6Address}}",
 		n.name, // ... against the "node" container
 	)
-	lines, err := exec.CombinedOutputLines(cmd)
+	lines, err := exec.OutputLines(cmd)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to get container details")
 	}


### PR DESCRIPTION
see https://github.com/kubernetes-sigs/kind/issues/1350#issuecomment-600357166

there's no reason to be using CombinedOutputLines here.