### PR TITLE
Look for update-alternatives before using it

### DIFF
--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -150,8 +150,10 @@ select_iptables() {
   fi
 
   echo "INFO: setting iptables to detected mode: ${mode}" >&2
+  if [ -x /usr/bin/update-alternatives ]; then
   update-alternatives --set iptables "/usr/sbin/iptables-${mode}" > /dev/null
   update-alternatives --set ip6tables "/usr/sbin/ip6tables-${mode}" > /dev/null
+  fi
 }
 
 enable_network_magic(){


### PR DESCRIPTION
It is only used with dpkg, not with other systems such as
buildroot (that already has iptables legacy as the default)

I experimented with doing an image based on "buildroot",
which uses busybox rather than ubuntu for the packages.

See https://github.com/kubernetes/minikube/issues/6942

Also had issues with "hostname --ip-address", but it seems gone