### PR TITLE
Fix indents of page quick-start.md

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -47,8 +47,9 @@ mv ./kind /some-dir-in-your-PATH/kind
 {{< /codeFromInline >}}
 
 On Mac (homebrew): 
+
 {{< codeFromInline lang="bash" >}}
-   brew install kind
+brew install kind
 {{< /codeFromInline >}}
 or
 {{< codeFromInline lang="bash" >}}


### PR DESCRIPTION
There is a glitch in `quick-start.md` on indentings: https://kind.sigs.k8s.io/docs/user/quick-start/

![image](https://user-images.githubusercontent.com/1425903/94322682-008a1900-ff48-11ea-85ca-9288394f97df.png)

This PR fixes this.

/kind documentation