### PR TITLE
use /16 service subnet by default

### DIFF
--- a/pkg/apis/config/v1alpha4/default.go
+++ b/pkg/apis/config/v1alpha4/default.go
@@ -54,11 +54,12 @@ func SetDefaultsCluster(obj *Cluster) {
 			obj.Networking.PodSubnet = "fd00:10:244::/64"
 		}
 	}
-	// default the service CIDR using the kubeadm default
+	// default the service CIDR using a different subnet than kubeadm default
 	// https://github.com/kubernetes/kubernetes/blob/746404f82a28e55e0b76ffa7e40306fb88eb3317/cmd/kubeadm/app/apis/kubeadm/v1beta2/defaults.go#L32
-	// Note: kubeadm is doing it already but this simplifies kind's logic
+	// Note: kubeadm is using a /12 subnet, that may allocate a 2^20 bitmap in etcd
+	// we allocate a /16 subnet that allows 65535 services (current Kubernetes tested limit is O(10k) services)
 	if obj.Networking.ServiceSubnet == "" {
-		obj.Networking.ServiceSubnet = "10.96.0.0/12"
+		obj.Networking.ServiceSubnet = "10.96.0.0/16"
 		if obj.Networking.IPFamily == "ipv6" {
 			obj.Networking.ServiceSubnet = "fd00:10:96::/112"
 		}


### PR DESCRIPTION
the service subnet uses a bitmap stored in etcd. Using a /12 subnet
imply that this bitmap can use 2^20 bits, something unnecessary
since Kubernetes is not validating more than 10K services.
A /16 subnet allows 65536 services, more than enough, and
from the networking perspective is more correct, because it belong
to the Class B subnet and allows a better subnet planning.

xref: https://github.com/kubernetes/kubernetes/issues/94029#issuecomment-675362298