### PR TITLE
Rollback containerd

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -23,7 +23,7 @@ FROM ubuntu:20.04
 
 # Configure containerd and runc binaries from kind-ci/containerd-nightlies repository
 # The repository contains latest stable releases and nightlies built for multiple architectures
-ARG CONTAINERD_VERSION="v1.4.0-beta.0-2-g6312b52d"
+ARG CONTAINERD_VERSION="v1.3.4-12-g1e902b2d"
 # Configure CNI binaries from upstream
 ARG CNI_VERSION="v0.8.6"
 # Configure crictl binary from upstream

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.18.2@sha256:c8f3e43281ebfac9a794f1e5a2c07c012f28c425906bcaafc2fe36c440b2d64a"
+const Image = "kindest/node:v1.18.2@sha256:1e57b3a1a5a44e4d3fd32ce7c19a34a9ec388564debd0121a387d19d75a6a397"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,7 +20,7 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20200515-fefccb7a"
+const DefaultBaseImage = "kindest/base:v20200530-c3e2b553"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
to latest 1.3.X, not 1.4.x

fixes https://github.com/kubernetes-sigs/kind/issues/1634

we're going to need to identify the breakage so we can eventually roll forward to 1.4.X when it comes out though, and this means we lose the fix for #1560 