### PR TITLE
Add CI for docker in Github Actions

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,86 @@
+name: Compatibility
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  images:
+    name: Node Images
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Verify
+        run: make verify
+
+      - name: Install kind from current repository
+        run: sudo make install INSTALL_DIR=/usr/local/bin
+
+      - name: Checkout Kubernetes
+        uses: actions/checkout@v2
+        with:
+          path: src/k8s.io/kubernetes
+          repository: kubernetes/kubernetes
+          ref: v1.20.0
+
+      - name: Install kubectl
+        run: |
+          curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+          chmod +x ./kubectl
+          sudo mv ./kubectl /usr/local/bin/kubectl
+
+      - name: Build kind node image from current repository
+        run: |
+          KUBE_PATH="${{ github.workspace }}/src/k8s.io/kubernetes"
+          kind build node-image --kube-root ${KUBE_PATH} --image node:test -v7
+
+      - name: Create cluster from current repository
+        run: |
+          kind create cluster --name kind-pr --wait 1m --image node:test -v7 --retain
+
+      - name: Create cluster with last stable version
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.9.0/kind-linux-amd64
+          chmod +x ./kind
+          cat <<EOF | ./kind create cluster -v7 --wait 1m --image node:test --retain --config=-
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          kubeadmConfigPatches:
+          - |
+            kind: InitConfiguration
+            nodeRegistration:
+              kubeletExtraArgs:
+                "v": "4"
+          EOF
+
+      - name: Get Cluster status
+        run: |
+          # wait network is ready
+          kubectl wait --for=condition=ready pods --namespace=kube-system -l k8s-app=kube-dns
+          kubectl get nodes -o wide
+          kubectl get pods -A
+
+      - name: Load docker image
+        run: ./kind load docker-image busybox:2
+
+      - name: Export logs
+        if: ${{ always() }}
+        run: |
+          mkdir -p /tmp/kind/logs
+          sudo kind export logs /tmp/kind/logs
+          sudo chown -R $USER:$USER /tmp/kind/logs
+
+      - name: Upload logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: kind-logs-${{ github.run_id }}
+          path: /tmp/kind/logs
+
+      - name: Delete cluster
+        run: kind delete cluster

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,95 @@
+name: Docker
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        ipFamily: [ipv4, ipv6]
+        deployment: [singleNode, multiNode]
+    env:
+      JOB_NAME: "docker-${{ matrix.deployment }}-${{ matrix.ipFamily }}"
+      IP_FAMILY: ${{ matrix.ipFamily }}
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Verify
+        run: make verify
+
+      - name: Install kind
+        run: sudo make install INSTALL_DIR=/usr/local/bin
+
+      - name: Install kubectl
+        run: |
+          curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+          chmod +x ./kubectl
+          sudo mv ./kubectl /usr/local/bin/kubectl
+
+      - name: Enable ipv4 and ipv6 forwarding
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.forwarding=1
+          sudo sysctl -w net.ipv4.ip_forward=1
+
+      - name: Create single node cluster
+        if: ${{ matrix.deployment == 'singleNode' }}
+        run: |
+          cat <<EOF | kind create cluster -v7 --wait 1m --retain --config=-
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          networking:
+            ipFamily: ${IP_FAMILY}
+          EOF
+
+      - name: Create multi node cluster
+        if: ${{ matrix.deployment == 'multiNode' }}
+        run: |
+          cat <<EOF | sudo kind create cluster -v7 --wait 1m --retain --config=-
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          networking:
+            ipFamily: ${IP_FAMILY}
+          nodes:
+          - role: control-plane
+          - role: worker
+          - role: worker
+          EOF
+
+      - name: Get Cluster status
+        run: |
+          # wait network is ready
+          sudo kubectl wait --for=condition=ready pods --namespace=kube-system -l k8s-app=kube-dns
+          sudo kubectl get nodes -o wide
+          sudo kubectl get pods -A
+
+      - name: Load docker image
+        run: kind load docker-image busybox:2
+        continue-on-error: true
+
+      - name: Export logs
+        if: always()
+        run: |
+          mkdir -p /tmp/kind/logs
+          sudo kind export logs /tmp/kind/logs
+          sudo chown -R $USER:$USER /tmp/kind/logs
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
+          path: /tmp/kind/logs
+
+      - name: Delete cluster
+        run: kind delete cluster

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -125,6 +125,24 @@ fix_cgroup() {
       mount_kubelet_cgroup_root "/kubelet" "${subsystem}"
     done
   fi
+  if [[ -z "${docker_cgroup_mounts}" ]] || [[ -z "${podman_cgroup_mounts}" ]]; then
+    while read -r subsystem; do
+      mount_kubelet_cgroup_root "/kubelet" "${subsystem}"
+    done <<EOF
+/sys/fs/cgroup/systemd
+/sys/fs/cgroup/cpu,cpuacct
+/sys/fs/cgroup/net_cls,net_prio
+/sys/fs/cgroup/cpuset
+/sys/fs/cgroup/hugetlb
+/sys/fs/cgroup/freezer
+/sys/fs/cgroup/blkio
+/sys/fs/cgroup/perf_event
+/sys/fs/cgroup/memory
+/sys/fs/cgroup/devices
+/sys/fs/cgroup/pids
+EOF
+  fi
+
 }
 
 fix_machine_id() {

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,7 +20,7 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20201130-23777eca"
+const DefaultBaseImage = "kindest/base:v20201204-49cad832"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
It also fixes a bug where the images failed to run after they were created locally

When we added `Support configuring a cgroup root for kubelet #1747` , we checked for podman or docker to remount the cgroups. However, docker in Github doesn't show docker in its cgroup path, causing that the script didn't remounted the cgroups subsystems under /kubelet, hence the `kubelet`, that is configured to use `cgroup-root: /kubelet` fails to start because there is nothing in that path.

```
grep /sys/fs/cgroup /proc/self/mountinfo | grep docker
root@kind-control-plane:/usr/local/bin# 
```


Fixes: #1969 