### PR TITLE
Support BTRFS and ZFS docker storage

### DIFF
--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -164,6 +164,13 @@ func commonArgs(cluster string, cfg *config.Cluster) ([]string, error) {
 	if usernsRemap() {
 		args = append(args, "--userns=host")
 	}
+
+	// handle Docker on Btrfs or ZFS
+	// https://github.com/kubernetes-sigs/kind/issues/1416#issuecomment-606514724
+	if mountDevMapper() {
+		args = append(args, "--volume", "/dev/mapper", "/dev/mapper")
+	}
+
 	return args, nil
 }
 

--- a/pkg/cluster/internal/providers/docker/util.go
+++ b/pkg/cluster/internal/providers/docker/util.go
@@ -36,3 +36,17 @@ func usernsRemap() bool {
 	}
 	return false
 }
+
+// mountDevMapper checks if the Docker storage driver is Btrfs or ZFS
+func mountDevMapper() bool {
+	storage := ""
+	cmd := exec.Command("docker", "info", "-f", "{{.Driver}}")
+	lines, err := exec.CombinedOutputLines(cmd)
+	if err != nil {
+		return false
+	}
+	if len(lines) > 0 {
+		storage = strings.ToLower(strings.TrimSpace(lines[0]))
+	}
+	return storage == "btrfs" || storage == "zfs"
+}


### PR DESCRIPTION
It seems that mounting /dev/mapper from the host to the kind
nodes remove the limitation on Docker of using BTRFS or ZFS

https://kind.sigs.k8s.io/docs/user/known-issues/#docker-on-btrfs-or-zfs

Fixes: https://github.com/kubernetes-sigs/kind/issues/1416