### PR TITLE
always create network with ipv6

### DIFF
--- a/pkg/cluster/internal/providers/docker/network.go
+++ b/pkg/cluster/internal/providers/docker/network.go
@@ -20,8 +20,6 @@ import (
 	"regexp"
 
 	"sigs.k8s.io/kind/pkg/exec"
-
-	"sigs.k8s.io/kind/pkg/internal/apis/config"
 )
 
 // TODO: we'll probably allow configuring this
@@ -35,7 +33,7 @@ import (
 const fixedNetworkName = "kind"
 
 // ensureNetwork checks if docker network by name exists, if not it creates it
-func ensureNetwork(name string, ipFamily config.ClusterIPFamily) error {
+func ensureNetwork(name string) error {
 	// TODO: the network might already exist and not have ipv6 ... :|
 	// discussion: https://github.com/kubernetes-sigs/kind/pull/1508#discussion_r414594198
 	out, err := exec.Output(exec.Command(
@@ -53,8 +51,5 @@ func ensureNetwork(name string, ipFamily config.ClusterIPFamily) error {
 	// TODO: ipv6 subnet should probably not be fixed
 	// Though maybe just require the user to handle this by creating the network
 	// as they desire before running kind ...
-	if ipFamily == config.IPv6Family {
-		return exec.Command("docker", "network", "create", "-d=bridge", "--ipv6", "--subnet=fc00:db8:2::/64", name).Run()
-	}
-	return exec.Command("docker", "network", "create", "-d=bridge", name).Run()
+	return exec.Command("docker", "network", "create", "-d=bridge", "--ipv6", "--subnet=fc00:db8:2::/64", name).Run()
 }

--- a/pkg/cluster/internal/providers/docker/provider.go
+++ b/pkg/cluster/internal/providers/docker/provider.go
@@ -58,7 +58,7 @@ func (p *Provider) Provision(status *cli.Status, cluster string, cfg *config.Clu
 		return err
 	}
 
-	if err := ensureNetwork(fixedNetworkName, cfg.Networking.IPFamily); err != nil {
+	if err := ensureNetwork(fixedNetworkName); err != nil {
 		return errors.Wrap(err, "failed to ensure docker network")
 	}
 


### PR DESCRIPTION
/shrug
turns out "enabling ipv6" is only for the default bridge ...?
so we can just always create the kind network with ipv6 enabled.