### PR TITLE
Upgrade Ingress resource definition from v1beta1 to v1

### DIFF
--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -46,7 +46,7 @@ spec:
   # Default port used by the image
   - port: 5678
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress
@@ -55,11 +55,17 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: Prefix
         backend:
-          serviceName: foo-service
-          servicePort: 5678
+          service:
+            name: foo-service
+            port:
+              number: 5678
       - path: /bar
+        pathType: Prefix
         backend:
-          serviceName: bar-service
-          servicePort: 5678
+          service:
+            name: bar-service
+            port:
+              number: 5678
 ---


### PR DESCRIPTION
The Kubernetes [Ingress API went GA in v1.19](https://opensource.googleblog.com/2020/09/kubernetes-ingress-goes-ga.html). Using **v1beta1** version on v1.19+ Kubernetes clusters raises the following message: `Warning: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress`. This change updates the syntax of that resource definition.