### PR TITLE
ensure root owns binaries in node image

### DIFF
--- a/pkg/build/nodeimage/build_impl.go
+++ b/pkg/build/nodeimage/build_impl.go
@@ -97,6 +97,9 @@ func (c *buildContext) buildImage(bits kube.Bits) error {
 		if err := execInBuild("chmod", "+x", nodePath); err != nil {
 			return err
 		}
+		if err := execInBuild("chown", "root:root", nodePath); err != nil {
+			return err
+		}
 	}
 
 	// write version


### PR DESCRIPTION
fixes: https://github.com/kubernetes-sigs/kind/issues/1824

root was the owner in previous images. some build changes caused these to have a different UID.
see https://github.com/kubernetes-sigs/kind/issues/1824#issuecomment-683165201