### PR TITLE
Shiny CI builds

### DIFF
--- a/hack/ci/push-latest-cli/push-latest-cli.sh
+++ b/hack/ci/push-latest-cli/push-latest-cli.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 set -o errexit -o nounset -o pipefail
+set -x;
 
 # cd to the repo root
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"

--- a/hack/ci/push-latest-cli/push-latest-cli.sh
+++ b/hack/ci/push-latest-cli/push-latest-cli.sh
@@ -23,19 +23,47 @@ cd "${REPO_ROOT}"
 # pass through git details from prow / image builder
 if [ -n "${PULL_BASE_SHA:-}" ]; then
   export COMMIT="${PULL_BASE_SHA:?}"
+else
+  COMMIT="$(git rev-parse HEAD 2>/dev/null)"
+  export COMMIT
 fi
+# short commmit is currently 8 characters
+SHORT_COMMIT="${COMMIT:0:8}"
+
+# we upload here
+BUCKET="${BUCKET:-k8s-staging-kind}"
+# under each of these
+VERSIONS=(
+  latest
+  "${SHORT_COMMIT}"
+)
 
 # build for all platforms
 hack/release/build/cross.sh
 
-# upload to latest bucket
-BUCKET="${BUCKET:-k8s-staging-kind}"
+# upload to the bucket
 for f in bin/kind-*; do
-  # NOTE: this bucket is temporary until prow is migrated to the CNCF
-  # this is just a google-hosted bucket used specifically for kind
-  # periodic UNTRUSTED CI builds used to speed up kubernetes CI
-  gsutil cp -P "$f" "gs://${BUCKET}/latest/$(basename "$f")"
+  # make a tarball with this
+  # TODO: eliminate e2e-k8s.sh
+  base="$(basename "$f")"
+  platform="${base/kind-//}"
+  tar \
+    -czvf "bin/${platform}.tgz" \
+    --transform 's#.*kind.*#kind#' \
+    --transform 's#.*e2e-k8s.sh#e2e-k8s.sh#' \
+    --transform='s#^/#./#' \
+    --mode='755' \
+    "${f}" \
+    "hack/ci/e2e-k8s.sh"
+  
+  # copy everything up to each version
+  for version in $VERSIONS; do
+    gsutil cp -P "bin/${platform}.tgz" "gs://${BUCKET}/${version}/${platform}.tgz"
+    gsutil cp -P "$f" "gs://${BUCKET}/${version}/${base}"
+  done
 done
 
 # upload the e2e script so kubernetes CI can consume it
-gsutil cp -P hack/ci/e2e-k8s.sh "gs://${BUCKET}/latest/e2e-k8s.sh"
+for version in $VERSIONS; do
+  gsutil cp -P hack/ci/e2e-k8s.sh "gs://${BUCKET}/${version}/e2e-k8s.sh"
+done

--- a/site/layouts/index.redirects
+++ b/site/layouts/index.redirects
@@ -2,3 +2,4 @@
 {{- range $apiVersions }}
 /{{ . }}     https://godoc.org/sigs.k8s.io/kind/pkg/apis/config/{{ . }}
 {{- end }}
+/dl/* https://storage.googleapis.com/k8s-staging-kind/:splat


### PR DESCRIPTION
- upload to multiple versions
- upload as a tarball containing the binar{y,ies} for the platform with mode set
- serve redirect on kind.sigs.k8s.io for shorter URLs