### PR TITLE
SCTP

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -23,7 +23,7 @@ FROM ubuntu:20.04
 
 # Configure containerd and runc binaries from kind-ci/containerd-nightlies repository
 # The repository contains latest stable releases and nightlies built for multiple architectures
-ARG CONTAINERD_VERSION="v1.4.0-beta.1-26-g834665d9"
+ARG CONTAINERD_VERSION="v1.4.0-beta.1-34-g49b0743c"
 # Configure CNI binaries from upstream
 ARG CNI_VERSION="v0.8.6"
 # Configure crictl binary from upstream

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,7 +20,7 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20200610-99eb0617"
+const DefaultBaseImage = "kindest/base:v20200616-e6c913bf"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/issues/92041
picks up containerd with the CRI patch to enable SCTP