### PR TITLE
Docs: Fix kubectl deployment command mistake in wsl2

### DIFF
--- a/site/content/docs/user/using-wsl2.md
+++ b/site/content/docs/user/using-wsl2.md
@@ -79,7 +79,7 @@ nodes:
 {{< /codeFromInline >}}
 
 1. create cluster `kind create cluster --config=cluster-config.yml`
-1. create deployment `kubectl create deployment nginx --image=nginx --port=80`
+1. create deployment `kubectl create deployment nginx --image=nginx`
 1. create service `kubectl create service nodeport nginx --tcp=80:80 --node-port=30000`
 1. access service `curl localhost:30000`
 


### PR DESCRIPTION
## Background 
In the Kind docs, [using-wsl2](https://kind.sigs.k8s.io/docs/user/using-wsl2/) mentioned a kubectl command to create a nginx deployment `kubectl create deployment nginx --image=nginx --port=80`, but seems `kubectl create deployment` does not support flags of `--port`.

## Changes
I update this command, remove the flags of `--port`. There is no code change. 