### PR TITLE
Update ingress example to use networking.k8s.io

### DIFF
--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -46,7 +46,7 @@ spec:
   # Default port used by the image
   - port: 5678
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: example-ingress


### PR DESCRIPTION
extensions api group is deprecated in newer versions of Kubernetes.