### PR TITLE
Tighten GA_ONLY configuration to drop CSR exception for 1.19

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -110,8 +110,7 @@ create_cluster() {
       echo "GA_ONLY=true is only supported on versions >= v1.18, got ${KUBE_VERSION}"
       exit 1
       ;;
-    v1.1[8-9].*)
-      # TODO(liggitt): drop this exception for 1.19 once the CSR API and feature are promoted to GA in 1.19
+    v1.18.*)
       echo "Limiting to GA APIs and features (plus certificates.k8s.io/v1beta1 and RotateKubeletClientCertificate) for ${KUBE_VERSION}"
       feature_gates='{"AllAlpha":false,"AllBeta":false,"RotateKubeletClientCertificate":true}'
       runtime_config='api/alpha=false,api/beta=false,certificates.k8s.io/v1beta1=true'


### PR DESCRIPTION
Removes the CSR exceptions for the GA_ONLY config

https://github.com/kubernetes/enhancements/issues/1333

Requires:
- [x] https://github.com/kubernetes/kubernetes/pull/91685
- [x] https://github.com/kubernetes/kubernetes/pull/91713
- [x] https://github.com/kubernetes/kubernetes/pull/91754
- [x] https://github.com/kubernetes/kubernetes/pull/91778
- [x] https://github.com/kubernetes/kubernetes/pull/91779
- [x] https://github.com/kubernetes/kubernetes/pull/91780
- [x] https://github.com/kubernetes/kubernetes/pull/92018