### PR TITLE
Podman load docker images

### DIFF
--- a/pkg/cluster/internal/providers/docker/provider.go
+++ b/pkg/cluster/internal/providers/docker/provider.go
@@ -253,3 +253,24 @@ func (p *Provider) CollectLogs(dir string, nodes []nodes.Node) error {
 	errs = append(errs, errors.AggregateConcurrent(fns))
 	return errors.NewAggregate(errs)
 }
+
+// SaveImage saves image to dest, as in `docker save`
+func (p *Provider) SaveImage(image, dest string) error {
+	return exec.Command("docker", "save", "-o", dest, image).Run()
+}
+
+// ImageID return the Id of the container image
+func (p *Provider) ImageID(containerNameOrID string) (string, error) {
+	cmd := exec.Command("docker", "image", "inspect",
+		"-f", "{{ .Id }}",
+		containerNameOrID, // ... against the container
+	)
+	lines, err := exec.CombinedOutputLines(cmd)
+	if err != nil {
+		return "", err
+	}
+	if len(lines) != 1 {
+		return "", errors.Errorf("Docker image ID should only be one line, got %d lines", len(lines))
+	}
+	return lines[0], nil
+}

--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -306,3 +306,24 @@ func (p *Provider) CollectLogs(dir string, nodes []nodes.Node) error {
 	errs = append(errs, errors.AggregateConcurrent(fns))
 	return errors.NewAggregate(errs)
 }
+
+// SaveImage saves image to dest, as in `docker save`
+func (p *Provider) SaveImage(image, dest string) error {
+	return exec.Command("podman", "save", "-o", dest, image).Run()
+}
+
+// ImageID return the Id of the container image
+func (p *Provider) ImageID(containerNameOrID string) (string, error) {
+	cmd := exec.Command("podman", "image", "inspect",
+		"-f", "{{.Id}}",
+		containerNameOrID, // ... against the container
+	)
+	lines, err := exec.CombinedOutputLines(cmd)
+	if err != nil {
+		return "", err
+	}
+	if len(lines) != 1 {
+		return "", errors.Errorf("Docker image ID should only be one line, got %d lines", len(lines))
+	}
+	return lines[0], nil
+}

--- a/pkg/cluster/internal/providers/provider/provider.go
+++ b/pkg/cluster/internal/providers/provider/provider.go
@@ -45,4 +45,8 @@ type Provider interface {
 	GetAPIServerInternalEndpoint(cluster string) (string, error)
 	// CollectLogs will populate dir with cluster logs and other debug files
 	CollectLogs(dir string, nodes []nodes.Node) error
+	// SaveImage saves image to dest, as in `docker save`
+	SaveImage(image, dest string) error
+	// ImageID return the Id of the container image
+	ImageID(containerNameOrID string) (string, error)
 }

--- a/pkg/cluster/provider.go
+++ b/pkg/cluster/provider.go
@@ -193,3 +193,13 @@ func (p *Provider) CollectLogs(name, dir string) error {
 	}
 	return p.provider.CollectLogs(dir, n)
 }
+
+// SaveImage saves image to dest, as in `docker save`
+func (p *Provider) SaveImage(image, dest string) error {
+	return p.provider.SaveImage(image, dest)
+}
+
+// ImageID return the Id of the container image
+func (p *Provider) ImageID(containerNameOrID string) (string, error) {
+	return p.provider.ImageID(containerNameOrID)
+}

--- a/pkg/cmd/kind/load/docker-image/docker-image.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
 	"sigs.k8s.io/kind/pkg/cmd"
 	"sigs.k8s.io/kind/pkg/errors"
-	"sigs.k8s.io/kind/pkg/exec"
 	"sigs.k8s.io/kind/pkg/fs"
 	"sigs.k8s.io/kind/pkg/log"
 
@@ -83,7 +82,7 @@ func runE(logger log.Logger, flags *flagpole, args []string) error {
 
 	// Check that the image exists locally and gets its ID, if not return error
 	imageName := args[0]
-	imageID, err := imageID(imageName)
+	imageID, err := provider.ImageID(imageName)
 	if err != nil {
 		return fmt.Errorf("image: %q not present locally", imageName)
 	}
@@ -141,7 +140,7 @@ func runE(logger log.Logger, flags *flagpole, args []string) error {
 	defer os.RemoveAll(dir)
 	imageTarPath := filepath.Join(dir, "image.tar")
 
-	err = save(imageName, imageTarPath)
+	err = provider.SaveImage(imageName, imageTarPath)
 	if err != nil {
 		return err
 	}
@@ -167,25 +166,4 @@ func loadImage(imageTarName string, node nodes.Node) error {
 	}
 	defer f.Close()
 	return nodeutils.LoadImageArchive(node, f)
-}
-
-// save saves image to dest, as in `docker save`
-func save(image, dest string) error {
-	return exec.Command("docker", "save", "-o", dest, image).Run()
-}
-
-// imageID return the Id of the container image
-func imageID(containerNameOrID string) (string, error) {
-	cmd := exec.Command("docker", "image", "inspect",
-		"-f", "{{ .Id }}",
-		containerNameOrID, // ... against the container
-	)
-	lines, err := exec.CombinedOutputLines(cmd)
-	if err != nil {
-		return "", err
-	}
-	if len(lines) != 1 {
-		return "", errors.Errorf("Docker image ID should only be one line, got %d lines", len(lines))
-	}
-	return lines[0], nil
 }


### PR DESCRIPTION
    podman: save and load images
    
    the kind load docker-image was not working in podman because it
    was using docker commands directly.
    
    This moves the helper functions used by the kind command to methods
    in the Provider interface, so it works both for podman and docker.