### PR TITLE
Fix the problem of container restart failure

### DIFF
--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -187,7 +187,7 @@ enable_network_magic(){
       old_ipv4=$(cat /kind/old-ipv4)
       echo "INFO: Detected old IPv4 address: ${old_ipv4}" >&2
       # sanity check that we have a current address
-      if [[ -n $curr_ipv4 ]]; then
+      if [[ -z $curr_ipv4 ]]; then
         echo "ERROR: Have an old IPv4 address but no current IPv4 address (!)" >&2
         exit 1
       fi

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -207,7 +207,7 @@ enable_network_magic(){
       old_ipv6=$(cat /kind/old-ipv6)
       echo "INFO: Detected old IPv6 address: ${old_ipv6}" >&2
       # sanity check that we have a current address
-      if [[ -n $curr_ipv6 ]]; then
+      if [[ -z $curr_ipv6 ]]; then
         echo "ERROR: Have an old IPv6 address but no current IPv6 address (!)" >&2
       fi
       # kubernetes manifests are only present on control-plane nodes


### PR DESCRIPTION
1. When restart docker, the kind container restart failed. Docker logs:
```
INFO: Detected IPv4 address: 172.18.0.2
INFO: Detected old IPv4 address: 172.18.0.2
ERROR: Have an old IPv4 address but no current IPv4 address (!)
```
2. After modifying the file and replacing it, the container starts normally:
```
docker cp entrypoint cluster-control-plane:/usr/local/bin/entrypoint
docker start cluster-control-plane
```