### PR TITLE
Extend site docs to include prereqs for building the base and node images

### DIFF
--- a/site/content/docs/design/base-image.md
+++ b/site/content/docs/design/base-image.md
@@ -12,9 +12,16 @@ menu:
 The ["base" image][base image] is a small-ish Docker image for running
 nested containers, systemd, and kubernetes components.
 
-To do this we need to set up an environment that will meet the CRI 
-(currently just docker) and systemd's particular needs. Documentation for each
-step we take is inline to the image's [Dockerfile][dockerfile],
+Logic for building ["base" image][base image] can be found in
+[`pkg/build`][build package], and it can be built with `kind build base-image`,
+respectively, via the `kind build base-image` command.  However, doing so
+requires the `kind` project's source is downloaded into the `GOPATH`. This can
+be accomplished via the command
+`GO111MODULE="on" go get sigs.k8s.io/kind@v0.8.0`.
+
+To create this base image, we need to set up an environment that will meet the
+CRI (currently just docker) and systemd's particular needs. Documentation for
+each step we take is inline to the image's [Dockerfile][dockerfile],
 but essentially:
 
 - we preinstall tools / packages expected by systemd / Docker / Kubernetes other
@@ -34,4 +41,6 @@ relatively up to date packages.
 We strive to minimize the image size where possible.
 
 [base image]: https://sigs.k8s.io/kind/images/base
+[build package]: https://sigs.k8s.io/kind/pkg/build
 [dockerfile]: https://sigs.k8s.io/kind/images/base/Dockerfile
+[node image]: https://sigs.k8s.io/kind/images/node

--- a/site/content/docs/design/base-image.md
+++ b/site/content/docs/design/base-image.md
@@ -12,12 +12,8 @@ menu:
 The ["base" image][base image] is a small-ish Docker image for running
 nested containers, systemd, and kubernetes components.
 
-Logic for building ["base" image][base image] can be found in
-[`pkg/build`][build package], and it can be built with `kind build base-image`,
-respectively, via the `kind build base-image` command.  However, doing so
-requires the `kind` project's source is downloaded into the `GOPATH`. This can
-be accomplished via the command
-`GO111MODULE="on" go get sigs.k8s.io/kind@v0.8.0`.
+If you want to build the base image for `kind`, the details for how to do that
+are documented in the [Quick Start Guide][build base image].
 
 To create this base image, we need to set up an environment that will meet the
 CRI (currently just docker) and systemd's particular needs. Documentation for
@@ -41,6 +37,5 @@ relatively up to date packages.
 We strive to minimize the image size where possible.
 
 [base image]: https://sigs.k8s.io/kind/images/base
-[build package]: https://sigs.k8s.io/kind/pkg/build
+[build base image]: https://kind.sigs.k8s.io/docs/user/quick-start/#building-the-base-image
 [dockerfile]: https://sigs.k8s.io/kind/images/base/Dockerfile
-[node image]: https://sigs.k8s.io/kind/images/node

--- a/site/content/docs/design/node-image.md
+++ b/site/content/docs/design/node-image.md
@@ -16,7 +16,12 @@ nested containers, systemd, and Kubernetes components.
 This image is built on top of the ["base" image][base image].
 
 Logic for building ["node" image][node image] can be found in [`pkg/build`][build package],
-and it can be built with `kind build node-image` respectively.
+and it can be built with `kind build node-image` respectively.  Building this
+image via the `kind` command requires both the `kind` and the `kubernetes`
+projects' source to be downloaded into the `GOPATH`.  The kind source can be
+installed via the command `GO111MODULE="on" go get sigs.k8s.io/kind@v0.8.0`.  To
+install the Kubernetes source, follow the
+[Kubernetes developer documentation][kubernetes developer docs].
 
 ## Design
 
@@ -48,3 +53,4 @@ each "node" container with [kubeadm][kubeadm].
 [docker image archives]: https://docs.docker.com/engine/reference/commandline/save/
 [systemd service]: https://www.freedesktop.org/software/systemd/man/systemd.service.html
 [kubeadm]: https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/
+[kubernetes developer docs]: https://github.com/kubernetes/kubernetes#you-have-a-working-go-environment


### PR DESCRIPTION
Ref. _*N/A_
Hopefully it's not presumptuous of me to open this PR without a corresponding issue in GitHub.  I saw an opportunity to expand on the documentation detailing how to build the base-image and node-image that KiND uses.  Since there's no code change, I figured I'd hop-in quickly and mention the prerequisite steps that are needed to build each image since I had to spend some time, myself, digging up why `kind build node-image` didn't work quite as the existing docs had lead me to believe it should.

/sig docs
/kind documentation
/area kind