### PR TITLE
Added support for cross building s390x kind binary and associated images

### DIFF
--- a/hack/release/build/cross.sh
+++ b/hack/release/build/cross.sh
@@ -49,5 +49,6 @@ export GOOS=darwin GOARCH=amd64
 export GOOS=linux GOARCH=amd64
 export GOOS=linux GOARCH=arm64
 export GOOS=linux GOARCH=ppc64le
+export GOOS=linux GOARCH=s390x
 EOF
 )

--- a/images/Makefile.common.in
+++ b/images/Makefile.common.in
@@ -13,7 +13,7 @@ IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # build with buildx
-PLATFORMS?=linux/amd64,linux/arm64,linux/ppc64le
+PLATFORMS?=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 OUTPUT=
 PROGRESS=auto
 build: ensure-buildx


### PR DESCRIPTION
Added support for cross building s390x kind binary and associated images namely base, kindnetd and haproxy. 