### PR TITLE
Better default info

### DIFF
--- a/cmd/kind/app/main.go
+++ b/cmd/kind/app/main.go
@@ -79,20 +79,29 @@ func checkQuiet(args []string) bool {
 
 // logError logs the error and the root stacktrace if there is one
 func logError(logger log.Logger, err error) {
-	if cmd.ColorEnabled(logger) {
+	colorEnabled := cmd.ColorEnabled(logger)
+	if colorEnabled {
 		logger.Errorf("\x1b[31mERROR\x1b[0m: %v", err)
 	} else {
 		logger.Errorf("ERROR: %v", err)
 	}
-	// If debugging is enabled (non-zero verbosity), display more info
-	if logger.V(1).Enabled() {
-		// Display Output if the error was running a command ...
-		if err := exec.RunErrorForError(err); err != nil {
-			logger.Errorf("\nOutput:\n%s", err.Output)
+	// Display Output if the error was from running a command ...
+	if err := exec.RunErrorForError(err); err != nil {
+		if colorEnabled {
+			logger.Errorf("\x1b[31mCommand Output\x1b[0m: %s", err.Output)
+		} else {
+			logger.Errorf("\nCommand Output: %s", err.Output)
 		}
+	}
+	// TODO: stacktrace should probably be guarded by a higher level ...?
+	if logger.V(1).Enabled() {
 		// Then display stack trace if any (there should be one...)
 		if trace := errors.StackTrace(err); trace != nil {
-			logger.Errorf("\nStack Trace: %+v", trace)
+			if colorEnabled {
+				logger.Errorf("\x1b[31mStack Trace\x1b[0m: %+v", trace)
+			} else {
+				logger.Errorf("\nStack Trace: %+v", trace)
+			}
 		}
 	}
 }

--- a/pkg/build/nodeimage/internal/container/docker/pull.go
+++ b/pkg/build/nodeimage/internal/container/docker/pull.go
@@ -55,8 +55,5 @@ func Pull(logger log.Logger, image string, retries int) error {
 			}
 		}
 	}
-	if err != nil {
-		logger.V(1).Infof("Failed to pull image: %q %v", image, err)
-	}
 	return err
 }

--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -100,7 +100,6 @@ func Cluster(logger log.Logger, ctx *context.Context, opts *ClusterOptions) erro
 	// Create node containers implementing defined config Nodes
 	if err := ctx.Provider().Provision(status, ctx.Name(), opts.Config); err != nil {
 		// In case of errors nodes are deleted (except if retain is explicitly set)
-		logger.Errorf("%v", err)
 		if !opts.Retain {
 			_ = delete.Cluster(logger, ctx, opts.KubeconfigPath)
 		}

--- a/pkg/cmd/kind/create/cluster/createcluster.go
+++ b/pkg/cmd/kind/create/cluster/createcluster.go
@@ -98,12 +98,6 @@ func runE(logger log.Logger, streams cmd.IOStreams, flags *flagpole) error {
 		cluster.CreateWithDisplayUsage(true),
 		cluster.CreateWithDisplaySalutation(true),
 	); err != nil {
-		if errs := errors.Errors(err); errs != nil {
-			for _, problem := range errs {
-				logger.Errorf("%v", problem)
-			}
-			return errors.New("aborting due to invalid configuration")
-		}
 		return errors.Wrap(err, "failed to create cluster")
 	}
 


### PR DESCRIPTION
fixes: https://github.com/kubernetes-sigs/kind/issues/1410

we still guard the stacktrace behind at least -v 1. possibly higher in the future...?

failed command output is *critical* to understanding what went wrong in many cases, we shouldn't hide this by default.