### PR TITLE
fix config featuregate handling

### DIFF
--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -530,6 +530,11 @@ func Config(data ConfigData) (config string, err error) {
 		return "", err
 	}
 
+	// ensure featureGates is non-nil, as we may add entries
+	if data.FeatureGates == nil {
+		data.FeatureGates = make(map[string]bool)
+	}
+
 	// assume the latest API version, then fallback if the k8s version is too low
 	templateSource := ConfigTemplateBetaV2
 	if ver.LessThan(version.MustParseSemantic("v1.12.0")) {


### PR DESCRIPTION
fixes a panic on some kubernetes versions
we need to not be potentially assigning to a nil map lower down.

/priority critical-urgent
/cc @amwat @aojea 