### PR TITLE
Prevent remote access to insecure registry

### DIFF
--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -7,7 +7,7 @@ reg_port='5000'
 running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
 if [ "${running}" != 'true' ]; then
   docker run \
-    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
     registry:2
 fi
 


### PR DESCRIPTION
**Issue**

The example to use a local insecure registry in a kind cluster also exposes the registry on the local network. See https://github.com/kubernetes-sigs/kind/blob/master/site/static/examples/kind-with-registry.sh#L10

**Solution**

Limit the port publishing for the local insecure registry to localhost. The change was checked by running the following:

```
docker pull nginx
docker tag nginx localhost:5000/nginx
docker push localhost:5000/nginx
kubectl run --image=localhost:5000/nginx nginx
```