### PR TITLE
experimentally allow custom networks

### DIFF
--- a/pkg/cluster/internal/providers/docker/network.go
+++ b/pkg/cluster/internal/providers/docker/network.go
@@ -27,14 +27,17 @@ import (
 	"sigs.k8s.io/kind/pkg/exec"
 )
 
-// TODO: we'll probably allow configuring this
+// This may be overridden by KIND_EXPERIMENTAL_DOCKER_NETWORK env,
+// experimentally...
 //
-// however currently picking a single network is equivalent to the previous
+// By default currently picking a single network is equivalent to the previous
 // behavior *except* that we moved from the default bridge to a user defined
 // network because the default bridge is actually special versus any other
 // docker network and lacks the emebdded DNS
 //
-// for now this also makes it easier for apps to join the same network
+// For now this also makes it easier for apps to join the same network, and
+// leaves users with complex networking desires to create and manage their own
+// networks.
 const fixedNetworkName = "kind"
 
 // ensureNetwork checks if docker network by name exists, if not it creates it

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -33,10 +33,10 @@ import (
 )
 
 // planCreation creates a slice of funcs that will create the containers
-func planCreation(cluster string, cfg *config.Cluster) (createContainerFuncs []func() error, err error) {
+func planCreation(cluster string, cfg *config.Cluster, networkName string) (createContainerFuncs []func() error, err error) {
 	// these apply to all container creation
 	nodeNamer := common.MakeNodeNamer(cluster)
-	genericArgs, err := commonArgs(cluster, cfg)
+	genericArgs, err := commonArgs(cluster, cfg, networkName)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func clusterHasImplicitLoadBalancer(cfg *config.Cluster) bool {
 }
 
 // commonArgs computes static arguments that apply to all containers
-func commonArgs(cluster string, cfg *config.Cluster) ([]string, error) {
+func commonArgs(cluster string, cfg *config.Cluster, networkName string) ([]string, error) {
 	// standard arguments all nodes containers need, computed once
 	args := []string{
 		"--detach", // run the container detached
@@ -145,7 +145,7 @@ func commonArgs(cluster string, cfg *config.Cluster) ([]string, error) {
 		// label the node with the cluster ID
 		"--label", fmt.Sprintf("%s=%s", clusterLabelKey, cluster),
 		// user a user defined docker network so we get embedded DNS
-		"--net", fixedNetworkName,
+		"--net", networkName,
 		// Docker supports the following restart modes:
 		// - no
 		// - on-failure[:max-retries]


### PR DESCRIPTION
fixes #273 
- we allow overriding the network
- it's not officially supported
- currently we do no validation
- it must be done via an experimental env, which comes with a warning