### PR TITLE
Fixes kind-with-registry.sh

### DIFF
--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -22,10 +22,10 @@ containerdConfigPatches:
 EOF
 
 # connect the registry to the cluster network
-docker network connect "kind" "${reg_name}"
+docker network connect "kind" "${reg_name}" 2>/dev/null || true
 
 # tell https://tilt.dev to use the registry
 # https://docs.tilt.dev/choosing_clusters.html#discovering-the-registry
 for node in $(kind get nodes); do
-  kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${reg_port}";
+  kubectl annotate node "${node}" "tilt.dev/registry=localhost:${reg_port}"
 done


### PR DESCRIPTION
Makes it more idempotent when connecting the network.
Switches the node annotation from `kind.x-k8s.io/registry` to `tilt.dev/registry`.