### PR TITLE
allow to select the kube-proxy mode in CI

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -139,6 +139,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   ipFamily: ${IP_FAMILY:-ipv4}
+  kubeProxyMode: ${KUBE_PROXY_MODE:-iptables}
 nodes:
 - role: control-plane
 - role: worker


### PR DESCRIPTION
ipvs is a GA feature of kube-proxy and it only has 2 jobs testing it.
We can add more coverage just using KIND 

xref: https://github.com/kubernetes/test-infra/pull/19463