### PR TITLE
trap INT and TERM in CI

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -205,7 +205,7 @@ run_tests() {
 main() {
   # create temp dir and setup cleanup
   TMP_DIR=$(mktemp -d)
-  trap cleanup EXIT
+  trap cleanup INT TERM EXIT
 
   # ensure artifacts (results) directory exists when not in CI
   export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"

--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -258,9 +258,11 @@ main() {
   fi
 
   # create the cluster and run tests
-  create_cluster && run_tests
-
-  cleanup
+  res=0
+  create_cluster || res=$?
+  run_tests || res=$?
+  cleanup || res=$?
+  exit $res
 }
 
 main

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -37,7 +37,7 @@ install_kind() {
 main() {
   # create temp dir and setup cleanup
   TMP_DIR=$(mktemp -d)
-  trap cleanup EXIT
+  trap cleanup INT TERM EXIT
 
   # install kind
   install_kind


### PR DESCRIPTION
EXIT is not handled consistently across shells

this will be obviated by #986 but the need to debug some timeouts is a bit more pressing and this change is tiny ...