### PR TITLE
replaced user-guide link with quick-start-guide

### DIFF
--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -6,16 +6,22 @@ TODO(bentheelder): this page should probably be removed now that we have navigat
 
 ## Usage
 
-If you want to get started with kind, checkout our [quick start guide][quick start guide].
-Here you will find all details to get you started along with some more advanced use cases.
+If you want to get started with kind, checkout our 
+[quick start guide][quick start guide].
+Here you will find all details to get you started along with some more advanced 
+use cases.
 
 ## Contributing
 
-If you are interested in modifying or contributing to kind, you can go and checkout our [design docs][design] where we explain how things are implemented.
+If you are interested in modifying or contributing to kind, you can go and 
+checkout our [design docs][design] where we explain how things are implemented.
 
-For those interested in contributing to the project with code or documentation, the [development guide][dev guide] will give you a more in-depth look into how kind works.
+For those interested in contributing to the project with code or documentation, 
+the [development guide][dev guide] will give you a more in-depth look into how 
+kind works.
 
-We will start by getting the required software and setting up the environment and then take a look into how kind and its different packages are laid out.
+We will start by getting the required software and setting up the environment 
+and then take a look into how kind and its different packages are laid out.
 
 You man also be interested in the [roadmap].
 

--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -4,25 +4,22 @@ TODO(bentheelder): this page should probably be removed now that we have navigat
 
 # Welcome to kind's Documentation
 
-
 ## Usage
-If you want to get started with kind, checkout our [user guide][user guide].
-Here you will find all details to get you started along with some more advanced
-use cases.
+
+If you want to get started with kind, checkout our [quick start guide][quick start guide].
+Here you will find all details to get you started along with some more advanced use cases.
 
 ## Contributing
-If you are interested in modifying or contributing to kind, you can go and 
-checkout our [design docs][design] where we explain how things are implemented.
 
-For those interested in contributing to the project with code or documentation,
-the [development guide][dev guide] will give you a more in-depth look into how 
-kind works. 
-We will start by getting the required software and setting up the environment
-and then take a look into how kind and its different packages are laid out.
+If you are interested in modifying or contributing to kind, you can go and checkout our [design docs][design] where we explain how things are implemented.
+
+For those interested in contributing to the project with code or documentation, the [development guide][dev guide] will give you a more in-depth look into how kind works.
+
+We will start by getting the required software and setting up the environment and then take a look into how kind and its different packages are laid out.
 
 You man also be interested in the [roadmap].
 
 [roadmap]: ./roadmap
 [design]: ./design/initial
-[user guide]: ./user/
+[quick start guide]: ./user/quick-start/
 [dev guide]: ./devel/


### PR DESCRIPTION
Just fixing a broken link on the index page. I also cleaned up some of the markdown. If there's a specific markdown style guide you're following, let me know and I can adjust it.

Cheers,
Peter