### PR TITLE
base image update: fix pormap plugin

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -25,7 +25,7 @@ FROM ubuntu:20.04
 # The repository contains latest stable releases and nightlies built for multiple architectures
 ARG CONTAINERD_VERSION="v1.4.0-beta.1-85-g334f567e"
 # Configure CNI binaries from upstream
-ARG CNI_VERSION="v0.8.6"
+ARG CNI_VERSION="v0.8.6-13-g877602d"
 # Configure crictl binary from upstream
 ARG CRICTL_VERSION="v1.18.0"
 
@@ -96,7 +96,7 @@ RUN echo "Ensuring scripts are executable ..." \
  && echo "Installing CNI binaries ..." \
     && export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') \
     && export CNI_TARBALL="${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz" \
-    && export CNI_URL="https://github.com/containernetworking/plugins/releases/download/${CNI_TARBALL}" \
+    && export CNI_URL="https://github.com/aojea/plugins/releases/download/${CNI_TARBALL}" \
     && curl -sSL --retry 5 --output /tmp/cni.tgz "${CNI_URL}" \
     && mkdir -p /opt/cni/bin \
     && tar -C /opt/cni/bin -xzf /tmp/cni.tgz \

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,7 +20,7 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20200709-8b878ace"
+const DefaultBaseImage = "kindest/base:v20200713-95e25d21"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
meanwhile the patch is not accepted and released in the CNI project,
we use the one with the fix hosted in our fork and released with
the same scripts used by the project, keeping the multi arch
support.

https://github.com/aojea/plugins/releases/tag/v0.8.6-13-g877602d
