### PR TITLE
Error if cluster to delete does not exist

### DIFF
--- a/pkg/cluster/internal/delete/delete.go
+++ b/pkg/cluster/internal/delete/delete.go
@@ -34,16 +34,15 @@ func Cluster(logger log.Logger, p providers.Provider, name, explicitKubeconfigPa
 	}
 
 	kerr := kubeconfig.Remove(name, explicitKubeconfigPath)
-	if kerr != nil {
-		logger.Errorf("failed to update kubeconfig: %v", kerr)
-	}
-
 	err = p.DeleteNodes(n)
 	if err != nil {
+		if kerr != nil {
+			logger.Errorf("failed to update kubeconfig: %v", kerr)
+		}
 		return err
 	}
 	if kerr != nil {
-		return err
+		return kerr
 	}
 	return nil
 }

--- a/pkg/cluster/internal/kubeconfig/internal/kubeconfig/remove.go
+++ b/pkg/cluster/internal/kubeconfig/internal/kubeconfig/remove.go
@@ -48,6 +48,8 @@ func RemoveKIND(kindClusterName string, explicitPath string) error {
 				if err := write(existing, configPath); err != nil {
 					return err
 				}
+			} else {
+				return errors.New("Cluster not found")
 			}
 
 			return nil

--- a/pkg/cmd/kind/delete/cluster/deletecluster.go
+++ b/pkg/cmd/kind/delete/cluster/deletecluster.go
@@ -34,7 +34,7 @@ type flagpole struct {
 	Kubeconfig string
 }
 
-// NewCommand returns a new cobra.Command for cluster creation
+// NewCommand returns a new cobra.Command for cluster deletion
 func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	flags := &flagpole{}
 	cmd := &cobra.Command{

--- a/pkg/cmd/kind/delete/clusters/deleteclusters.go
+++ b/pkg/cmd/kind/delete/clusters/deleteclusters.go
@@ -33,7 +33,7 @@ type flagpole struct {
 	All        bool
 }
 
-// NewCommand returns a new cobra.Command for cluster creation
+// NewCommand returns a new cobra.Command for cluster deletion
 func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	flags := &flagpole{}
 	cmd := &cobra.Command{

--- a/pkg/cmd/kind/delete/delete.go
+++ b/pkg/cmd/kind/delete/delete.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/kind/pkg/log"
 )
 
-// NewCommand returns a new cobra.Command for cluster creation
+// NewCommand returns a new cobra.Command for cluster deletion
 func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Args: cobra.NoArgs,


### PR DESCRIPTION
If we have a typo in the name of the cluster to delete, the current output is (the same as when we actually delete a cluster):

    $ kind delete cluster --name=anything
    Deleting cluster "anything" ...

After this change, we have this:

    $ kind delete cluster --name=anything
    Deleting cluster "anything" ...
    ERROR: failed to delete cluster "anything": Cluster not found