### PR TITLE
Fix bug mounting /dev/mapper

### DIFF
--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -168,7 +168,7 @@ func commonArgs(cluster string, cfg *config.Cluster) ([]string, error) {
 	// handle Docker on Btrfs or ZFS
 	// https://github.com/kubernetes-sigs/kind/issues/1416#issuecomment-606514724
 	if mountDevMapper() {
-		args = append(args, "--volume", "/dev/mapper", "/dev/mapper")
+		args = append(args, "--volume", "/dev/mapper:/dev/mapper")
 	}
 
 	return args, nil


### PR DESCRIPTION
Fix the wrong syntax used for mounting the /dev/mapper as a volume

Fixes: https://github.com/kubernetes-sigs/kind/issues/1498