### PR TITLE
create redirect for release downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ into your `$PATH`:
 On Mac & Linux:
 
 ```console
-curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$(uname)-amd64"
+curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.7.0/kind-$(uname)-amd64"
 chmod +x ./kind
 mv ./kind /some-dir-in-your-PATH/kind
 ```
@@ -54,7 +54,7 @@ brew install kind
 On Windows:
 
 ```powershell
-curl.exe -Lo kind-windows-amd64.exe https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-windows-amd64
+curl.exe -Lo kind-windows-amd64.exe https://kind.sigs.k8s.io/dl/v0.7.0/kind-windows-amd64
 Move-Item .\kind-windows-amd64.exe c:\some-dir-in-your-PATH\kind.exe
 
 # OR via Chocolatey (https://chocolatey.org/packages/kind)

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -37,7 +37,7 @@ into your `$PATH`.
 On macOS / Linux:
 
 {{< codeFromInline lang="bash" >}}
-curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$(uname)-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.7.0/kind-$(uname)-amd64
 chmod +x ./kind
 mv ./kind /some-dir-in-your-PATH/kind
 {{< /codeFromInline >}}
@@ -51,7 +51,7 @@ brew install kind
 On Windows:
 
 {{< codeFromInline lang="powershell" >}}
-curl.exe -Lo kind-windows-amd64.exe https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-windows-amd64
+curl.exe -Lo kind-windows-amd64.exe https://kind.sigs.k8s.io/dl/v0.7.0/kind-windows-amd64
 Move-Item .\kind-windows-amd64.exe c:\some-dir-in-your-PATH\kind.exe
 {{< /codeFromInline >}}
 

--- a/site/layouts/index.redirects
+++ b/site/layouts/index.redirects
@@ -2,4 +2,5 @@
 {{- range $apiVersions }}
 /{{ . }}     https://godoc.org/sigs.k8s.io/kind/pkg/apis/config/{{ . }}
 {{- end }}
+/dl/v* https://github.com/kubernetes-sigs/kind/releases/download/v:splat
 /dl/* https://storage.googleapis.com/k8s-staging-kind/:splat


### PR DESCRIPTION
After this you can use `https://kind.sigs.k8s.io/dl/v0.7.0/kind-linux-amd64` (and generically any of our release binaries are served by this redirect)

Updated our docs to use this as it's shorter and it gives us more control over hosting (e.g. we have a wg-k8s prod GCS bucket now, and GCS seems to much faster than github artifacts).