### PR TITLE
default ipv6 subnet to /56

### DIFF
--- a/pkg/apis/config/v1alpha4/default.go
+++ b/pkg/apis/config/v1alpha4/default.go
@@ -51,7 +51,9 @@ func SetDefaultsCluster(obj *Cluster) {
 	if obj.Networking.PodSubnet == "" {
 		obj.Networking.PodSubnet = "10.244.0.0/16"
 		if obj.Networking.IPFamily == "ipv6" {
-			obj.Networking.PodSubnet = "fd00:10:244::/64"
+			// node-mask cidr default is /64 so we need a larger subnet, we use /56 following best practices
+			// xref: https://www.ripe.net/publications/docs/ripe-690#4--size-of-end-user-prefix-assignment---48---56-or-something-else-
+			obj.Networking.PodSubnet = "fd00:10:244::/56"
 		}
 	}
 	// default the service CIDR using a different subnet than kubeadm default

--- a/pkg/internal/apis/config/default.go
+++ b/pkg/internal/apis/config/default.go
@@ -72,9 +72,10 @@ func SetDefaultsCluster(obj *Cluster) {
 
 	// default the service CIDR using the kubeadm default
 	// https://github.com/kubernetes/kubernetes/blob/746404f82a28e55e0b76ffa7e40306fb88eb3317/cmd/kubeadm/app/apis/kubeadm/v1beta2/defaults.go#L32
-	// Note: kubeadm is doing it already but this simplifies kind's logic
+	// Note: kubeadm is using a /12 subnet, that may allocate a 2^20 bitmap in etcd
+	// we allocate a /16 subnet that allows 65535 services (current Kubernetes tested limit is O(10k) services)
 	if obj.Networking.ServiceSubnet == "" {
-		obj.Networking.ServiceSubnet = "10.96.0.0/12"
+		obj.Networking.ServiceSubnet = "10.96.0.0/16"
 		if obj.Networking.IPFamily == "ipv6" {
 			obj.Networking.ServiceSubnet = "fd00:10:96::/112"
 		}

--- a/pkg/internal/apis/config/default.go
+++ b/pkg/internal/apis/config/default.go
@@ -64,7 +64,9 @@ func SetDefaultsCluster(obj *Cluster) {
 	if obj.Networking.PodSubnet == "" {
 		obj.Networking.PodSubnet = "10.244.0.0/16"
 		if obj.Networking.IPFamily == "ipv6" {
-			obj.Networking.PodSubnet = "fd00:10:244::/64"
+			// node-mask cidr default is /64 so we need a larger subnet, we use /56 following best practices
+			// xref: https://www.ripe.net/publications/docs/ripe-690#4--size-of-end-user-prefix-assignment---48---56-or-something-else-
+			obj.Networking.PodSubnet = "fd00:10:244::/56"
 		}
 	}
 


### PR DESCRIPTION
we were defaulting IPv6 subnet to a /64, this was working because
kubeadm was calculating and modifying directly the node-cidr-mask,
so the controller manager does not complain.

Kubeadm should only validate that the config is correct and fail
in case of error, this behavior will be changed soon, but once
this happen it will break kind default deployment.