### PR TITLE
disable CGO by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,9 @@ PATH:=$(shell . hack/build/setup-go.sh && echo "$${PATH}")
 GOROOT:=
 # enable modules
 GO111MODULE=on
-export PATH GOROOT GO111MODULE
+# disable CGO by default for static binaries
+CGO_ENABLED=0
+export PATH GOROOT GO111MODULE CGO_ENABLED
 # work around broken PATH export
 SPACE:=$(subst ,, )
 SHELL:=env PATH=$(subst $(SPACE),\$(SPACE),$(PATH)) $(SHELL)


### PR DESCRIPTION
This also shrinks the binary another bit on linux 7.1M to 7.0M
Fixes a build failure I encountered.

iI someone really wants CGO (no real reason currently) they can build with `make build CGO_ENABLED=1`