### PR TITLE
upgrade to go 1.15beta1

### DIFF
--- a/hack/go_container.sh
+++ b/hack/go_container.sh
@@ -30,7 +30,7 @@ SOURCE_DIR="${SOURCE_DIR:-$(pwd -P)}"
 # default to disabling CGO for easier reproducible builds and cross compilation
 export CGO_ENABLED="${CGO_ENABLED:-0}"
 # the container image, by default a recent official golang image
-GOIMAGE="${GOIMAGE:-golang:1.14.4}"
+GOIMAGE="${GOIMAGE:-golang:1.15beta1}"
 # docker volume name, used as a go module / build cache
 CACHE_VOLUME="${CACHE_VOLUME:-kind-build-cache}"
 # allow overriding docker cli, auto-detect with fallback to docker


### PR DESCRIPTION
go 1.15 has some mitigations for various EINTR
this is only used for the kind binary, but we're getting ahead of k8s
k/k will possibly try to do something similar for 1.19 (adopt 1.15rc1, ship with 1.15)

kindnetd is still built with go1.13, using the multi-stage image build there, and indeed each image has it's own.