### PR TITLE
add a flag for the path in export logs

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -35,7 +35,7 @@ cleanup() {
   fi
   # KIND_CREATE_ATTEMPTED is true once we: kind create
   if [ "${KIND_CREATE_ATTEMPTED:-}" = true ]; then
-    kind "export" logs "${ARTIFACTS}/logs" || true
+    kind export logs -C "${ARTIFACTS}/logs" || true
     kind delete cluster || true
   fi
   rm -f _output/bin/e2e.test || true

--- a/pkg/cmd/kind/root.go
+++ b/pkg/cmd/kind/root.go
@@ -111,11 +111,7 @@ func runE(logger log.Logger, flags *flagpole, command *cobra.Command) error {
 	maybeSetVerbosity(logger, log.Level(flags.Verbosity))
 	// warn about deprecated flag if used
 	if setLogLevel {
-		if cmd.ColorEnabled(logger) {
-			logger.Warn("\x1b[93mWARNING\x1b[0m: --loglevel is deprecated, please switch to -v and -q!")
-		} else {
-			logger.Warn("WARNING: --loglevel is deprecated, please switch to -v and -q!")
-		}
+		cmd.FancyWarn(logger, "--loglevel is deprecated, please switch to -v and -q!")
 	}
 	return nil
 }

--- a/pkg/cmd/logger.go
+++ b/pkg/cmd/logger.go
@@ -45,3 +45,13 @@ func ColorEnabled(logger log.Logger) bool {
 	v, ok := logger.(maybeColorer)
 	return ok && v.ColorEnabled()
 }
+
+// FancyWarn writes "WARNING: "+msg to logger.Warn, coloring WARNING if
+// ColorEnabled(logger)
+func FancyWarn(logger log.Logger, msg string) {
+	if ColorEnabled(logger) {
+		logger.Warn("\x1b[93mWARNING\x1b[0m: " + msg)
+	} else {
+		logger.Warn("WARNING: " + msg)
+	}
+}


### PR DESCRIPTION
`kind export logs` is currently _the only_ CLI command accepting an argument, and it only accepts this one argument. All other commands require zero arguments.

This PR creates a migration path off of that argument by adding a flag to control it instead. 
We can explore supporting arguments for `--name` in v0.9.0, which is more intuitive / ecosystem compatible in retrospect. `minikube`'s `--profile` was probably not desirable to mimic.

i.e. we can enable `kind get cluster kind2` <-> `kubectl get po baz` in a PR after v0.8.0 is out (so v0.8.0 only warns about the argument but still supports it and provides time to migrate).