### PR TITLE
Support Rootless Docker

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -70,6 +70,7 @@ RUN echo "Ensuring scripts are executable ..." \
       libseccomp2 pigz \
       bash ca-certificates curl rsync \
       nfs-common \
+      jq \
     && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-tmpfiles-setup.service" -delete \
     && rm -f /lib/systemd/system/multi-user.target.wants/* \
     && rm -f /etc/systemd/system/*.wants/* \

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -38,7 +38,11 @@ fix_mount() {
   # https://systemd.io/CONTAINER_INTERFACE/
   # however, we need other things from `docker run --privileged` ...
   # and this flag also happens to make /sys rw, amongst other things
+  #
+  # EACCES on rootless is negligible.
+  set +o errexit
   mount -o remount,ro /sys
+  set -o errexit
 
   echo 'INFO: making mounts shared' >&2
   # for mount propagation

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -236,6 +236,13 @@ enable_network_magic(){
   fi
 }
 
+select_containerd_config_toml() {
+  if ! egrep -q "0[[:space:]]+0[[:space:]]+4294967295" /proc/1/uid_map; then
+    echo "INFO: Detected rootless provider. Overriding /etc/containerd/config.toml with /etc/containerd/config-rootless.toml" >&2
+    cp -f /etc/containerd/config-rootless.toml /etc/containerd/config.toml
+  fi
+}
+
 # run pre-init fixups
 fix_kmsg
 fix_mount
@@ -246,6 +253,7 @@ fix_product_uuid
 configure_proxy
 select_iptables
 enable_network_magic
+select_containerd_config_toml
 
 # we want the command (expected to be systemd) to be PID1, so exec to it
 exec "$@"

--- a/images/base/files/usr/local/bin/ociwrapper
+++ b/images/base/files/usr/local/bin/ociwrapper
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# A wrapper script to remove .linux.resources.devices, which are meaningless in userns.
+# Needs jq.
+#
+# Workaround until we get proper fixes in containerd and runc
+set -eu -o pipefail
+RUNTIME="runc"
+
+if egrep -q "0[[:space:]]+0[[:space:]]+4294967295" /proc/self/uid_map; then
+	# we are not in userns, no need to patch the config
+	exec $RUNTIME "$@"
+	exit $?
+fi
+
+bundle="."
+bundle_flag=""
+# FIXME: support `--bundle=STRING` as well
+for f in $@; do
+	if [[ -n $bundle_flag ]]; then
+		bundle=$f
+		break
+	else
+		case $f in
+		-b | --bundle)
+			bundle_flag=$f
+			;;
+		esac
+	fi
+done
+
+if [ -f $bundle/config.json ]; then
+    q="del(.linux.resources.devices) | del(.linux.devices)"
+	tmp=$(mktemp -d ociwrapper.XXXXXXXX)
+	jq "$q" <$bundle/config.json >$tmp/config.json
+	mv $tmp/config.json $bundle/config.json
+	rm -rf $tmp
+fi
+
+exec $RUNTIME "$@"

--- a/pkg/build/nodeimage/build_impl.go
+++ b/pkg/build/nodeimage/build_impl.go
@@ -187,13 +187,26 @@ func (c *buildContext) buildImage(dir string) error {
 		return errors.New("failed to find imported pause image")
 	}
 	containerdConfig, err := getContainerdConfig(containerdConfigTemplateData{
-		SandboxImage: pauseImage,
+		SandboxImage:       pauseImage,
+		DefaultRuntimeName: "runc",
 	})
 	if err != nil {
 		return err
 	}
 	const containerdConfigPath = "/etc/containerd/config.toml"
 	if err := createFile(cmder, containerdConfigPath, containerdConfig); err != nil {
+		return err
+	}
+	containerdRootlessConfig, err := getContainerdConfig(containerdConfigTemplateData{
+		SandboxImage:        pauseImage,
+		DefaultRuntimeName:  "ociwrapper",
+		RestrictOOMScoreAdj: true,
+	})
+	if err != nil {
+		return err
+	}
+	const containerdRootlessConfigPath = "/etc/containerd/config-rootless.toml"
+	if err := createFile(cmder, containerdRootlessConfigPath, containerdRootlessConfig); err != nil {
 		return err
 	}
 

--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -60,10 +60,8 @@ func (p *Provider) Provision(status *cli.Status, cfg *config.Cluster) (err error
 		return err
 	}
 
-	// kind doesn't work with podman rootless, surface an error
 	if os.Geteuid() != 0 {
-		p.logger.Errorf("podman provider does not work properly in rootless mode")
-		os.Exit(1)
+		p.logger.Warn("support for rootless mode is experimental, some features may not work")
 	}
 
 	// TODO: validate cfg


### PR DESCRIPTION
This PR adds support for running kind with Rootless Docker provider.
Requires cgroup v2 hosts.

## Commits in this PR

### 1. "podman: unlock rootless"
Turn off `"podman provider does not work properly in rootless mode"` error and print a warning message instead.
However, Podman provider still doesn't work . (see the bottom of this PR)

### 2. "base: ignore EACCES from `mount -o remount,ro /sys`"
`mount -o remount,ro /sys` fails with `permission denied` on rootless Docker and on rootless Podman, but the error is negligible.
### 3. "containerd: add /etc/containerd/config-rootless.toml"
`/etc/containerd/config-rootless.toml` is the config for running kind in rootless Docker/Podman.

 * `ociwrapper` script is used to remove `.linux.resources.devices` from `config.json`,  because `.linux.resources.devices` is meaningless on rootless and yet produces errors. Workaround until we get proper fixes in containerd and runc.
 * `restrict_oom_score_adj` is set to true to ignore oom_score_adj errors

The entrypoint overrides `/etc/containerd/config.toml` with `config-rootless.toml` when running in rootless Docker/Podman.
The rootless-ness is detected by comparing `/proc/1/uid_map` with `0 0 4294967295`.

## How to test
### Images
#### Base

```console
$ docker build -t kind-base ./images/base
```

Available on Docker Hub as `	akihirosuda/tmp-kind-base:g554d2e07`.
Built from https://github.com/AkihiroSuda/kind/commits/554d2e076b1ea0fb55fcdff5cf8d972933bb78df .


#### Node

Needs PR https://github.com/kubernetes/kubernetes/pull/93012 and PR https://github.com/kubernetes/kubernetes/pull/92863. 
The `kubelet: new feature gate: Rootless` commit is not necessary for `kind`, because Rootless Docker itself sets up cgroup fs.

```console
$ kind build node-image --base-image kind-base
```

Available on Docker Hub as `akihirosuda/tmp-kind-node:g554d2e07-g3c1dda52`
Built from https://github.com/AkihiroSuda/kind/commits/554d2e076b1ea0fb55fcdff5cf8d972933bb78df  +  https://github.com/AkihiroSuda/kubernetes/commits/3c1dda52bb3a931acb4810e34fbfa1afee949ec5


> **NOTE**
> 
> Rootful Docker is still required for `kind build node-image`.

### Rootless Docker

* Boot Ubuntu 20.04 host with `systemd.unified_cgroup_hierarchy=1`
* Install Moby from its master branch (Docker 20.0X). Binaries are available at https://github.com/AkihiroSuda/moby-snapshot
* Run `dockerd-rootless.sh`
* `export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock`, and make sure `docker info` shows "rootless" as a security option.
* Run `kind create cluster --image akihirosuda/tmp-kind-node:g554d2e07-g3c1dda52`
* Run `ps auxw` on the hosts, and make sure the kind processes are running as unprivileged users
* Make sure `kubectl get pods -A` shows all pods as `Running`

```console
$ export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock

$ docker info
...
Cgroup Driver: systemd
 Cgroup Version: 2
...
 Security Options:
  seccomp
   Profile: default
  rootless
  cgroupns
...

$ kind create cluster --image akihirosuda/tmp-kind-node:g554d2e07-g3c1dda52
Creating cluster "kind" ...
 ✓ Ensuring node image (akihirosuda/tmp-kind-node:g554d2e07-g3c1dda52) 🖼 
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Set kubectl context to "kind-kind"
You can now use your cluster with:     
                                                  
kubectl cluster-info --context kind-kind
                                                  
Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/

$ kubectl get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
kube-system          coredns-f9fd979d6-r2ts9                      1/1     Running   0          5m23s
kube-system          coredns-f9fd979d6-t8nnc                      1/1     Running   0          5m23s
kube-system          etcd-kind-control-plane                      1/1     Running   0          5m28s
kube-system          kindnet-pxnxs                                1/1     Running   0          5m23s
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          5m28s
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          5m28s
kube-system          kube-proxy-v9txg                             1/1     Running   0          5m23s
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          5m28s
local-path-storage   local-path-provisioner-7994557747-ggnt4      1/1     Running   0          5m23s
```

### Rootless Podman (doesn't work yet)
* Boot Ubuntu 20.04 host with `systemd.unified_cgroup_hierarchy=1`
* Install Podman from its master branch (Podman 2.X.X), with https://github.com/containers/podman/pull/6949
* Run `KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster --image akihirosuda/tmp-kind-node:g554d2e07-g3c1dda52`
* Still doesn't work :(
```console
$ KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster --image akihirosuda/tmp-kind-node:g554d2e07-g3c1dda52
using podman due to KIND_EXPERIMENTAL_PROVIDER
enabling experimental podman provider
Creating cluster "kind" ...
support for rootless mode is experimental, some features may not work
 ✓ Ensuring node image (akihirosuda/tmp-kind-node:g554d2e07-g3c1dda52) 🖼 
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✗ Starting control-plane 🕹️ 
ERROR: failed to create cluster: failed to init node with kubeadm: command "podman exec --privileged kind-control-plane kubeadm init --ignore-preflight-errors=all --config=/kind/kubeadm.conf --skip-token-print --v=6" failed with error: exit status 1
Command Output: I0713 12:29:24.380961      49 initconfiguration.go:200] loading configuration from "/kind/kubeadm.conf"
[config] WARNING: Ignored YAML document with GroupVersionKind kubeadm.k8s.io/v1beta2, Kind=JoinConfiguration
I0713 12:29:24.391266      49 interface.go:400] Looking for default routes with IPv4 addresses
I0713 12:29:24.391279      49 interface.go:405] Default route transits interface "tap0"
I0713 12:29:24.391411      49 interface.go:208] Interface tap0 is up
I0713 12:29:24.391987      49 interface.go:256] Interface "tap0" has 2 addresses :[10.0.2.100/24 fe80::d07b:4cff:fe69:ba48/64].
I0713 12:29:24.392058      49 interface.go:223] Checking addr  10.0.2.100/24.
I0713 12:29:24.392063      49 interface.go:230] IP found 10.0.2.100
I0713 12:29:24.392068      49 interface.go:262] Found valid IPv4 address 10.0.2.100 for interface "tap0".
I0713 12:29:24.392071      49 interface.go:411] Found active IP 10.0.2.100 
hostport :6443: host '' must be a valid IP address or a valid RFC-1123 DNS subdomain
k8s.io/kubernetes/cmd/kubeadm/app/util.ParseHostPort
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/util/endpoint.go:113
k8s.io/kubernetes/cmd/kubeadm/app/util/config.SetClusterDynamicDefaults
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/util/config/initconfiguration.go:157
k8s.io/kubernetes/cmd/kubeadm/app/util/config.SetInitDynamicDefaults
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/util/config/initconfiguration.go:56
k8s.io/kubernetes/cmd/kubeadm/app/util/config.documentMapToInitConfiguration
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/util/config/initconfiguration.go:305
k8s.io/kubernetes/cmd/kubeadm/app/util/config.BytesToInitConfiguration
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/util/config/initconfiguration.go:235
k8s.io/kubernetes/cmd/kubeadm/app/util/config.LoadInitConfigurationFromFile
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/util/config/initconfiguration.go:207
k8s.io/kubernetes/cmd/kubeadm/app/util/config.LoadOrDefaultInitConfiguration
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/util/config/initconfiguration.go:219
k8s.io/kubernetes/cmd/kubeadm/app/cmd.newInitData
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/cmd/init.go:333
k8s.io/kubernetes/cmd/kubeadm/app/cmd.NewCmdInit.func3
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/cmd/init.go:193
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).InitData
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow/runner.go:183
k8s.io/kubernetes/cmd/kubeadm/app/cmd.NewCmdInit.func1
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/cmd/init.go:141
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).execute
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:842
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).ExecuteC
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:950
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).Execute
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:887
k8s.io/kubernetes/cmd/kubeadm/app.Run
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/kubeadm.go:50
main.main
        _output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/kubeadm.go:25
runtime.main
        /usr/local/go/src/runtime/proc.go:203
runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1373
Error: exec session exited with non-zero exit code 1: OCI runtime error
```
