### PR TITLE
fix(hack): send cd output to null in case CDPATH is in effect

### DIFF
--- a/hack/ci/push-latest-cli/push-latest-cli.sh
+++ b/hack/ci/push-latest-cli/push-latest-cli.sh
@@ -17,7 +17,7 @@ set -o errexit -o nounset -o pipefail
 set -x;
 
 # cd to the repo root
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &> /dev/null && pwd -P)"
 cd "${REPO_ROOT}"
 
 # pass through git details from prow / image builder

--- a/hack/make-rules/update/all.sh
+++ b/hack/make-rules/update/all.sh
@@ -17,7 +17,7 @@
 set -o errexit -o nounset -o pipefail
 
 # cd to the repo root
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &> /dev/null && pwd -P)"
 cd "${REPO_ROOT}"
 
 hack/make-rules/update/deps.sh

--- a/hack/make-rules/update/deps.sh
+++ b/hack/make-rules/update/deps.sh
@@ -20,7 +20,7 @@
 set -o errexit -o nounset -o pipefail
 
 # cd to the repo root and setup go
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &> /dev/null && pwd -P)"
 cd "${REPO_ROOT}"
 source hack/build/setup-go.sh
 

--- a/hack/make-rules/update/generated.sh
+++ b/hack/make-rules/update/generated.sh
@@ -17,7 +17,7 @@
 set -o errexit -o nounset -o pipefail
 
 # cd to the repo root and setup go
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &> /dev/null && pwd -P)"
 cd "${REPO_ROOT}"
 source hack/build/setup-go.sh
 

--- a/hack/make-rules/update/gofmt.sh
+++ b/hack/make-rules/update/gofmt.sh
@@ -18,7 +18,7 @@
 set -o errexit -o nounset -o pipefail
 
 # cd to the repo root and setup go
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &> /dev/null && pwd -P)"
 cd "${REPO_ROOT}"
 source hack/build/setup-go.sh
 

--- a/hack/make-rules/verify/all.sh
+++ b/hack/make-rules/verify/all.sh
@@ -16,7 +16,7 @@
 set -o errexit -o nounset -o pipefail
 
 # cd to the repo root
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &> /dev/null && pwd -P)"
 cd "${REPO_ROOT}"
 
 # exit code, if a script fails we'll set this to 1

--- a/hack/make-rules/verify/generated.sh
+++ b/hack/make-rules/verify/generated.sh
@@ -16,7 +16,7 @@
 set -o errexit -o nounset -o pipefail
 
 # cd to the repo root and setup go
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &> /dev/null && pwd -P)"
 cd "${REPO_ROOT}"
 source hack/build/setup-go.sh
 

--- a/hack/make-rules/verify/lint.sh
+++ b/hack/make-rules/verify/lint.sh
@@ -17,7 +17,7 @@
 set -o errexit -o nounset -o pipefail
 
 # cd to the repo root and setup go
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &> /dev/null && pwd -P)"
 cd "${REPO_ROOT}"
 source hack/build/setup-go.sh
 

--- a/hack/make-rules/verify/shellcheck.sh
+++ b/hack/make-rules/verify/shellcheck.sh
@@ -20,7 +20,7 @@ set -o nounset
 set -o pipefail
 
 # cd to the repo root
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &> /dev/null && pwd -P)"
 cd "${REPO_ROOT}"
 
 # upstream shellcheck latest stable image as of January 10th, 2019

--- a/hack/release/build/cross.sh
+++ b/hack/release/build/cross.sh
@@ -17,7 +17,7 @@
 set -o errexit -o nounset -o pipefail
 
 # cd to the repo root and setup go
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &> /dev/null && pwd -P)"
 cd "${REPO_ROOT}"
 source hack/build/setup-go.sh
 

--- a/hack/release/build/push-node.sh
+++ b/hack/release/build/push-node.sh
@@ -16,7 +16,7 @@
 set -o errexit -o nounset -o pipefail
 
 # cd to the repo root
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &> /dev/null && pwd -P)"
 cd "${REPO_ROOT}"
 
 # ensure we have up to date kind


### PR DESCRIPTION
#1887 - will prevent `CDPATH` interference when running various Bash hack scripts.