### PR TITLE
Fix golint warning: package comment should be of the form "Package nodeimage ..."

### DIFF
--- a/pkg/build/nodeimage/doc.go
+++ b/pkg/build/nodeimage/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// package nodeimage implements functionality to build the kind node image
+// Package nodeimage implements functionality to build the kind node image
 package nodeimage


### PR DESCRIPTION
Signed-off-by: zouyu <zouy.fnst@cn.fujitsu.com>