### PR TITLE
Support Rootless Docker and Rootless Podman, without patching Kubernetes

### DIFF
--- a/images/base/files/etc/containerd/config.toml
+++ b/images/base/files/etc/containerd/config.toml
@@ -20,3 +20,5 @@ version = 2
   tolerate_missing_hugepages_controller = true
   # explicitly use default snapshotter so we can sed it in entrypoint
   snapshotter = "overlayfs"
+  # restrict_oom_score_adj needs to be true when running inside UserNS (rootless)
+  restrict_oom_score_adj = false

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -18,10 +18,96 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# If /proc/self/uid_map 4294967295 mappings, we are in the initial user namespace, i.e. the host.
+# Otherwise we are in a non-initial user namespace.
+# https://github.com/opencontainers/runc/blob/v1.0.0-rc92/libcontainer/system/linux.go#L109-L118
+userns=""
+if grep -Eqv "0[[:space:]]+0[[:space:]]+4294967295" /proc/self/uid_map; then
+  userns="1"
+  echo 'INFO: running in a user namespace (experimental)'
+fi
+
+validate_userns() {
+  if [[ -z "${userns}" ]]; then
+    return
+  fi
+
+  local nofile_hard
+  nofile_hard="$(ulimit -Hn)"
+  local nofile_hard_expected="64000"
+  if [[ "${nofile_hard}" -lt "${nofile_hard_expected}" ]]; then
+    echo "WARN: UserNS: expected RLIMIT_NOFILE to be at least ${nofile_hard_expected}, got ${nofile_hard}" >&2
+  fi
+
+  if [[ ! -f "/sys/fs/cgroup/cgroup.controllers" ]]; then
+    echo "ERROR: UserNS: cgroup v2 needs to be enabled" >&2
+    exit 1
+  fi
+  for f in cpu memory pids; do
+    if ! grep -qw $f /sys/fs/cgroup/cgroup.controllers; then
+      echo "ERROR: UserNS: $f controller needs to be delegated" >&2
+    exit 1
+    fi
+  done
+}
+
+fake_file_with_content(){
+  local path="$1"
+  local content="$2"
+  local base="/run/fake"
+  local fake_path="${base}/${path}"
+  mkdir -p "$(dirname "${fake_path}")"
+  echo "INFO: UserNS: faking ${path} to be \"${content}\" (writable)"
+  echo "${content}" > "${fake_path}"
+  mount --bind "${fake_path}" "${path}"
+}
+
+fake_sysctl() {
+  local key="$1"
+  local key_slash
+  # shellcheck disable=SC2001
+  key_slash="$(echo "${key}" | sed -e s@\\.@/@g)"
+  local path="/proc/sys/${key_slash}"
+  if [[ -f "${path}" ]]; then
+    local content
+    content="$(cat "${path}")"
+    fake_file_with_content "${path}" "${content}"
+  fi
+}
+
 configure_containerd() {
   # we need to switch to the 'native' snapshotter on zfs
   if [[ "$(stat -f -c %T /kind)" == 'zfs' ]]; then
     sed -i 's/snapshotter = "overlayfs"/snapshotter = "native"/' /etc/containerd/config.toml
+  fi
+
+  # userns (rootless) configs
+  if [[ -n "$userns" ]]; then
+    # Adjust oomScoreAdj
+    sed -i 's/restrict_oom_score_adj = false/restrict_oom_score_adj = true/' /etc/containerd/config.toml
+
+    # mounting overlayfs inside userns requires patching kernel.
+    # Ubuntu kernel is patched by default.
+    # Debian kernel is patched by default as well, but Debian needs `sudo modprobe overlay permit_mounts_in_userns=1`.
+    local tmp
+    tmp=$(mktemp -d)
+    mkdir -p "${tmp}"/{l,u,w,m}
+    if mount -t overlay overlay -o "lowerdir=${tmp}/l,upperdir=${tmp}/u,workdir=${tmp}/w" "${tmp}/m"; then
+      umount "${tmp}/m"
+    else
+      echo 'INFO: UserNS: this kernel does not support mounting overlayfs inside userns. Disabling overlayfs'
+      sed -i 's/snapshotter = "overlayfs"/snapshotter = "native"/' /etc/containerd/config.toml
+    fi
+    rm -rf "${tmp}"
+
+    # To run vanilla kubelet inside UserNS, we need to fake several unwritable sysctl to be writable.
+    # Workaround until https://github.com/kubernetes/kubernetes/pull/92863 gets merged in the upstream.
+    fake_sysctl "vm.overcommit_memory"
+    fake_sysctl "vm.panic_on_oom"
+    fake_sysctl "kernel.panic"
+    fake_sysctl "kernel.panic_on_oops"
+    fake_sysctl "kernel.keys.root_maxkeys"
+    fake_sysctl "kernel.keys.root_maxbytes"
   fi
 }
 
@@ -50,12 +136,16 @@ fix_mount() {
     sync
   fi
 
-  echo 'INFO: remounting /sys read-only'
-  # systemd-in-a-container should have read only /sys
-  # https://systemd.io/CONTAINER_INTERFACE/
-  # however, we need other things from `docker run --privileged` ...
-  # and this flag also happens to make /sys rw, amongst other things
-  mount -o remount,ro /sys
+  if [[ -z "${userns}" ]]; then
+    echo 'INFO: remounting /sys read-only'
+    # systemd-in-a-container should have read only /sys
+    # https://systemd.io/CONTAINER_INTERFACE/
+    # however, we need other things from `docker run --privileged` ...
+    # and this flag also happens to make /sys rw, amongst other things
+    #
+    # This step is skipped when running inside UserNS, because it fails with EACCES.
+    mount -o remount,ro /sys
+  fi
 
   echo 'INFO: making mounts shared' >&2
   # for mount propagation
@@ -212,6 +302,13 @@ fix_kmsg() {
     else
       echo 'WARN: /dev/kmsg does not exist, nor does /dev/console!' >&2
     fi
+  elif [[ -n "${userns}" ]]; then
+    if [[ -f "/proc/sys/kernel/dmesg_restrict" ]]; then
+      if [[ "$(cat /proc/sys/kernel/dmesg_restrict)" = "1" ]]; then
+        echo 'WARN: UserNS: /dev/kmsg is not readable, faking with /dev/null (hint: set sysctl value "kernel.dmesg_restrict" to 0)' >&2
+        mount --bind /dev/null /dev/kmsg
+      fi
+    fi
   fi
 }
 
@@ -298,6 +395,9 @@ enable_network_magic(){
     echo -n "${curr_ipv6}" >/kind/old-ipv6
   fi
 }
+
+# validate state
+validate_userns
 
 # run pre-init fixups
 # NOTE: it's important that we do configure* first in this order to avoid races

--- a/pkg/cluster/internal/create/actions/config/config.go
+++ b/pkg/cluster/internal/create/actions/config/config.go
@@ -48,6 +48,11 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 	ctx.Status.Start("Writing configuration 📜")
 	defer ctx.Status.End(false)
 
+	providerInfo, err := ctx.Provider.Info()
+	if err != nil {
+		return err
+	}
+
 	allNodes, err := ctx.Nodes()
 	if err != nil {
 		return err
@@ -76,6 +81,7 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 		IPv6:                 ctx.Config.Networking.IPFamily == "ipv6",
 		FeatureGates:         ctx.Config.FeatureGates,
 		RuntimeConfig:        ctx.Config.RuntimeConfig,
+		RootlessProvider:     providerInfo.Rootless,
 	}
 
 	kubeadmConfigPlusPatches := func(node nodes.Node, data kubeadm.ConfigData) func() error {

--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -68,12 +68,6 @@ func (p *provider) Provision(status *cli.Status, cfg *config.Cluster) (err error
 		return err
 	}
 
-	// kind doesn't work with podman rootless, surface an error
-	if os.Geteuid() != 0 {
-		p.logger.Errorf("podman provider does not work properly in rootless mode")
-		os.Exit(1)
-	}
-
 	// TODO: validate cfg
 	// ensure node images are pulled before actually provisioning
 	if err := ensureNodeImages(p.logger, status, cfg); err != nil {
@@ -349,4 +343,12 @@ func (p *provider) CollectLogs(dir string, nodes []nodes.Node) error {
 	// run and collect up all errors
 	errs = append(errs, errors.AggregateConcurrent(fns))
 	return errors.NewAggregate(errs)
+}
+
+// Info returns the provider info.
+func (p *provider) Info() (*providers.ProviderInfo, error) {
+	info := &providers.ProviderInfo{
+		Rootless: os.Geteuid() != 0,
+	}
+	return info, nil
 }

--- a/pkg/cluster/internal/providers/provider.go
+++ b/pkg/cluster/internal/providers/provider.go
@@ -45,4 +45,11 @@ type Provider interface {
 	GetAPIServerInternalEndpoint(cluster string) (string, error)
 	// CollectLogs will populate dir with cluster logs and other debug files
 	CollectLogs(dir string, nodes []nodes.Node) error
+	// Info returns the provider info
+	Info() (*ProviderInfo, error)
+}
+
+// ProviderInfo is the info of the provider
+type ProviderInfo struct {
+	Rootless bool
 }

--- a/site/content/docs/user/rootless.md
+++ b/site/content/docs/user/rootless.md
@@ -1,0 +1,59 @@
+---
+title: "Running kind with Rootless Docker"
+menu:
+  main:
+    parent: "user"
+    identifier: "rootless"
+    weight: 3
+---
+Starting with kind 0.11.0, [Rootless Docker](https://docs.docker.com/go/rootless/) and [Rootless Podman](https://github.com/containers/podman/blob/master/docs/tutorials/rootless_tutorial.md) can be used as the node provider of kind.
+
+## Provider requirements
+- Docker: 20.10 or later
+- Podman: 3.0 or later
+
+## Host requirements
+The host needs to be running with cgroup v2.
+
+cgroup v2 is enabled by default on Fedora.
+On other distros, cgroup v2 can be typically enabled by adding `GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=1"` to `/etc/default/grub` and
+running `sudo update-grub`.
+
+Also, depending on the host configuration, the following steps might be needed:
+
+- Create `/etc/systemd/system/user@.service.d/delegate.conf` with the following content, and then run `sudo systemctl daemon-reload`:
+```ini
+[Service]
+Delegate=yes
+```
+
+- Create `/etc/modules-load.d/iptables.conf` with the following content:
+```
+iptables_nat
+ip6tables_nat
+```
+
+## Restrictions
+
+The restrictions of Rootless Docker apply to kind clusters as well.
+
+e.g.
+- OverlayFS cannot be used unless the host is using kernel >= 5.11, or Ubuntu/Debian kernel
+- Cannot mount block storages
+- Cannot mount NFS
+
+## Creating a kind cluster with Rootless Docker
+
+To create a kind cluster with Rootless Docker, just run:
+```console
+$ export DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/docker.sock
+$ kind create cluster
+```
+
+To create a kind cluster with Rootless Podman, just run:
+```console
+$ KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster
+```
+
+## Tips
+- To enable OOM watching, allow `dmesg` by running `sysctl -w kernel.dmesg_restrict=0`.


### PR DESCRIPTION
This PR adds support for running kind with Rootless Docker provider.
Requires Docker 20.10 / Podman 3.0, with cgroup v2.

Unlike the previous PR (https://github.com/kubernetes-sigs/kind/pull/1727), this version works without patching Kubernetes (1.20.4).

However, this version has dirty hacks such as faking sysctl keys by bind-mounting regular files under `/proc/sys`.
So I still want the Kubernetes PR to be merged: https://github.com/kubernetes/kubernetes/pull/92863

## Restrictions

The restrictions of Rootless Docker apply to kind clusters as well.

e.g.
- OverlayFS cannot be used unless the host is Ubuntu or Debian
- Cannot mount block storages
- Cannot mount NFS

To workaround the OverlayFS issue, we could use fuse-overlayfs on kernel >= 4.18: https://github.com/AkihiroSuda/containerd-fuse-overlayfs
However, to decrease complexity of PR, the support for fuse-overlayfs is not included in this PR, and will be introduced in a separate PR after this PR gets merged.


## How this PR works
When the entrypoint script detect that it is running inside user namespace (i.e. rootless), it modifies `/etc/containerd/config.toml` to:

- Set `restrict_oom_score_adj` to true to adjust oomScoreAdj value
- Change the snapshotter from overlay to native, unless running with Ubuntu/Debian kernel

The entrypoint script also does:
- Bind-mount several fake regular files inside `/proc/sys` to make them writable. Workaround until https://github.com/kubernetes/kubernetes/pull/92863 gets merged.
- Set `kubeProxyConfiguration.conntrack.maxPerCore` to 0, for avoiding an error during setting sysctl value `net.netfilter.nf_conntrack_max`

## How to test

### Step 1: Prepare host
- Install Ubuntu 20.10 host. 

- Add `GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=1"` to `/etc/default/grub`.

- Create `/etc/systemd/system/user@.service.d/delegate.conf` with the following content:
```
[Service]
Delegate=yes
```

- Run `sudo update-grub` and reboot.

- Install Docker 20.10 or Podman 3.0.
```console
$ curl -fsSL https://get.docker.com | sh
$ sudo apt-get install -y docker-ce-rootless-extras
$ dockerd-rootless-setuptool.sh install -f
```

- Run `docker info` with `DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock`, and make sure it shows "rootless" as a Security Option:
```console
$ export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock

$ docker info
...
Cgroup Driver: systemd
 Cgroup Version: 2
...
 Security Options:
  seccomp
   Profile: default
  rootless
  cgroupns
...
```

### Step 2: Prepare the node image


```console
$ (cd $GOPATH/src/k8s.io/kubernetes && git checkout v1.20.4)
```

```console
export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock
docker build -t kindest/base:latest ./images/base && kind build node-image --base-image kindest/base:latest --type=bazel
```

The image is registered as `kindest/node:latest` in Rootless Docker's image store.

NOTE: `--type=bazel` is required for running `kind build node-image` with Rootless Docker.

### Step 3: Start kind with Rootless Docker
- Run `kind create cluster --image kindest/node:latest`
- Run `ps auxw` on the hosts, and make sure the kind processes are running as unprivileged users
- Make sure `kubectl get pods -A` shows all pods as `Running`

```console
$ export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock
$ kind create cluster --image kindest/node:latest
...
$ kubectl get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
kube-system          coredns-74ff55c5b-cgdfs                      1/1     Running   0          113s
kube-system          coredns-74ff55c5b-hpldh                      1/1     Running   0          113s
kube-system          etcd-kind-control-plane                      1/1     Running   0          114s
kube-system          kindnet-qqm9j                                1/1     Running   0          113s
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          114s
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          114s
kube-system          kube-proxy-qx849                             1/1     Running   0          113s
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          114s
local-path-storage   local-path-provisioner-78776bfc44-68n5f      1/1     Running   0          113s
```

- - -

Pre-built image is temporarily available on my Docker Hub: https://hub.docker.com/r/akihirosuda/tmp-kind-node/tags