### PR TITLE
Initial changes to enable KinD + Sysbox.

### DIFF
--- a/pkg/build/nodeimage/internal/container/docker/exec.go
+++ b/pkg/build/nodeimage/internal/container/docker/exec.go
@@ -67,10 +67,9 @@ type containerCmd struct {
 func (c *containerCmd) Run() error {
 	args := []string{
 		"exec",
-		// run with privileges so we can remount etc..
-		// this might not make sense in the most general sense, but it is
-		// important to many kind commands
-		"--privileged",
+
+		// Nestybox: --privileged is not required with Sysbox
+		//"--privileged",
 	}
 	if c.stdin != nil {
 		args = append(args,

--- a/pkg/cluster/internal/providers/docker/node.go
+++ b/pkg/cluster/internal/providers/docker/node.go
@@ -102,10 +102,9 @@ type nodeCmd struct {
 func (c *nodeCmd) Run() error {
 	args := []string{
 		"exec",
-		// run with privileges so we can remount etc..
-		// this might not make sense in the most general sense, but it is
-		// important to many kind commands
-		"--privileged",
+
+		// Nestybox: --privileged is not required with Sysbox
+		// "--privileged",
 	}
 	if c.stdin != nil {
 		args = append(args,


### PR DESCRIPTION
This change modifies the KinD Docker provisioner to work with the
Nestybox Sysbox runtime.

This allows deployment of K8s-in-Docker clusters without resorting
to privileged containers (i.e., much more securely) as well as
taking advantage of several other features unique to Sysbox (e.g.,
significant reduction in storage overhead for multi-node KinD clusters,
commit of K8s nodes capturing inner container images, etc).

The changes are in the Docker provisioner, namely to invoke the "docker run"
command with "--runtime=sysbox", without "--privileged", and without
configuring special host mounts (Sysbox does not require them).