### PR TITLE
use beta label in older kubernetes

### DIFF
--- a/pkg/build/nodeimage/build_impl.go
+++ b/pkg/build/nodeimage/build_impl.go
@@ -281,7 +281,12 @@ func (c *buildContext) prePullImages(dir, containerID string) ([]string, error) 
 	requiredImages = append(requiredImages, defaultCNIImages...)
 
 	// write the default Storage manifest
-	if err := createFile(cmder, defaultStorageManifestLocation, defaultStorageManifest); err != nil {
+	// in < 1.14 we need to use beta labels
+	storageManifest := defaultStorageManifest
+	if ver.LessThan(version.MustParseSemantic("v1.14.0")) {
+		storageManifest = strings.ReplaceAll(storageManifest, "kubernetes.io/os", "beta.kubernetes.io/os")
+	}
+	if err := createFile(cmder, defaultStorageManifestLocation, storageManifest); err != nil {
 		c.logger.Errorf("Image build Failed! Failed write default Storage Manifest: %v", err)
 		return nil, err
 	}


### PR DESCRIPTION
follow up to #1508 
you can see 1.12 / 1.13 started failing in testgrid due to this.