### PR TITLE
Set listenAddress in example to 127.0.0.1

### DIFF
--- a/site/static/examples/config-with-port-mapping.yaml
+++ b/site/static/examples/config-with-port-mapping.yaml
@@ -8,7 +8,7 @@ nodes:
     hostPort: 80
     # optional: set the bind address on the host
     # 0.0.0.0 is the current default
-    listenAddress: "127.0.0.0"
+    listenAddress: "127.0.0.1"
     # optional: set the protocol to one of TCP, UDP, SCTP.
     # TCP is the default
     protocol: TCP


### PR DESCRIPTION
Docker for mac fails with the following if --publish is set to 127.0.0.0:

> bind: can't assign requested address.

Updating the example to be working out of the box.