### PR TITLE
site: update the registry docs to use the config map

### DIFF
--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -22,10 +22,20 @@ containerdConfigPatches:
 EOF
 
 # connect the registry to the cluster network
-docker network connect "kind" "${reg_name}"
+# (the network may already be connected)
+docker network connect "kind" "${reg_name}" || true
 
-# tell https://tilt.dev to use the registry
-# https://docs.tilt.dev/choosing_clusters.html#discovering-the-registry
-for node in $(kind get nodes); do
-  kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${reg_port}";
-done
+# Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+


### PR DESCRIPTION
I still think it's worth having a native way to do this in Kind (as per https://github.com/kubernetes-sigs/kind/issues/1543 and https://github.com/kubernetes-sigs/kind/issues/1213) but for now I'm just updating the docs to match current best practices