### PR TITLE
Have CNI assume mtu from eth0

### DIFF
--- a/images/kindnetd/cmd/kindnetd/main.go
+++ b/images/kindnetd/cmd/kindnetd/main.go
@@ -70,9 +70,15 @@ func main() {
 		))
 	}
 
+	mtu, err := computeBridgeMTU()
+	klog.Infof("setting mtu %d for CNI \n", mtu)
+	if err != nil {
+		klog.Infof("Failed to get MTU size from interface eth0, using kernel default MTU size error:%v", err)
+	}
 	// used to track if the cni config inputs changed and write the config
 	cniConfigWriter := &CNIConfigWriter{
 		path: cniConfigPath,
+		mtu:  mtu,
 	}
 
 	// enforce ip masquerade rules

--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -20,7 +20,7 @@ package nodeimage
 The default CNI manifest and images are our own tiny kindnet
 */
 
-var defaultCNIImages = []string{"kindest/kindnetd:v20200619-15f5b3ab"}
+var defaultCNIImages = []string{"kindest/kindnetd:v20200707-3aec2c7e"}
 
 const defaultCNIManifest = `
 # kindnetd networking manifest
@@ -93,7 +93,7 @@ spec:
       serviceAccountName: kindnet
       containers:
       - name: kindnet-cni
-        image: kindest/kindnetd:v20200619-15f5b3ab
+        image: kindest/kindnetd:v20200707-3aec2c7e
         env:
         - name: HOST_IP
           valueFrom:


### PR DESCRIPTION
As per my conversation with @aojea in the following [issue](https://github.com/kubernetes-sigs/kind/issues/1468#issuecomment-649051368) We figured the best path going forward would be to auto configure the MTU of kindnet from the host's device 

This pull request replaces the one here 
https://github.com/kubernetes-sigs/kind/pull/1686 