### PR TITLE
implement dns caching

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -70,6 +70,7 @@ RUN echo "Ensuring scripts are executable ..." \
       libseccomp2 \
       bash ca-certificates curl rsync \
       nfs-common \
+      nscd \
     && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-tmpfiles-setup.service" -delete \
     && rm -f /lib/systemd/system/multi-user.target.wants/* \
     && rm -f /etc/systemd/system/*.wants/* \
@@ -112,7 +113,9 @@ RUN echo "Ensuring scripts are executable ..." \
  && echo "Adjusting systemd-tmpfiles timer" \
     && sed -i /usr/lib/systemd/system/systemd-tmpfiles-clean.timer -e 's#OnBootSec=.*#OnBootSec=1min#' \
  && echo "Modifying /etc/nsswitch.conf to prefer hosts" \
-    && sed -i /etc/nsswitch.conf -re 's#^(hosts:\s*).*#\1dns files#'
+    && sed -i /etc/nsswitch.conf -re 's#^(hosts:\s*).*#\1dns files#' \
+ && echo "Enabling DNS caching" \
+    && systemctl enable nscd
 
 # tell systemd that it is in docker (it will check for the container env)
 # https://systemd.io/CONTAINER_INTERFACE/

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -81,6 +81,14 @@ fix_machine_id() {
   systemd-machine-id-setup
 }
 
+fix_nscd_dir() {
+  # nscd creates the folder /var/run/nscd at install time so he can create a
+  # socket /var/run/nscd/socket. Because we are mounting /var/run as a tmpfs
+  # the folder does not exists and nscd fails to start.
+  echo 'INFO: ensuring /var/run/nscd exists ' >&2
+  mkdir -p /var/run/nscd
+}
+
 fix_product_name() {
   # this is a small fix to hide the underlying hardware and fix issue #426
   # https://github.com/kubernetes-sigs/kind/issues/426
@@ -225,6 +233,7 @@ fix_kmsg
 fix_mount
 fix_cgroup
 fix_machine_id
+fix_nscd_dir
 fix_product_name
 fix_product_uuid
 configure_proxy


### PR DESCRIPTION
since we implemented custom docker bridges, we use hostnames
instead of ip addresses on all the components.
This allows us to not care about the nodes IP addresses, so there
is no problem if the cluster is rebooted and other IPs are assigned
to the node.
However, this is not free, and it comes at the cost that every
hostname resolution is a DNS request, and by default uses UDP.
On noise environments this can cause packet drops, the most common
solution to avoid this is implement caching.
Linux has implemented caching in the glibc library using the nscd
daemon, that seems a good fit for us because does not require to
change the /etc/resolv.conf, instead other alternatives like dnsmasq.