### PR TITLE
Include notice for Fedora32 and Docker users

### DIFF
--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -298,6 +298,10 @@ systemctl restart firewalld
 
 See [#1547 (comment)](https://github.com/kubernetes-sigs/kind/issues/1547#issuecomment-623756313)
 
+## Fedora32 and Docker
+
+The situation with Docker on Fedora is not ideal. See Fedora Magazine article ["Fedora and Docker"](https://fedoramagazine.org/docker-and-fedora-32/) for information regarding workarounds for cgroups, firewalld, and installing docker.
+
 [issue tracker]: https://github.com/kubernetes-sigs/kind/issues
 [file an issue]: https://github.com/kubernetes-sigs/kind/issues/new
 [#kind]: https://kubernetes.slack.com/messages/CEKK1KTN2/

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -300,7 +300,7 @@ See [#1547 (comment)](https://github.com/kubernetes-sigs/kind/issues/1547#issuec
 
 ## Fedora32 and Docker
 
-The situation with Docker on Fedora is not ideal. See Fedora Magazine article ["Fedora and Docker"](https://fedoramagazine.org/docker-and-fedora-32/) for information regarding workarounds for cgroups, firewalld, and installing docker.
+Docker is currently not supported on Fedora 32 and requires additional setup. See Fedora Magazine article ["Fedora and Docker"](https://fedoramagazine.org/docker-and-fedora-32/) for information regarding workarounds for cgroups, firewalld, and installing Docker.
 
 [issue tracker]: https://github.com/kubernetes-sigs/kind/issues
 [file an issue]: https://github.com/kubernetes-sigs/kind/issues/new


### PR DESCRIPTION
Include notice for Fedora32 and Docker users

This update directs Fedora users to the correct information on how to implement workarounds to blockers to being able to use kind.

Fixes: [issues/1807](https://github.com/kubernetes-sigs/kind/issues/1807)