### PR TITLE
drop --no-trunc

### DIFF
--- a/pkg/cluster/internal/providers/docker/provider.go
+++ b/pkg/cluster/internal/providers/docker/provider.go
@@ -77,8 +77,7 @@ func (p *Provider) Provision(status *cli.Status, cluster string, cfg *config.Clu
 func (p *Provider) ListClusters() ([]string, error) {
 	cmd := exec.Command("docker",
 		"ps",
-		"-a",         // show stopped nodes
-		"--no-trunc", // don't truncate
+		"-a", // show stopped nodes
 		// filter for nodes with the cluster label
 		"--filter", "label="+clusterLabelKey,
 		// format to include the cluster name
@@ -95,8 +94,7 @@ func (p *Provider) ListClusters() ([]string, error) {
 func (p *Provider) ListNodes(cluster string) ([]nodes.Node, error) {
 	cmd := exec.Command("docker",
 		"ps",
-		"-a",         // show stopped nodes
-		"--no-trunc", // don't truncate
+		"-a", // show stopped nodes
 		// filter for nodes with the cluster label
 		"--filter", fmt.Sprintf("label=%s=%s", clusterLabelKey, cluster),
 		// format to include the cluster name

--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -90,8 +90,7 @@ func (p *Provider) Provision(status *cli.Status, cluster string, cfg *config.Clu
 func (p *Provider) ListClusters() ([]string, error) {
 	cmd := exec.Command("podman",
 		"ps",
-		"-a",         // show stopped nodes
-		"--no-trunc", // don't truncate
+		"-a", // show stopped nodes
 		// filter for nodes with the cluster label
 		"--filter", "label="+clusterLabelKey,
 		// format to include the cluster name
@@ -108,8 +107,7 @@ func (p *Provider) ListClusters() ([]string, error) {
 func (p *Provider) ListNodes(cluster string) ([]nodes.Node, error) {
 	cmd := exec.Command("podman",
 		"ps",
-		"-a",         // show stopped nodes
-		"--no-trunc", // don't truncate
+		"-a", // show stopped nodes
 		// filter for nodes with the cluster label
 		"--filter", fmt.Sprintf("label=%s=%s", clusterLabelKey, cluster),
 		// format to include the cluster name


### PR DESCRIPTION
fixes https://github.com/kubernetes-sigs/kind/pull/1409

I did a bunch of testing, I don't think we ever needed this ... the longest names that you can even make a working kind container with (before setting hostname fails and breaks starting the container in docker...) are not truncated ...

we can just drop `--no-trunc`.