### PR TITLE
Docs docs docs

### DIFF
--- a/site/assets/css/inline.css
+++ b/site/assets/css/inline.css
@@ -370,6 +370,21 @@ blockquote p {
   height: 100%;
 }
 
+/* mock github labels */
+.gh-label {
+  /* mimic github */
+  display: inline-block;
+  padding: 0 7px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 18px;
+  border: 1px solid transparent;
+  border-radius: 2em;
+  background: #bfd4f2;
+  /* additional styling to allow using on a tags */
+  text-decoration: none;
+}
+
 /* mobile */
 @media (max-width: 50em) {
   #content {

--- a/site/content/docs/contributing/development.md
+++ b/site/content/docs/contributing/development.md
@@ -7,9 +7,9 @@ menu:
     weight: 3
 toc: true
 description: |-
-  🚧  This page is a work-in-progress  🚧
+  🚧  This is a work-in-progress  🚧
 
-  This page is intended to provide an introduction to developing kind. 
+  This page is intended to provide contributors with an introduction to developing the kind project. 
 ---
 
 ## Overview
@@ -75,7 +75,7 @@ Like other targets, these targets automatically manage the correct [`.go-version
 
 ### E2E Testing
 
-Coming soon ...
+🚧 More here coming soon ... 🚧
 
 TLDR: `hack/ci/e2e.sh` will run e2e tests against your local Kubernetes checkout.
 
@@ -101,7 +101,7 @@ Lints include:
 
 Our docs are built with [hugo] just like [kubernetes.io](https://kubernetes.io).
 We provide a makefile for development that uses hugo in docker so you don't need
-to install anything further, just `make -C site serve`.
+to install anything further, just [install docker](#install-docker).
 
 Markdown content is under `site/content/` with a structure mirroring this site.
 
@@ -112,12 +112,15 @@ pull request. A build preview will be created by netlify which you can browse by
 clicking the "details" link next to the `deploy/netlify` status at the bottom of
 your pull request on GitHub.
 
-These are also predictable as `https://deploy-preview-$PR_NUMBER--k8s-kind.netlify.app/`, just replace `$PR_NUMBER` with the nuber of your Pull Request.
+These are also predictable as `https://deploy-preview-$PR_NUMBER--k8s-kind.netlify.app/`, just replace `$PR_NUMBER` with the number of your Pull Request.
+
+For more involved site / documentation development, you can run `make -C site serve` from the kind repo to run a local instance of the documentation, browsable at [http://localhost:1313](http://localhost:1313). As mentioned previously, do this you'll need to [install docker](#install-docker).
 
 This site has a custom hugo theme under `site/layouts` & `site/assets`. It's
 mostly relatively simple but it has a few extra features:
-- The theme layout takes a `description` parameter in page frontmatter
-- We have a few useful but simple shortcodes
+- The theme layout takes a `description` parameter in page [front matter]
+  - This renders the blockquote you see just below the page title, on this page wth the text `This page is intended to provide contributors with an introduction to developing the kind project.`
+- We have a few useful but simple custom shortcodes
 
 ### Shortcodes
 
@@ -164,3 +167,4 @@ GitHub actions are configured in `.github/workflows` in the kind repo.
 [hugo]: https://gohugo.io
 [prow]: https://git.k8s.io/test-infra/
 [GitHub Actions]: https://github.com/features/actions
+[front matter]: https://gohugo.io/content-management/front-matter/

--- a/site/content/docs/contributing/getting-started.md
+++ b/site/content/docs/contributing/getting-started.md
@@ -92,21 +92,30 @@ philosphy and direction.
 Issues are tracked on GitHub. Please check [the issue tracker][issues] to see
 if there is any existing discussion or work related to your interests.
 
+In particular, if you're just getting started, you may want to look for issues
+labeled <a href="https://github.com/kubernetes-sigs/kind/labels/good%20first%20issue" class="gh-label" style="background: #7057ff; color: white">good first issue</a> or <a href="https://github.com/kubernetes-sigs/kind/labels/help%20wanted" class="gh-label" style="background: #006b75; color: white">help wanted</a> which are standard labels in the Kubernetes
+project.
+The <a href="https://github.com/kubernetes-sigs/kind/labels/help%20wanted" class="gh-label" style="background: #006b75; color: white">help wanted</a> label marks issues we're actively seeking help with while <a href="https://github.com/kubernetes-sigs/kind/labels/good%20first%20issue" class="gh-label" style="background: #7057ff; color: white">good first issue</a> is additionally applied to a subset of issues we think will be particularly good for newcomers.
+
+If you're interested in working on any of these, leave a comment to let us know!
+
 If you do not see anything, please [file a new issue][file an issue].
 
 > **NOTE**: _Please_ file an enhancement / [feature request issue][fr-issue] to discuss features before filing a PR (ideally even before writing any code), we have a lot to consider with respect to our
 > existing users and future support when accepting any new feature.
+>
 > To streamline the process, please reach out and discuss the concept and design
 > / approach ASAP so the maintainers and community can get involved early.
 
-Please reach out for bugs, feature requests, and other issues!  
+Also -- Please reach out in general for bugs, feature requests, and other issues!  
+
 The maintainers of this project are reachable via:
 
 - [Kubernetes Slack] in the [#kind] channel (most active, along with the community)
 - The issue tracker by [filing an issue][file an issue]
 - The Kubernetes [SIG-Testing][SIG-Testing] [Mailing List][SIG-Testing Mailing List]
 
-Current maintainers are [@BenTheElder] and [@munnerz] - feel free to
+Current maintainers are [@BenTheElder] and [@munnerz] -- feel free to
 reach out directly if you have any questions!
 
 See also: the Kubernetes [community page].
@@ -118,8 +127,8 @@ contributor guides, signed the CLA ... now what?
 
 If you're planning to contribute code changes, you'll want to read the [development guide] next.
 
-If you plan to contribute documentation changes, you'll specifically want to see
-the [documentation section] of the development guide.
+If you're looking to contribute documentation improvements, first: Thank you! 🎉🤗
+You'll specifically want to see the [documentation section] of the development guide.
 
 [git]: https://git-scm.com/
 [hugo]: https://gohugo.io

--- a/site/content/docs/contributing/getting-started.md
+++ b/site/content/docs/contributing/getting-started.md
@@ -152,6 +152,7 @@ You'll specifically want to see the [documentation section] of the development g
 [community page]: http://kubernetes.io/community/
 [modules]: https://github.com/golang/go/wiki/Modules
 [SIG-Testing Mailing List]: https://groups.google.com/forum/#!forum/kubernetes-sig-testing
+[CNCF]: https://www.cncf.io/
 [CNCF-cla]: https://git.k8s.io/community/CLA.md
 [fr-issue]: https://github.com/kubernetes-sigs/kind/issues/new?labels=kind%2Ffeature&template=enhancement.md
 [SIG-Testing]: https://github.com/kubernetes/community/blob/master/sig-testing/README.md

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -75,11 +75,16 @@ choco install kind
 Creating a Kubernetes cluster is as simple as `kind create cluster`.
 
 This will bootstrap a Kubernetes cluster using a pre-built
-[node image][node image] - you can find it on docker hub
-[`kindest/node`][kindest/node].
-If you desire to build the node image yourself see the
-[building image](#building-images) section.
-To specify another image use the `--image` flag.
+[node image][node image]. Prebuilt images are hosted at[`kindest/node`][kindest/node], but to find images suitable for a given release currently you should check the [release notes] for your given kind version (check with `kind version`) where
+you'll find a complete listing of images created for a kind release. 
+
+To specify another image use the `--image` flag -- `kind create cluster --image=...`.
+
+Using a different image allows you to change the Kubernetes version of the created
+cluster.
+
+If you desire to build the node image yourself with a custom version see the
+[building images](#building-images) section.
 
 By default, the cluster will be given the name `kind`.
 Use the `--name` flag to assign the cluster a different context name.
@@ -88,6 +93,8 @@ If you want the `create cluster` command to block until the control plane
 reaches a ready status, you can use the `--wait` flag and specify a timeout.
 To use `--wait` you must specify the units of the time to wait. For example, to
 wait for 30 seconds, do `--wait 30s`, for 5 minutes do `--wait 5m`, etc.
+
+More usage can be discovered with `kind create cluster --help`.
 
 ## Interacting With Your Cluster
 
@@ -421,3 +428,4 @@ kind, the Kubernetes cluster itself, etc.
 [Private Registries]: /docs/user/private-registries
 [customize control plane with kubeadm]: https://kubernetes.io/docs/setup/independent/control-plane-flags/
 [access multiple clusters]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
+[release notes]: https://github.com/kubernetes-sigs/kind/releases


### PR DESCRIPTION
- improve getting started guide with linked issue labels (e.g. help wanted)
- enhance documentation development guide
- don't point users to dockerhub for node images in quick start