### PR TITLE
remove unnecessary usage of CombinedOutputLines

### DIFF
--- a/pkg/build/nodeimage/build_impl.go
+++ b/pkg/build/nodeimage/build_impl.go
@@ -166,7 +166,7 @@ func (c *buildContext) prePullImages(bits kube.Bits, dir, containerID string) ([
 
 	// get the Kubernetes version we installed on the node
 	// we need this to ask kubeadm what images we need
-	rawVersion, err := exec.CombinedOutputLines(cmder.Command("cat", kubernetesVersionLocation))
+	rawVersion, err := exec.OutputLines(cmder.Command("cat", kubernetesVersionLocation))
 	if err != nil {
 		c.logger.Errorf("Image build Failed! Failed to get Kubernetes version: %v", err)
 		return nil, err

--- a/pkg/build/nodeimage/internal/container/docker/image.go
+++ b/pkg/build/nodeimage/internal/container/docker/image.go
@@ -70,7 +70,7 @@ func ImageInspect(containerNameOrID, format string) ([]string, error) {
 		containerNameOrID, // ... against the container
 	)
 
-	return exec.CombinedOutputLines(cmd)
+	return exec.OutputLines(cmd)
 }
 
 // ImageID return the Id of the container image

--- a/pkg/build/nodeimage/internal/container/docker/run.go
+++ b/pkg/build/nodeimage/internal/container/docker/run.go
@@ -28,6 +28,5 @@ func Run(image string, runArgs []string, containerArgs []string) error {
 	args = append(args, image)
 	args = append(args, containerArgs...)
 	cmd := exec.Command("docker", args...)
-	_, err := exec.CombinedOutputLines(cmd)
-	return err
+	return cmd.Run()
 }

--- a/pkg/build/nodeimage/internal/kube/source.go
+++ b/pkg/build/nodeimage/internal/kube/source.go
@@ -59,7 +59,7 @@ func sourceVersion(kubeRoot string) (string, error) {
 			shellescape.Quote(kubeRoot),
 		),
 	)
-	output, err := exec.CombinedOutputLines(cmd)
+	output, err := exec.OutputLines(cmd)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cluster/internal/create/actions/waitforready/waitforready.go
+++ b/pkg/cluster/internal/create/actions/waitforready/waitforready.go
@@ -93,7 +93,7 @@ func waitForReady(node nodes.Node, until time.Time) bool {
 			// to true.
 			"-o=jsonpath='{.items..status.conditions[-1:].status}'",
 		)
-		lines, err := exec.CombinedOutputLines(cmd)
+		lines, err := exec.OutputLines(cmd)
 		if err != nil {
 			return false
 		}

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -310,7 +310,7 @@ func getProxyEnv(cfg *config.Cluster, networkName string, nodeNames []string) (m
 func getSubnets(networkName string) ([]string, error) {
 	format := `{{range (index (index . "IPAM") "Config")}}{{index . "Subnet"}} {{end}}`
 	cmd := exec.Command("docker", "network", "inspect", "-f", format, networkName)
-	lines, err := exec.CombinedOutputLines(cmd)
+	lines, err := exec.OutputLines(cmd)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get subnets")
 	}

--- a/pkg/cluster/internal/providers/docker/util.go
+++ b/pkg/cluster/internal/providers/docker/util.go
@@ -35,7 +35,7 @@ func IsAvailable() bool {
 // usernsRemap checks if userns-remap is enabled in dockerd
 func usernsRemap() bool {
 	cmd := exec.Command("docker", "info", "--format", "'{{json .SecurityOptions}}'")
-	lines, err := exec.CombinedOutputLines(cmd)
+	lines, err := exec.OutputLines(cmd)
 	if err != nil {
 		return false
 	}
@@ -51,7 +51,7 @@ func usernsRemap() bool {
 func mountDevMapper() bool {
 	storage := ""
 	cmd := exec.Command("docker", "info", "-f", "{{.Driver}}")
-	lines, err := exec.CombinedOutputLines(cmd)
+	lines, err := exec.OutputLines(cmd)
 	if err != nil {
 		return false
 	}

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -268,7 +268,7 @@ func getProxyEnv(cfg *config.Cluster) (map[string]string, error) {
 func getSubnets(networkName string) ([]string, error) {
 	format := `{{range (index (index . "IPAM") "Config")}}{{index . "Subnet"}} {{end}}`
 	cmd := exec.Command("podman", "network", "inspect", "-f", format, networkName)
-	lines, err := exec.CombinedOutputLines(cmd)
+	lines, err := exec.OutputLines(cmd)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get subnets")
 	}

--- a/pkg/cluster/internal/providers/podman/util.go
+++ b/pkg/cluster/internal/providers/podman/util.go
@@ -38,7 +38,7 @@ func IsAvailable() bool {
 
 func getPodmanVersion() (*version.Version, error) {
 	cmd := exec.Command("podman", "--version")
-	lines, err := exec.CombinedOutputLines(cmd)
+	lines, err := exec.OutputLines(cmd)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/nodeutils/util.go
+++ b/pkg/cluster/nodeutils/util.go
@@ -32,7 +32,7 @@ import (
 func KubeVersion(n nodes.Node) (version string, err error) {
 	// grab kubernetes version from the node image
 	cmd := n.Command("cat", "/kind/version")
-	lines, err := exec.CombinedOutputLines(cmd)
+	lines, err := exec.OutputLines(cmd)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get file")
 	}

--- a/pkg/cmd/kind/load/docker-image/docker-image.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image.go
@@ -180,7 +180,7 @@ func imageID(containerNameOrID string) (string, error) {
 		"-f", "{{ .Id }}",
 		containerNameOrID, // ... against the container
 	)
-	lines, err := exec.CombinedOutputLines(cmd)
+	lines, err := exec.OutputLines(cmd)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
we only want stdout for these

there's two remaining usages, where we're only going to debug the output, not parse it (kubeadm init / kubeadm join)