### PR TITLE
increase etcd backend quota to match GCE / kube-up

### DIFF
--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -140,6 +140,14 @@ scheduler:
 networking:
   podSubnet: "{{ .PodSubnet }}"
   serviceSubnet: "{{ .ServiceSubnet }}"
+etcd:
+  # TODO: external etcd / HA ..?
+  local:
+    extraArgs:
+      # this matches GCE
+      # https://github.com/kubernetes/kubernetes/commit/ca99cbca02542ae63e72f5be84d23078e7422f85
+      # https://github.com/kubernetes/kubernetes/issues/94029
+      "quota-backend-bytes": "4294967296"
 ---
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: InitConfiguration
@@ -257,6 +265,14 @@ scheduler:
 networking:
   podSubnet: "{{ .PodSubnet }}"
   serviceSubnet: "{{ .ServiceSubnet }}"
+etcd:
+  # TODO: external etcd / HA ..?
+  local:
+    extraArgs:
+      # this matches GCE
+      # https://github.com/kubernetes/kubernetes/commit/ca99cbca02542ae63e72f5be84d23078e7422f85
+      # https://github.com/kubernetes/kubernetes/issues/94029
+      "quota-backend-bytes": "4294967296"
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/issues/94029

TODO:
- should this be bumped in kubeadm upstream in future versions?
- should we change the healthcheck behavior?
- can we reduce the storage usage, should we adjust the compaction behavior?