### PR TITLE
use new portmap plugin

### DIFF
--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,7 +20,7 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20200709-8b878ace"
+const DefaultBaseImage = "aojea/kindbase:portmap"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
the portmap plugin is buggy on deletion, it just blindly tries to
delete everything once it gets a DEL, no matter the IP family.

Added to the problem caused because it is being executed with the
-w option without any timeout (see go-iptables), it may hold the
lock or cause contention, making all services in the cluster to
fail.

Use the new portmap version
https://github.com/containernetworking/plugins/pull/509