### PR TITLE
Updating Code based on Additional Linters

### DIFF
--- a/pkg/apis/config/v1alpha4/default.go
+++ b/pkg/apis/config/v1alpha4/default.go
@@ -43,14 +43,14 @@ func SetDefaultsCluster(obj *Cluster) {
 	// and [::1]:randomPort on ipv6
 	if obj.Networking.APIServerAddress == "" {
 		obj.Networking.APIServerAddress = "127.0.0.1"
-		if obj.Networking.IPFamily == "ipv6" {
+		if obj.Networking.IPFamily == IPv6Family {
 			obj.Networking.APIServerAddress = "::1"
 		}
 	}
 	// default the pod CIDR
 	if obj.Networking.PodSubnet == "" {
 		obj.Networking.PodSubnet = "10.244.0.0/16"
-		if obj.Networking.IPFamily == "ipv6" {
+		if obj.Networking.IPFamily == IPv6Family {
 			obj.Networking.PodSubnet = "fd00:10:244::/64"
 		}
 	}
@@ -60,7 +60,7 @@ func SetDefaultsCluster(obj *Cluster) {
 	// we allocate a /16 subnet that allows 65535 services (current Kubernetes tested limit is O(10k) services)
 	if obj.Networking.ServiceSubnet == "" {
 		obj.Networking.ServiceSubnet = "10.96.0.0/16"
-		if obj.Networking.IPFamily == "ipv6" {
+		if obj.Networking.IPFamily == IPv6Family {
 			obj.Networking.ServiceSubnet = "fd00:10:96::/112"
 		}
 	}

--- a/pkg/cluster/internal/providers/podman/util.go
+++ b/pkg/cluster/internal/providers/podman/util.go
@@ -102,7 +102,7 @@ func getVolumes(label string) ([]string, error) {
 	// Trim away the last `\n`.
 	trimmedOutput := strings.TrimSuffix(string(output), "\n")
 	// Get names of all volumes by splitting via `\n`.
-	return strings.Split(string(trimmedOutput), "\n"), nil
+	return strings.Split(trimmedOutput, "\n"), nil
 }
 
 func deleteVolumes(names []string) error {

--- a/pkg/internal/apis/config/default.go
+++ b/pkg/internal/apis/config/default.go
@@ -48,14 +48,14 @@ func SetDefaultsCluster(obj *Cluster) {
 		SetDefaultsNode(a)
 	}
 	if obj.Networking.IPFamily == "" {
-		obj.Networking.IPFamily = "ipv4"
+		obj.Networking.IPFamily = IPv4Family
 	}
 
 	// default to listening on 127.0.0.1:randomPort on ipv4
 	// and [::1]:randomPort on ipv6
 	if obj.Networking.APIServerAddress == "" {
 		obj.Networking.APIServerAddress = "127.0.0.1"
-		if obj.Networking.IPFamily == "ipv6" {
+		if obj.Networking.IPFamily == IPv6Family {
 			obj.Networking.APIServerAddress = "::1"
 		}
 	}
@@ -63,7 +63,7 @@ func SetDefaultsCluster(obj *Cluster) {
 	// default the pod CIDR
 	if obj.Networking.PodSubnet == "" {
 		obj.Networking.PodSubnet = "10.244.0.0/16"
-		if obj.Networking.IPFamily == "ipv6" {
+		if obj.Networking.IPFamily == IPv6Family {
 			obj.Networking.PodSubnet = "fd00:10:244::/64"
 		}
 	}
@@ -73,7 +73,7 @@ func SetDefaultsCluster(obj *Cluster) {
 	// Note: kubeadm is doing it already but this simplifies kind's logic
 	if obj.Networking.ServiceSubnet == "" {
 		obj.Networking.ServiceSubnet = "10.96.0.0/12"
-		if obj.Networking.IPFamily == "ipv6" {
+		if obj.Networking.IPFamily == IPv6Family {
 			obj.Networking.ServiceSubnet = "fd00:10:96::/112"
 		}
 	}


### PR DESCRIPTION
Slowing adding a couple of linters listed beflow, there are a number of lint issues to resolve.    Fixed in this PR:
1. some `goconst` around existing consts that were not used
2. `unconvert` for unnecessary conversations

history:   The current project configuration is such that a user with a `.golangci-lint.yml` in their home dir would override existing configurations.   Remaining on this PR are reasonable noncontroversial updates to code based on some additional linters (unknownly at the time) being applied.   There is another PR coming to change to a configuration which will eliminate this environmental issue.

Signed-off-by: Ken Sipe <kensipe@gmail.com>
