### PR TITLE
WIP configure mtu 

### DIFF
--- a/images/kindnetd/cmd/kindnetd/cni.go
+++ b/images/kindnetd/cmd/kindnetd/cni.go
@@ -34,18 +34,22 @@ import (
 type CNIConfigInputs struct {
 	PodCIDR      string
 	DefaultRoute string
+	MTU          string
 }
 
 // ComputeCNIConfigInputs computes the template inputs for CNIConfigWriter
 func ComputeCNIConfigInputs(node corev1.Node) CNIConfigInputs {
 	podCIDR := node.Spec.PodCIDR
 	defaultRoute := "0.0.0.0/0"
+	defaultMtu := "1480"
+
 	if net.IsIPv6CIDRString(podCIDR) {
 		defaultRoute = "::/0"
 	}
 	return CNIConfigInputs{
 		PodCIDR:      podCIDR,
 		DefaultRoute: defaultRoute,
+		MTU:          defaultMtu,
 	}
 }
 
@@ -75,7 +79,8 @@ const cniConfigTemplate = `
 				}
 			]
 		]
-		}
+		},
+		"mtu": "{{ .Mtu }}"
 	},
 	{
 		"type": "portmap",

--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -181,6 +181,8 @@ type Networking struct {
 	// KubeProxyMode defines if kube-proxy should operate in iptables or ipvs mode
 	// Defaults to 'iptables' mode
 	KubeProxyMode ProxyMode `yaml:"kubeProxyMode,omitempty"`
+	// MTU is the mtu value the ptp CNI plugin will use, if specified
+	MTU int32 `yaml:"mtu,omitempty"`
 }
 
 // ClusterIPFamily defines cluster network IP family

--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -182,7 +182,7 @@ type Networking struct {
 	// Defaults to 'iptables' mode
 	KubeProxyMode ProxyMode `yaml:"kubeProxyMode,omitempty"`
 	// MTU is the mtu value the ptp CNI plugin will use, if specified
-	MTU int32 `yaml:"mtu,omitempty"`
+	MTU string `yaml:"mtu,omitempty"`
 }
 
 // ClusterIPFamily defines cluster network IP family

--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -105,6 +105,8 @@ spec:
               fieldPath: status.podIP
         - name: POD_SUBNET
           value: {{ .PodSubnet }}
+	- name: MTU
+	  value: {{ .Mtu }}
         volumeMounts:
         - name: cni-cfg
           mountPath: /etc/cni/net.d

--- a/pkg/cluster/internal/create/actions/installcni/cni.go
+++ b/pkg/cluster/internal/create/actions/installcni/cni.go
@@ -74,8 +74,10 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		var out bytes.Buffer
 		err = t.Execute(&out, &struct {
 			PodSubnet string
+			Mtu       int32
 		}{
 			PodSubnet: ctx.Config.Networking.PodSubnet,
+			Mtu:       ctx.Config.Networking.Mtu,
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to execute CNI manifest template")

--- a/pkg/cluster/internal/create/actions/installcni/cni.go
+++ b/pkg/cluster/internal/create/actions/installcni/cni.go
@@ -74,7 +74,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		var out bytes.Buffer
 		err = t.Execute(&out, &struct {
 			PodSubnet string
-			Mtu       int32
+			Mtu       string
 		}{
 			PodSubnet: ctx.Config.Networking.PodSubnet,
 			Mtu:       ctx.Config.Networking.Mtu,

--- a/pkg/internal/apis/config/convert_v1alpha4.go
+++ b/pkg/internal/apis/config/convert_v1alpha4.go
@@ -83,6 +83,7 @@ func convertv1alpha4Networking(in *v1alpha4.Networking, out *Networking) {
 	out.KubeProxyMode = ProxyMode(in.KubeProxyMode)
 	out.ServiceSubnet = in.ServiceSubnet
 	out.DisableDefaultCNI = in.DisableDefaultCNI
+	out.MTU = in.MTU
 }
 
 func convertv1alpha4Mount(in *v1alpha4.Mount, out *Mount) {

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -137,7 +137,7 @@ type Networking struct {
 	// KubeProxyMode defines if kube-proxy should operate in iptables or ipvs mode
 	KubeProxyMode ProxyMode
 	//MTU defines the MTU for the CNI of the nodes if the user needs to set them
-	MTU int32
+	MTU string
 }
 
 // ClusterIPFamily defines cluster network IP family

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -136,6 +136,8 @@ type Networking struct {
 	DisableDefaultCNI bool
 	// KubeProxyMode defines if kube-proxy should operate in iptables or ipvs mode
 	KubeProxyMode ProxyMode
+	//MTU defines the MTU for the CNI of the nodes if the user needs to set them
+	MTU int32
 }
 
 // ClusterIPFamily defines cluster network IP family


### PR DESCRIPTION
This is my attempt at solving the problem I was outlining in https://github.com/kubernetes-sigs/kind/issues/1468. I imagine that that the MTU should be configured via the networking object 

```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
networking:
  mtu: 1480
```

I tried following the example of POD_SUBNET outlined in this [comment](https://github.com/kubernetes-sigs/kind/issues/1468#issuecomment-614625988) Where it is passed in as an envvar and templated from there. 

Please let me know how all of this looks and give suggestions 

