### PR TITLE
Fix issue with Podman deleting volumes

### DIFF
--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -146,11 +146,11 @@ func (p *Provider) DeleteNodes(n []nodes.Node) error {
 	}
 	var nodeVolumes []string
 	for _, node := range n {
-		volume, err := getVolume(node.String())
+		volumes, err := getVolumes(node.String())
 		if err != nil {
 			return err
 		}
-		nodeVolumes = append(nodeVolumes, volume)
+		nodeVolumes = append(nodeVolumes, volumes...)
 	}
 	return deleteVolumes(nodeVolumes)
 }

--- a/pkg/cluster/internal/providers/podman/util.go
+++ b/pkg/cluster/internal/providers/podman/util.go
@@ -87,18 +87,22 @@ func createAnonymousVolume(label string) (string, error) {
 	return strings.TrimSuffix(string(name), "\n"), nil
 }
 
-// getVolume gets the volume name filtered on specified label
-func getVolume(label string) (string, error) {
+// getVolumes gets volume names filtered on specified label
+func getVolumes(label string) ([]string, error) {
 	cmd := exec.Command("podman",
 		"volume",
 		"ls",
 		"--filter", fmt.Sprintf("label=%s", label),
 		"--quiet")
-	name, err := exec.Output(cmd)
+	// `output` from the above command is names of all volumes each followed by `\n`.
+	output, err := exec.Output(cmd)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return strings.TrimSuffix(string(name), "\n"), nil
+	// Trim away the last `\n`.
+	trimmedOutput := strings.TrimSuffix(string(output), "\n")
+	// Get names of all volumes by splitting via `\n`.
+	return strings.Split(string(trimmedOutput), "\n"), nil
 }
 
 func deleteVolumes(names []string) error {


### PR DESCRIPTION
Fix the issue with Podman failing to delete cluster as it failed to correctly delete all anonymous volumes.

# Old behavior
``` $ sudo ./kind delete cluster -v 1000000
enabling experimental podman provider
Deleting cluster "kind" ...
ERROR: failed to delete cluster "kind": command "podman volume rm --force '000fcd56f075c129d8c0fbfb6190923cafd20a65ed1bdbb9f27777e99bc25129
022fe51cd05427cd741a0355d0cbfdee230f8a314fa2fbcccc0c57b2e66cb7c4
10597316f16a8fb4227da9d6ccbd986074937e0ec3be2f088cc53419c1070d73
1933e143a1ca617b4002a3d55647a6eb3a11d7eb725887ee62ad363b0fc61be8
20e2090dc98ba9f278049d58b985d63bb7ffad7a5bf1b16b7cf14d5434055e25
2fa3d617bac948e7c3703e600a87a1e10b6543ca7530d4b1bd2434dc47dda2f9
2fbee920787e978c391756150a5b0b5725b5d4739c2bf717326203ddac545170
3b757825f62a14aae723a61d94d5d9ed3fb24d61a0418935efa7bc3b69810c81
56c369d51bc61bac4aecfa9023f39dc03882152c5b4f62f9f6bd67d1a489139f
643b0a80296d1e8d4d03db48961d135eca0ea67f358f5ae3579c9a3fd2252c72
6eb42729f37ae9ace9bc63af94be298dbcf562ba9d637f19e096e675c5e16a75
7d0826c99eb0fa7eff86bf60a2d674b11d985c95e9a5889423356712c264f569
82e607be9e77f7c843d27d6dc45e77bd3ae430de0395e9212d1cead335aca231
86ae7ed35e2f1fb168e9e44f97f9f1abfcc15875ee07beb3d845f3fcb65702ef
935f5df8fa29b9090cb4c29461e125ccbbe7303767598277e9bf9dc9f194a426
99b8b2e78642aa44403efd2d86c44d4eb12d1c9996584af01d01b4220ef72c4b
aa6f601dd8410240dc0a777617511c499f3477069bb89ae3a72635f6490cfa8b
ae13c601621fe905dabe75b460857f4e503adf420744b083401cd995fae78fe7
ae30d747734b266bec0302539b332232bd8d33a415d12dfbe713747ed20162c4
b6342d3f1d966d9a7d4b639c5ad28f3ffd21cde57a4a4d507602bd9eab837d60
bb315dc5155b3ba982262ff8e29530ebeb1f5c2e4ccc2816bb7639858214ea23
c29b7922af5741f0074d637e2cd3ff8dc94ebe2236ef38e61370d9307b6406cd
c6f8b0badfe8db1b6ac69915a54529db00ea3ee2a28a37dee64f69a317c28fd4
c99e5d110e93dfeb4938b7c5b66e554fb4ebf7992d9c8c74ddc24813d665a232
cef64eedb8efa7182cda8e9f960e0e133be53f9190aa9f5f440d85e5e8d7f030
cf040d8d4cb01700058eeb6251ca7c0c9002609706517bc6051edc66d734f74f
d26d72627d7b727b8fc5ba340030d47fbf422837dcffd86459c3705a4dbf1397
d689002597cc350add32091800de243b5a375260e591d13bda6a95f344de3c25
d8d7cb084e4dd93e69a1859ed86852083d8069fc6d2678bbd3d943c9b4907274
e5efb23fa86428628cb37ec68fe589255ccc2d0c432304106526139115c8c6c8'" failed with error: exit status 125
Command Output: Error: no volume with name "000fcd56f075c129d8c0fbfb6190923cafd20a65ed1bdbb9f27777e99bc25129\n022fe51cd05427cd741a0355d0cbfdee230f8a314fa2fbcccc0c57b2e66cb7c4\n10597316f16a8fb4227da9d6ccbd986074937e0ec3be2f088cc53419c1070d73\n1933e143a1ca617b4002a3d55647a6eb3a11d7eb725887ee62ad363b0fc61be8\n20e2090dc98ba9f278049d58b985d63bb7ffad7a5bf1b16b7cf14d5434055e25\n2fa3d617bac948e7c3703e600a87a1e10b6543ca7530d4b1bd2434dc47dda2f9\n2fbee920787e978c391756150a5b0b5725b5d4739c2bf717326203ddac545170\n3b757825f62a14aae723a61d94d5d9ed3fb24d61a0418935efa7bc3b69810c81\n56c369d51bc61bac4aecfa9023f39dc03882152c5b4f62f9f6bd67d1a489139f\n643b0a80296d1e8d4d03db48961d135eca0ea67f358f5ae3579c9a3fd2252c72\n6eb42729f37ae9ace9bc63af94be298dbcf562ba9d637f19e096e675c5e16a75\n7d0826c99eb0fa7eff86bf60a2d674b11d985c95e9a5889423356712c264f569\n82e607be9e77f7c843d27d6dc45e77bd3ae430de0395e9212d1cead335aca231\n86ae7ed35e2f1fb168e9e44f97f9f1abfcc15875ee07beb3d845f3fcb65702ef\n935f5df8fa29b9090cb4c29461e125ccbbe7303767598277e9bf9dc9f194a426\n99b8b2e78642aa44403efd2d86c44d4eb12d1c9996584af01d01b4220ef72c4b\naa6f601dd8410240dc0a777617511c499f3477069bb89ae3a72635f6490cfa8b\nae13c601621fe905dabe75b460857f4e503adf420744b083401cd995fae78fe7\nae30d747734b266bec0302539b332232bd8d33a415d12dfbe713747ed20162c4\nb6342d3f1d966d9a7d4b639c5ad28f3ffd21cde57a4a4d507602bd9eab837d60\nbb315dc5155b3ba982262ff8e29530ebeb1f5c2e4ccc2816bb7639858214ea23\nc29b7922af5741f0074d637e2cd3ff8dc94ebe2236ef38e61370d9307b6406cd\nc6f8b0badfe8db1b6ac69915a54529db00ea3ee2a28a37dee64f69a317c28fd4\nc99e5d110e93dfeb4938b7c5b66e554fb4ebf7992d9c8c74ddc24813d665a232\ncef64eedb8efa7182cda8e9f960e0e133be53f9190aa9f5f440d85e5e8d7f030\ncf040d8d4cb01700058eeb6251ca7c0c9002609706517bc6051edc66d734f74f\nd26d72627d7b727b8fc5ba340030d47fbf422837dcffd86459c3705a4dbf1397\nd689002597cc350add32091800de243b5a375260e591d13bda6a95f344de3c25\nd8d7cb084e4dd93e69a1859ed86852083d8069fc6d2678bbd3d943c9b4907274\ne5efb23fa86428628cb37ec68fe589255ccc2d0c432304106526139115c8c6c8" found: no such volume
Stack Trace:
sigs.k8s.io/kind/pkg/errors.WithStack
	/src/pkg/errors/errors.go:51
sigs.k8s.io/kind/pkg/exec.(*LocalCmd).Run
	/src/pkg/exec/local.go:124
sigs.k8s.io/kind/pkg/cluster/internal/providers/podman.deleteVolumes
	/src/pkg/cluster/internal/providers/podman/util.go:112
sigs.k8s.io/kind/pkg/cluster/internal/providers/podman.(*Provider).DeleteNodes
	/src/pkg/cluster/internal/providers/podman/provider.go:155
sigs.k8s.io/kind/pkg/cluster/internal/delete.Cluster
	/src/pkg/cluster/internal/delete/delete.go:41
sigs.k8s.io/kind/pkg/cluster.(*Provider).Delete
	/src/pkg/cluster/provider.go:148
sigs.k8s.io/kind/pkg/cmd/kind/delete/cluster.deleteCluster
	/src/pkg/cmd/kind/delete/cluster/deletecluster.go:63
sigs.k8s.io/kind/pkg/cmd/kind/delete/cluster.NewCommand.func1
	/src/pkg/cmd/kind/delete/cluster/deletecluster.go:48
github.com/spf13/cobra.(*Command).execute
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:842
github.com/spf13/cobra.(*Command).ExecuteC
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950
github.com/spf13/cobra.(*Command).Execute
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
sigs.k8s.io/kind/cmd/kind/app.Run
	/src/cmd/kind/app/main.go:53
sigs.k8s.io/kind/cmd/kind/app.Main
	/src/cmd/kind/app/main.go:35
main.main
	/src/main.go:25
runtime.main
	/usr/local/go/src/runtime/proc.go:204
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1374```

# Root cause
In `pkg/cluster/internal/providers/podman/util.go`, function `getVolume` calls Podman to get volume for the Kind cluster.

However, it took the output from Podman as is, before the result was passed to `DeleteNodes` in `pkg/cluster/internal/providers/podman/provider.go`, and eventually ended up in `deleteVolumes`.

`deleteVolumes` will pass the raw output from `getVolume` to Podman and got back  return code`125` since Podman cannot understand the input format with all volume names followed by `\n`.

# Fix
Rewrite the function `getVolume` in `pkg/cluster/internal/providers/podman/util.go` to split the raw output by `\n` to return all volume names associated with the `label` passed in as parameter.

