### PR TITLE
WIP: Modify hack/ci/e2e-k8s.sh to support audit logging

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -171,7 +171,7 @@ kubeadmConfigPatches:
     extraArgs:
       "v": "${KIND_CLUSTER_LOG_LEVEL}"
       "audit-policy-file": "/etc/kubernetes/pki/audit/policy.yaml"
-      "audit-log-path": "/etc/kubernetes/pki/audit.log"
+      "audit-log-path": "/etc/kubernetes/pki/audit/audit.log"
   controllerManager:
     extraArgs:
       "v": "${KIND_CLUSTER_LOG_LEVEL}"

--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -156,7 +156,7 @@ nodes:
 - role: control-plane
   extraMounts:
   - hostPath: ${ARTIFACTS}/audit
-    containerPath: /var/audit
+    containerPath: /etc/kubernetes/pki/audit
     readOnly: False
 - role: worker
 - role: worker
@@ -170,8 +170,8 @@ kubeadmConfigPatches:
   apiServer:
     extraArgs:
       "v": "${KIND_CLUSTER_LOG_LEVEL}"
-      "audit-policy-file": "/var/audit/policy.yaml"
-      "audit-log-path": "/var/audit/audit.log"
+      "audit-policy-file": "/etc/kubernetes/pki/audit/policy.yaml"
+      "audit-log-path": "/etc/kubernetes/pki/audit.log"
   controllerManager:
     extraArgs:
       "v": "${KIND_CLUSTER_LOG_LEVEL}"


### PR DESCRIPTION
This is to get feedback and test a version of e2e-k8s.sh that supports creating ARTIFACTS/audit/audit.log without any filters.

See: https://github.com/kubernetes/test-infra/issues/19613#issuecomment-713091006