### PR TITLE
improved provider detection

### DIFF
--- a/pkg/cluster/internal/providers/docker/util.go
+++ b/pkg/cluster/internal/providers/docker/util.go
@@ -22,6 +22,16 @@ import (
 	"sigs.k8s.io/kind/pkg/exec"
 )
 
+// IsAvailable checks if docker is available in the system
+func IsAvailable() bool {
+	cmd := exec.Command("docker", "-v")
+	lines, err := exec.OutputLines(cmd)
+	if err != nil || len(lines) != 1 {
+		return false
+	}
+	return strings.HasPrefix(lines[0], "Docker version")
+}
+
 // usernsRemap checks if userns-remap is enabled in dockerd
 func usernsRemap() bool {
 	cmd := exec.Command("docker", "info", "--format", "'{{json .SecurityOptions}}'")

--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -60,9 +60,10 @@ func (p *Provider) Provision(status *cli.Status, cfg *config.Cluster) (err error
 		return err
 	}
 
-	// kind doesn't currently work with podman rootless, surface a warning
+	// kind doesn't work with podman rootless, surface an error
 	if os.Geteuid() != 0 {
-		p.logger.Warn("podman provider may not work properly in rootless mode")
+		p.logger.Errorf("podman provider does not work properly in rootless mode")
+		os.Exit(1)
 	}
 
 	// TODO: validate cfg

--- a/pkg/cluster/internal/providers/podman/util.go
+++ b/pkg/cluster/internal/providers/podman/util.go
@@ -26,6 +26,16 @@ import (
 	"sigs.k8s.io/kind/pkg/exec"
 )
 
+// IsAvailable checks if podman is available in the system
+func IsAvailable() bool {
+	cmd := exec.Command("podman", "-v")
+	lines, err := exec.OutputLines(cmd)
+	if err != nil || len(lines) != 1 {
+		return false
+	}
+	return strings.HasPrefix(lines[0], "podman version")
+}
+
 func getPodmanVersion() (*version.Version, error) {
 	cmd := exec.Command("podman", "--version")
 	lines, err := exec.CombinedOutputLines(cmd)

--- a/pkg/cluster/provider.go
+++ b/pkg/cluster/provider.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"os/exec"
 	"sort"
 
 	"sigs.k8s.io/kind/pkg/cluster/constants"
@@ -70,11 +69,11 @@ func NewProvider(options ...ProviderOption) *Provider {
 	}
 
 	if p.provider == nil {
-		// auto-detect based on what is available in path
+		// auto-detect based on each package IsAvailable() function
 		// default to docker for backwards compatibility
-		if path, err := exec.LookPath("docker"); err == nil && path != "" {
+		if docker.IsAvailable() {
 			p.provider = docker.NewProvider(p.logger)
-		} else if path, err := exec.LookPath("podman"); err == nil && path != "" {
+		} else if podman.IsAvailable() {
 			p.provider = podman.NewProvider(p.logger)
 		} else {
 			p.provider = docker.NewProvider(p.logger)


### PR DESCRIPTION
Two changes in this PR:

* Fail if podman is running rootless, currently it throws a warning and later it fails or exits with noop operation ... it's confusing/annoying :upside_down_face: , I think is better failing fast and inform about the problem

* Detect the provider by checking the `command -v` output, we were looking for the path of the binary, but since we are executing the commands directly this should be safe. Also, we avoid the tricks done to replace one or the other command

Fixes: https://github.com/kubernetes-sigs/kind/issues/1611