### PR TITLE
Add support to configure kube-proxy mode

### DIFF
--- a/pkg/apis/config/v1alpha4/default.go
+++ b/pkg/apis/config/v1alpha4/default.go
@@ -63,6 +63,10 @@ func SetDefaultsCluster(obj *Cluster) {
 			obj.Networking.ServiceSubnet = "fd00:10:96::/112"
 		}
 	}
+	// default the KubeProxyMode using iptables as it's already the default
+	if obj.Networking.KubeProxyMode == "" {
+		obj.Networking.KubeProxyMode = IPTablesMode
+	}
 }
 
 // SetDefaultsNode sets uninitialized fields to their default value.

--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -174,6 +174,9 @@ type Networking struct {
 	// If DisableDefaultCNI is true, kind will not install the default CNI setup.
 	// Instead the user should install their own CNI after creating the cluster.
 	DisableDefaultCNI bool `yaml:"disableDefaultCNI,omitempty"`
+	// KubeProxyMode defines if kube-proxy should operate in iptables or ipvs mode
+	// Defaults to 'iptables' mode
+	KubeProxyMode ProxyMode `yaml:"kubeProxyMode,omitempty"`
 }
 
 // ClusterIPFamily defines cluster network IP family
@@ -184,6 +187,16 @@ const (
 	IPv4Family ClusterIPFamily = "ipv4"
 	// IPv6Family sets ClusterIPFamily to ipv6
 	IPv6Family ClusterIPFamily = "ipv6"
+)
+
+// ProxyMode defines a proxy mode for kube-proxy
+type ProxyMode string
+
+const (
+	// IPTablesMode sets ProxyMode to iptables
+	IPTablesMode ProxyMode = "iptables"
+	// IPVSMode sets ProxyMode to iptables
+	IPVSMode ProxyMode = "ipvs"
 )
 
 // PatchJSON6902 represents an inline kustomize json 6902 patch

--- a/pkg/cluster/internal/create/actions/config/config.go
+++ b/pkg/cluster/internal/create/actions/config/config.go
@@ -66,6 +66,7 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 		APIServerAddress:     ctx.Config.Networking.APIServerAddress,
 		Token:                kubeadm.Token,
 		PodSubnet:            ctx.Config.Networking.PodSubnet,
+		KubeProxyMode:        string(ctx.Config.Networking.KubeProxyMode),
 		ServiceSubnet:        ctx.Config.Networking.ServiceSubnet,
 		ControlPlane:         true,
 		IPv6:                 ctx.Config.Networking.IPFamily == "ipv6",

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -45,6 +45,8 @@ type ConfigData struct {
 	NodeAddress string
 	// The Token for TLS bootstrap
 	Token string
+	// KubeProxyMode defines the kube-proxy mode between iptables or ipvs
+	KubeProxyMode string
 	// The subnet used for pods
 	PodSubnet string
 	// The subnet used for services
@@ -288,6 +290,7 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 metadata:
   name: config
+mode: "{{ .KubeProxyMode }}"
 {{if .FeatureGates}}featureGates:
 {{ range $key := .SortedFeatureGateKeys }}
   "{{ $key }}": {{$.FeatureGates $key }}
@@ -402,6 +405,7 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 metadata:
   name: config
+mode: "{{ .KubeProxyMode }}"
 {{if .FeatureGates}}featureGates:
 {{ range $key := .SortedFeatureGateKeys }}
   "{{ $key }}": {{ index $.FeatureGates $key }}
@@ -516,6 +520,7 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 metadata:
   name: config
+mode: "{{ .KubeProxyMode }}"
 {{if .FeatureGates}}featureGates:
 {{ range $key := .SortedFeatureGateKeys }}
   "{{ $key }}": {{ index $.FeatureGates $key }}

--- a/pkg/internal/apis/config/convert_v1alpha4.go
+++ b/pkg/internal/apis/config/convert_v1alpha4.go
@@ -79,6 +79,7 @@ func convertv1alpha4Networking(in *v1alpha4.Networking, out *Networking) {
 	out.APIServerPort = in.APIServerPort
 	out.APIServerAddress = in.APIServerAddress
 	out.PodSubnet = in.PodSubnet
+	out.KubeProxyMode = ProxyMode(in.KubeProxyMode)
 	out.ServiceSubnet = in.ServiceSubnet
 	out.DisableDefaultCNI = in.DisableDefaultCNI
 }

--- a/pkg/internal/apis/config/default.go
+++ b/pkg/internal/apis/config/default.go
@@ -67,6 +67,10 @@ func SetDefaultsCluster(obj *Cluster) {
 			obj.Networking.ServiceSubnet = "fd00:10:96::/112"
 		}
 	}
+	// default the KubeProxyMode using iptables as it's already the default
+	if obj.Networking.KubeProxyMode == "" {
+		obj.Networking.KubeProxyMode = IPTablesMode
+	}
 }
 
 // SetDefaultsNode sets uninitialized fields to their default value.

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -130,6 +130,8 @@ type Networking struct {
 	// If DisableDefaultCNI is true, kind will not install the default CNI setup.
 	// Instead the user should install their own CNI after creating the cluster.
 	DisableDefaultCNI bool
+	// KubeProxyMode defines if kube-proxy should operate in iptables or ipvs mode
+	KubeProxyMode ProxyMode
 }
 
 // ClusterIPFamily defines cluster network IP family
@@ -140,6 +142,16 @@ const (
 	IPv4Family ClusterIPFamily = "ipv4"
 	// IPv6Family sets ClusterIPFamily to ipv6
 	IPv6Family ClusterIPFamily = "ipv6"
+)
+
+// ProxyMode defines a proxy mode for kube-proxy
+type ProxyMode string
+
+const (
+	// IPTablesMode sets ProxyMode to iptables
+	IPTablesMode ProxyMode = "iptables"
+	// IPVSMode sets ProxyMode to iptables
+	IPVSMode ProxyMode = "ipvs"
 )
 
 // PatchJSON6902 represents an inline kustomize json 6902 patch

--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -45,6 +45,11 @@ func (c *Cluster) Validate() error {
 		errs = append(errs, errors.Wrapf(err, "invalid serviceSubnet"))
 	}
 
+	// KubeProxyMode should be iptables or ipvs
+	if c.Networking.KubeProxyMode != IPTablesMode && c.Networking.KubeProxyMode != IPVSMode {
+		errs = append(errs, errors.Errorf("invalid kubeProxyMode: %s", c.Networking.KubeProxyMode))
+	}
+
 	// validate nodes
 	numByRole := make(map[NodeRole]int32)
 	// All nodes in the config should be valid

--- a/pkg/internal/apis/config/validate_test.go
+++ b/pkg/internal/apis/config/validate_test.go
@@ -86,6 +86,16 @@ func TestClusterValidate(t *testing.T) {
 			ExpectErrors: 1,
 		},
 		{
+			Name: "bogus kubeProxyMode",
+			Cluster: func() Cluster {
+				c := Cluster{}
+				SetDefaultsCluster(&c)
+				c.Networking.KubeProxyMode = "notiptables"
+				return c
+			}(),
+			ExpectErrors: 1,
+		},
+		{
 			Name: "missing control-plane",
 			Cluster: func() Cluster {
 				c := Cluster{}

--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -134,6 +134,18 @@ networking:
 {{< /codeFromInline >}}
 
 
+#### kube-proxy mode
+
+You can configure the kube-proxy mode that will be used, between iptables and ipvs. By
+default iptables is used
+
+{{< codeFromInline lang="yaml" >}}
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  kubeProxyMode: "ipvs"
+{{< /codeFromInline >}}
+
 ### Nodes
 The `kind: Cluster` object has a `nodes` field containing a list of `node`
 objects. If unset this defaults to:


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

This PR adds support to configure the kube-proxy mode in KinD.

Instead of patching the kubeadm configuration, the user now just need to use the following in KinD config:

```
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
networking:
  kubeProxyMode: ipvs
```

And hopefully I won't break anything :D