### PR TITLE
Lint Configuration via YAML

### DIFF
--- a/hack/make-rules/verify/lint.sh
+++ b/hack/make-rules/verify/lint.sh
@@ -26,15 +26,5 @@ cd "${REPO_ROOT}/hack/tools"
 go build -o "${REPO_ROOT}/bin/golangci-lint" github.com/golangci/golangci-lint/cmd/golangci-lint
 cd "${REPO_ROOT}"
 
-# run golangci-lint
-LINTS=(
-  # default golangci-lint lints
-  deadcode errcheck gosimple govet ineffassign staticcheck \
-  structcheck typecheck unused varcheck \
-  # additional lints
-  golint gofmt misspell gochecknoinits unparam scopelint
-)
-LINTS_JOINED="$(IFS=','; echo "${LINTS[*]}")"
-
 # first for the repo in general
-./bin/golangci-lint --disable-all --enable="${LINTS_JOINED}" --timeout=2m run ./...
+./bin/golangci-lint --config "${REPO_ROOT}/hack/tools/.golangci.yml" run ./...

--- a/hack/tools/.golangci.yml
+++ b/hack/tools/.golangci.yml
@@ -1,0 +1,27 @@
+run:
+  timeout: 2m
+
+linters:
+  disable-all: true
+  enable:
+    # default golangci-lint lints
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+
+    # additional lints
+    - gochecknoinits
+    - gofmt
+    - golint
+    - misspell
+    - scopelint
+    - unparam
+
+linters-settings:

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -86,6 +86,7 @@ github.com/go-toolsmith/strparse v1.0.0 h1:Vcw78DnpCAKlM20kSbAyO4mPfJn/lyYA4BJUD
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
 github.com/go-toolsmith/typep v1.0.0 h1:zKymWyA1TRYvqYrYDrfEMZULyrhcnGY3x7LDKU2XQaA=
 github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
+github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b h1:khEcpUM4yFcxg4/FHQWkvVRmgijNXRfzkIDHh23ggEo=
 github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
@@ -240,6 +241,7 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d h1:CdDQnGF8Nq9ocOS/xlSptM1N3BbrA6/kmaep5ggwaIA=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Moving golangci-lint configuration to yaml vs sh which provides a number of benefits.
1. It stops dev env with user or global configurations from highjacking the configuration of the linters 
2. it provides a better / easier to maintain configurations with granular controls not available with shell execution

There are NO changes to the configured linters for this PR.
There is an upgrade to golangci-lint to the latest which requires no additional code updates.
Signed-off-by: Ken Sipe <kensipe@gmail.com>