### PR TITLE
disallow capitals in cluster names

### DIFF
--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -53,7 +53,7 @@ const (
 // and suffix this name, we can relax it a little
 // see NewContext() for usage
 // https://godoc.org/github.com/docker/docker/daemon/names#pkg-constants
-var validNameRE = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
+var validNameRE = regexp.MustCompile(`^[a-z0-9_.-]+$`)
 
 // ClusterOptions holds cluster creation options
 type ClusterOptions struct {


### PR DESCRIPTION
"fixes" https://github.com/kubernetes-sigs/kind/issues/1601
I'll follow up with the other commit making this regex more accurate when I'm more confident in it, filing this to ensure the trivial fix doesn't slip.