### PR TITLE
return error when attemp to delete a non-existent cluster

### DIFF
--- a/pkg/cluster/internal/delete/delete.go
+++ b/pkg/cluster/internal/delete/delete.go
@@ -39,6 +39,9 @@ func Cluster(logger log.Logger, c *context.Context, explicitKubeconfigPath strin
 		logger.Errorf("failed to update kubeconfig: %v", kerr)
 	}
 
+	if len(n) == 0 {
+		return errors.New("No such cluster")
+	}
 	err = c.Provider().DeleteNodes(n)
 	if err != nil {
 		return err


### PR DESCRIPTION
the behaviors become:
$ ./bin/kind delete clusters aaaa bb cc
failed to delete cluster "aaaa": No such cluster
failed to delete cluster "bb": No such cluster
failed to delete cluster "cc": No such cluster
Deleted clusters: []
$ ./bin/kind delete cluster --name ccc
Deleting cluster "ccc" ...
ERROR: failed to delete cluster "ccc": No such cluster

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>