### PR TITLE
move sleep to begining of retry loop

### DIFF
--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -159,11 +159,11 @@ func Cluster(logger log.Logger, p providers.Provider, opts *ClusterOptions) erro
 	// TODO: factor out into a public errors API w/ backoff handling?
 	// for now this is easier than coming up with a good API
 	var err error
-	for _, b := range []time.Duration{time.Millisecond, time.Millisecond * 50, time.Millisecond * 100} {
+	for _, b := range []time.Duration{0, time.Millisecond, time.Millisecond * 50, time.Millisecond * 100} {
+		time.Sleep(b)
 		if err = kubeconfig.Export(p, opts.Config.Name, opts.KubeconfigPath); err == nil {
 			break
 		}
-		time.Sleep(b)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
/cc @amwat 

Note that in go `time.Sleep(0` just returns immediately, versus `sleep(0)` in other languages that give up scheduling time