### PR TITLE
add gpus support in docker provider

### DIFF
--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -142,6 +142,9 @@ type Node struct {
 	// The node-level patches will be applied after the cluster-level patches
 	// have been applied. (See Cluster.KubeadmConfigPatchesJSON6902)
 	KubeadmConfigPatchesJSON6902 []PatchJSON6902 `yaml:"kubeadmConfigPatchesJSON6902,omitempty"`
+
+	// ExtraArguments to be given to the provider
+	ExtraArguments []string `yaml:"extraArguments,omitempty"`
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -251,6 +251,8 @@ func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, n
 	}
 	args = append(args, mappingArgs...)
 
+	args = append(args, node.ExtraArguments...)
+
 	// finally, specify the image to run
 	return append(args, node.Image), nil
 }

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -209,6 +209,8 @@ func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, n
 	}
 	args = append(args, mappingArgs...)
 
+	args = append(args, node.ExtraArguments...)
+
 	// finally, specify the image to run
 	_, image := sanitizeImage(node.Image)
 	return append(args, image), nil

--- a/pkg/internal/apis/config/convert_v1alpha4.go
+++ b/pkg/internal/apis/config/convert_v1alpha4.go
@@ -55,6 +55,7 @@ func convertv1alpha4Node(in *v1alpha4.Node, out *Node) {
 	out.ExtraMounts = make([]Mount, len(in.ExtraMounts))
 	out.ExtraPortMappings = make([]PortMapping, len(in.ExtraPortMappings))
 	out.KubeadmConfigPatchesJSON6902 = make([]PatchJSON6902, len(in.KubeadmConfigPatchesJSON6902))
+	out.ExtraArguments = in.ExtraArguments
 
 	for i := range in.ExtraMounts {
 		convertv1alpha4Mount(&in.ExtraMounts[i], &out.ExtraMounts[i])

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -104,6 +104,9 @@ type Node struct {
 	// KubeadmConfigPatchesJSON6902 are applied to the generated kubeadm config
 	// as patchesJson6902 to `kustomize build`
 	KubeadmConfigPatchesJSON6902 []PatchJSON6902
+
+	// ExtraArguments allow for custom options to be passed to the provider
+	ExtraArguments []string
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`

--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -294,3 +294,22 @@ nodes:
 
 [YAML]: https://yaml.org/
 [feature gates]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+
+### Extra Arguments
+
+Extra arguments can optionally be used augment the default behavior of the container runtime that provisions cluster nodes.
+
+NOTE: Extra Arguments are specifc to the underlying container management system. They are *not* necessarily portable between container management systems (IE: docker vs podman), and may not be supported at all in future releases. Use this configuration option with care, and as a last resort only.
+
+For example, the following configuration is valid for docker, and will expose all GPUs devices present to the cluster node, as well as adjust the limit on open file handles.
+{{< codeFromInline lang="yaml" >}}
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraArguments:
+  - --gpus
+  - all
+  - --ulimit
+  - nofile=8192:8192
+{{< /codeFromInline >}}


### PR DESCRIPTION
Exposes a new external api node parameter, `gpus` that, when present, is passed through as the `--gpus` flag of the associated node.  Only the docker provider is supported currently, though podman support should be doable as well.