### PR TITLE
Docs for using Ambassador as Ingress Controller

### DIFF
--- a/site/content/docs/user/ingress.md
+++ b/site/content/docs/user/ingress.md
@@ -25,6 +25,7 @@ by the ingress controller `nodeSelector`.
 
 1. [Create a cluster](#create-cluster)
 2. Deploy an Ingress controller, the following ingress controllers are known to work:
+    - [Ambassador](#ambassador)
     - [Contour](#contour)
     - [Ingress NGINX](#ingress-nginx)
 
@@ -57,6 +58,37 @@ nodes:
 EOF
 {{< /codeFromInline >}}
 
+### Ambassador
+
+[Ambassador](https://www.getambassador.io/) will be installed with the help of
+the [Ambassador operator](https://www.getambassador.io/docs/latest/topics/install/aes-operator/).
+
+First install the CRDs with
+
+{{< codeFromInline lang="bash" >}}
+kubectl apply -f https://github.com/datawire/ambassador-operator/releases/latest/download/ambassador-operator-crds.yaml
+{{< /codeFromInline >}}
+
+Now install the kind-specific manifest for installing Ambassador with the operator
+in the `ambassador` namespace:
+
+{{< codeFromInline lang="bash" >}}
+kubectl apply -n ambassador -f https://github.com/datawire/ambassador-operator/releases/latest/download/ambassador-operator-kind.yaml
+kubectl wait --timeout=180s -n ambassador --for=condition=deployed ambassadorinstallations/ambassador
+{{< /codeFromInline >}}
+
+Ambassador is now ready for use. You can try the example in [Using Ingress](#using-ingress) at this moment,
+but Ambassador will not automatically load the `Ingress` defined there. `Ingress` resources must include
+the annotation `kubernetes.io/ingress.class: ambassador` for being recognized by Ambassador (otherwise they are just ignored).
+So once the example has been loaded you can add this annotation with:
+
+{{< codeFromInline lang="bash" >}}
+kubectl annotate ingress example-ingress kubernetes.io/ingress.class=ambassador
+{{< /codeFromInline >}}
+
+Ambassador should be exposing your Ingress now. Please find additional documentation on
+Ambassador [here](https://www.getambassador.io/docs/latest/).
+
 ### Contour
 
 Deploy [Contour components](https://projectcontour.io/quickstart/contour.yaml).
@@ -83,6 +115,7 @@ Now the Contour is all setup to be used.
 Refer to [Using Ingress](#using-ingress) for a basic example usage.
 
 Additional information about Contour can be found at: [projectcontour.io](https://projectcontour.io)
+
 
 ### Ingress NGINX
 


### PR DESCRIPTION
This PR documents how to install [Ambassador](https://getambassador.io/) as an Ingress Controller.

Ambassador is installed via the Ambassador Operator which is the recommended way of installing Ambassador (it makes sure users always have the latest version of Ambassador installed and takes care of updates as well).
