### PR TITLE
[Podman] Fix volume mount options

### DIFF
--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -143,7 +143,15 @@ func (p *Provider) DeleteNodes(n []nodes.Node) error {
 	if err := exec.Command(command, args...).Run(); err != nil {
 		return errors.Wrap(err, "failed to delete nodes")
 	}
-	return nil
+	var nodeVolumes []string
+	for _, node := range n {
+		volume, err := getVolume(node.String())
+		if err != nil {
+			return err
+		}
+		nodeVolumes = append(nodeVolumes, volume)
+	}
+	return deleteVolumes(nodeVolumes)
 }
 
 // GetAPIServerEndpoint is part of the providers.Provider interface

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -162,6 +162,11 @@ func commonArgs(cluster string, cfg *config.Cluster) ([]string, error) {
 }
 
 func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, name string, args []string) ([]string, error) {
+	volume, err := createAnonymousVolume(name)
+	if err != nil {
+		return nil, err
+	}
+
 	args = append([]string{
 		"run",
 		"--hostname", name, // make hostname match container name
@@ -184,7 +189,11 @@ func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, n
 		// filesystem, which is not only better for performance, but allows
 		// running kind in kind for "party tricks"
 		// (please don't depend on doing this though!)
-		"--volume", "/var",
+		// also enable default docker volume options
+		// suid: SUID applications on the volume will be able to change their privilege
+		// exec: executables on the volume will be able to executed within the container
+		// dev: devices on the volume will be able to be used by processes within the container
+		"--volume", fmt.Sprintf("%s:/var:suid,exec,dev", volume),
 		// some k8s things want to read /lib/modules
 		"--volume", "/lib/modules:/lib/modules:ro",
 	},

--- a/pkg/cluster/internal/providers/podman/util.go
+++ b/pkg/cluster/internal/providers/podman/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podman
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/version"
@@ -57,4 +58,46 @@ func ensureMinVersion() error {
 		return errors.Errorf("podman version %q is too old, please upgrade to %q or later", v, minSupportedVersion)
 	}
 	return nil
+}
+
+// createAnonymousVolume creates a new anonymous volume
+// with the specified label=true
+// returns the name of the volume created
+func createAnonymousVolume(label string) (string, error) {
+	cmd := exec.Command("podman",
+		"volume",
+		"create",
+		// podman only support filter on key during list
+		// so we use the unique id as key
+		"--label", fmt.Sprintf("%s=true", label))
+	name, err := exec.Output(cmd)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(string(name), "\n"), nil
+}
+
+// getVolume gets the volume name filtered on specified label
+func getVolume(label string) (string, error) {
+	cmd := exec.Command("podman",
+		"volume",
+		"ls",
+		"--filter", fmt.Sprintf("label=%s", label),
+		"--quiet")
+	name, err := exec.Output(cmd)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(string(name), "\n"), nil
+}
+
+func deleteVolumes(names []string) error {
+	args := []string{
+		"volume",
+		"rm",
+		"--force",
+	}
+	args = append(args, names...)
+	cmd := exec.Command("podman", args...)
+	return cmd.Run()
 }


### PR DESCRIPTION
fixes: https://github.com/kubernetes-sigs/kind/issues/1581

Unfortunately podman doesn't support adding volume mount options to anonymous volumes during container run time.
Precreated anonymous volumes, labeled them with appropriate node name as key (for later retrieval and deletion)
Also added other default options that docker volume mounts have.
 