### PR TITLE
use iptables-nft to avoid xtables.lock

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -79,6 +79,9 @@ RUN echo "Ensuring scripts are executable ..." \
     && rm -f /lib/systemd/system/basic.target.wants/* \
     && echo "ReadKMsg=no" >> /etc/systemd/journald.conf \
     && ln -s "$(which systemd)" /sbin/init \
+ && echo "Using iptables-nft ..." \
+    && update-alternatives --set iptables /usr/sbin/iptables-nft \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-nft \
  && echo "Installing containerd ..." \
     && export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') \
     && export CONTAINERD_BASE_URL="https://github.com/kind-ci/containerd-nightlies/releases/download/containerd-${CONTAINERD_VERSION#v}" \


### PR DESCRIPTION
kube-proxy images uses the same version that is using in the host where it is running, so it should pick nft if we default the nodes to nft.

iptables-legacy use an external lock 
```
openat(AT_FDCWD, "/run/xtables.lock", O_RDONLY|O_CREAT, 0600) = 4
flock(4, LOCK_EX|LOCK_NB)  
```

iptables-nft does not, and is namespaced, that should avoid interference when running cluster in different pods 

```
iptables vs. iptables-nft vs. nft
In comparison to legacy iptables, iptables-nft has a few clear benefits: With back end transactions being atomic, there is no need for the global xtables lock which has proven problematic in environments with large and/or rapidly changing rulesets. 
```
xref https://www.redhat.com/en/blog/using-iptables-nft-hybrid-linux-firewall