### PR TITLE
Add completion for oh-my-zsh

### DIFF
--- a/pkg/cmd/kind/completion/completion.go
+++ b/pkg/cmd/kind/completion/completion.go
@@ -53,6 +53,9 @@ This depends on the bash-completion binary.  Example installation instructions:
 	% autoload -U compinit && compinit
 # or if zsh-completion is installed via homebrew
     % kind completion zsh > "${fpath[1]}/_kind"
+# or if you use oh-my-zsh (needs zsh-completions plugin)
+	% mkdir ~/.oh-my-zsh/completions/
+	% kind completion zsh > ~/.oh-my-zsh/completions/_kind
 
 # for fish users
 	% kind completion fish > ~/.config/fish/completions/kind.fish

--- a/pkg/cmd/kind/completion/completion.go
+++ b/pkg/cmd/kind/completion/completion.go
@@ -54,8 +54,8 @@ This depends on the bash-completion binary.  Example installation instructions:
 # or if zsh-completion is installed via homebrew
     % kind completion zsh > "${fpath[1]}/_kind"
 # or if you use oh-my-zsh (needs zsh-completions plugin)
-	% mkdir ~/.oh-my-zsh/completions/
-	% kind completion zsh > ~/.oh-my-zsh/completions/_kind
+	% mkdir $ZSH/completions/
+	% kind completion zsh > $ZSH/completions/_kind
 
 # for fish users
 	% kind completion fish > ~/.config/fish/completions/kind.fish


### PR DESCRIPTION
### Issue
I've installed kind few days ago and never been able to setup completion for zsh using the commands printed by `kind completion zsh` because both paths are incorrect.
The first one tells the user to create the `/usr/local/share/zsh/site-functions/_kind` file but in my case there isn't that path in my system, sudo privileges are required and zsh doesn't read files from there. The second option uses fpath to determine the path in which the file should be located but, in my case it was the `~/.oh-my-zsh/` folder and _kind was completely ignored.

### Proposed solution
My solution is an extended but more precise version of the second method and uses a predefined path (already present in fpath) `~/.oh-my-zsh/completions` but requires the plugin [zsh-completions](https://github.com/zsh-users/zsh-completions) to be installed.

#### Acknowledgments
1. #522
2. #719
3. #729