### PR TITLE
Move cluster name validation to Validate method

### DIFF
--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -19,7 +19,6 @@ package create
 import (
 	"fmt"
 	"math/rand"
-	"regexp"
 	"time"
 
 	"github.com/alessio/shellescape"
@@ -49,12 +48,6 @@ const (
 	clusterNameMax = 50
 )
 
-// similar to valid docker container names, but since we will prefix
-// and suffix this name, we can relax it a little
-// see NewContext() for usage
-// https://godoc.org/github.com/docker/docker/daemon/names#pkg-constants
-var validNameRE = regexp.MustCompile(`^[a-z0-9_.-]+$`)
-
 // ClusterOptions holds cluster creation options
 type ClusterOptions struct {
 	Config       *config.Cluster
@@ -83,14 +76,6 @@ func Cluster(logger log.Logger, p providers.Provider, opts *ClusterOptions) erro
 		return err
 	}
 
-	// TODO: move to config validation
-	// validate the name
-	if !validNameRE.MatchString(opts.Config.Name) {
-		return errors.Errorf(
-			"'%s' is not a valid cluster name, cluster names must match `%s`",
-			opts.Config.Name, validNameRE.String(),
-		)
-	}
 	// warn if cluster name might typically be too long
 	if len(opts.Config.Name) > clusterNameMax {
 		logger.Warnf("cluster name %q is probably too long, this might not work properly on some systems", opts.Config.Name)

--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -18,14 +18,27 @@ package config
 
 import (
 	"net"
+	"regexp"
 
 	"sigs.k8s.io/kind/pkg/errors"
 )
+
+// similar to valid docker container names, but since we will prefix
+// and suffix this name, we can relax it a little
+// see NewContext() for usage
+// https://godoc.org/github.com/docker/docker/daemon/names#pkg-constants
+var validNameRE = regexp.MustCompile(`^[a-z0-9_.-]+$`)
 
 // Validate returns a ConfigErrors with an entry for each problem
 // with the config, or nil if there are none
 func (c *Cluster) Validate() error {
 	errs := []error{}
+
+	// validate the name
+	if !validNameRE.MatchString(c.Name) {
+		errs = append(errs, errors.Errorf("'%s' is not a valid cluster name, cluster names must match `%s`",
+			c.Name, validNameRE.String()))
+	}
 
 	// the api server port only needs checking if we aren't picking a random one
 	// at runtime


### PR DESCRIPTION
Quick chore: moving the name regex parsing to `cluster.Validate()` method