### PR TITLE
issue 1905/support for multiple images to kind load

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -151,11 +151,12 @@ context name `kind` and delete that cluster.
 ## Loading an Image Into Your Cluster
 
 Docker images can be loaded into your cluster nodes with:
-`kind load docker-image my-custom-image`
 
-> **NOTE**: If using a named cluster you will need to specify the name of the 
-cluster you wish to load the image into:
-`kind load docker-image my-custom-image --name kind-2`
+`kind load docker-image my-custom-image-0 my-custom-image-1`
+
+**Note**: If using a named cluster you will need to specify the name of the 
+cluster you wish to load the images into:
+`kind load docker-image my-custom-image-0 my-custom-image-1 --name kind-2`
 
 Additionally, image archives can be loaded with:
 `kind load image-archive /my-image-archive.tar`


### PR DESCRIPTION
closes #1905 

**Usage:**

Multiple image names provided (all images present locally):
```
./kind load docker-image nginx,busybox --name master    

```
Multiple image names provided (all images are not present locally):
```
./kind load docker-image nginx,busybox,python --name master
ERROR: image: "python" not present locally
```
One image name provided without commas **(backwards compatibility)**:
```
./kind load docker-image nginx --name master               

```