### PR TITLE
mark v0.9.0 release

### DIFF
--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.18.8@sha256:ab79f7a98e8b4267cb0717bb1b29df05cf8e6aa0082acda837347bd81fbe10e3"
+const Image = "kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600"

--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -50,11 +50,11 @@ func DisplayVersion() string {
 }
 
 // VersionCore is the core portion of the kind CLI version per Semantic Versioning 2.0.0
-const VersionCore = "0.9.0"
+const VersionCore = "0.10.0"
 
 // VersionPreRelease is the pre-release portion of the kind CLI version per
 // Semantic Versioning 2.0.0
-const VersionPreRelease = ""
+const VersionPreRelease = "alpha"
 
 // GitCommit is the commit used to build the kind binary, if available.
 // It is injected at build time.

--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -54,7 +54,7 @@ const VersionCore = "0.9.0"
 
 // VersionPreRelease is the pre-release portion of the kind CLI version per
 // Semantic Versioning 2.0.0
-const VersionPreRelease = "alpha"
+const VersionPreRelease = ""
 
 // GitCommit is the commit used to build the kind binary, if available.
 // It is injected at build time.


### PR DESCRIPTION
- bump node image to latest
- add commits for 0.9.0