### PR TITLE
Containerd release 1.4

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -23,7 +23,7 @@ FROM ubuntu:20.10
 
 # Configure containerd and runc binaries from kind-ci/containerd-nightlies repository
 # The repository contains latest stable releases and nightlies built for multiple architectures
-ARG CONTAINERD_VERSION="v1.4.0-rc.1-4-g43366250"
+ARG CONTAINERD_VERSION="v1.4.0"
 # Configure CNI binaries
 # TODO: switch back to upstream binaries at next release
 ARG CNI_VERSION="v0.8.6-14-g6eb8e31"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,7 +20,7 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20200814-d13ba9f7"
+const DefaultBaseImage = "kindest/base:v20200817-222e7545"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
1.4.x had various useful changes so we've been shipping unreleased commits

this switches us to 1.4 release.
was blocked on https://github.com/kind-ci/containerd-nightlies/commit/fe5c346dbff16dcd34be4c1d075aad142b8d792b, done now