### PR TITLE
Added release builder

### DIFF
--- a/pkg/build/nodeimage/internal/kube/builder.go
+++ b/pkg/build/nodeimage/internal/kube/builder.go
@@ -34,16 +34,18 @@ type Builder interface {
 // currently this includes:
 // "bazel" -> NewBazelBuilder(kubeRoot)
 // "docker" or "make" -> NewDockerBuilder(kubeRoot)
-func NewNamedBuilder(logger log.Logger, name, kubeRoot, arch string) (Builder, error) {
+func NewNamedBuilder(logger log.Logger, name, kubeRoot, releaseUrl, arch string) (Builder, error) {
 	fn, err := nameToImpl(name)
 	if err != nil {
 		return nil, err
 	}
-	return fn(logger, kubeRoot, arch)
+	return fn(logger, kubeRoot, releaseUrl, arch)
 }
 
-func nameToImpl(name string) (func(log.Logger, string, string) (Builder, error), error) {
+func nameToImpl(name string) (func(log.Logger, string, string, string) (Builder, error), error) {
 	switch name {
+	case "release":
+		return NewReleaseBuilder, nil
 	case "bazel":
 		return NewBazelBuilder, nil
 	// TODO: docker builder should be as-dockerized as possible, make builder

--- a/pkg/build/nodeimage/internal/kube/builder_bazel.go
+++ b/pkg/build/nodeimage/internal/kube/builder_bazel.go
@@ -38,7 +38,7 @@ var _ Builder = &bazelBuilder{}
 
 // NewBazelBuilder returns a new Builder backed by bazel build,
 // given kubeRoot, the path to the kubernetes source directory
-func NewBazelBuilder(logger log.Logger, kubeRoot, arch string) (Builder, error) {
+func NewBazelBuilder(logger log.Logger, kubeRoot, releaseUrl, arch string) (Builder, error) {
 	return &bazelBuilder{
 		kubeRoot: kubeRoot,
 		arch:     arch,

--- a/pkg/build/nodeimage/internal/kube/builder_docker.go
+++ b/pkg/build/nodeimage/internal/kube/builder_docker.go
@@ -41,7 +41,7 @@ var _ Builder = &dockerBuilder{}
 
 // NewDockerBuilder returns a new Bits backed by the docker-ized build,
 // given kubeRoot, the path to the kubernetes source directory
-func NewDockerBuilder(logger log.Logger, kubeRoot, arch string) (Builder, error) {
+func NewDockerBuilder(logger log.Logger, kubeRoot, releaseUrl, arch string) (Builder, error) {
 	return &dockerBuilder{
 		kubeRoot: kubeRoot,
 		arch:     arch,

--- a/pkg/build/nodeimage/internal/kube/builder_release.go
+++ b/pkg/build/nodeimage/internal/kube/builder_release.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/kind/pkg/errors"
+	"sigs.k8s.io/kind/pkg/log"
+)
+
+// releaseBuilder uses pre-built artifacts
+type releaseBuilder struct {
+	releaseUrl string
+	arch       string
+	logger     log.Logger
+}
+
+var _ Builder = &releaseBuilder{}
+
+// NewReleaseBuilder returns a new Bits from a release URL.
+func NewReleaseBuilder(logger log.Logger, kubeBase, releaseUrl, arch string) (Builder, error) {
+	return &releaseBuilder{
+		releaseUrl: releaseUrl,
+		arch:       arch,
+		logger:     logger,
+	}, nil
+}
+
+func (b *releaseBuilder) Build() (Bits, error) {
+	u, err := url.Parse(b.releaseUrl)
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing release-url")
+	}
+	sourceVersion := filepath.Base(u.EscapedPath())
+
+	tmpdir, err := ioutil.TempDir("", "kind-release-fetch")
+	if err != nil {
+		return nil, err
+	}
+	b.logger.V(10).Infof("Created tmp dir %s for release downloads", tmpdir)
+
+	binPaths, err := b.getReleaseFiles(tmpdir, u, []string{"kubeadm", "kubelet", "kubectl"})
+	if err != nil {
+		return nil, err
+	}
+
+	imagePaths, err := b.getReleaseFiles(tmpdir, u, []string{
+		"kube-apiserver.tar",
+		"kube-controller-manager.tar",
+		"kube-scheduler.tar",
+		"kube-proxy.tar",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &bits{
+		binaryPaths: binPaths,
+		imagePaths:  imagePaths,
+		version:     sourceVersion,
+	}, nil
+}
+
+func (b *releaseBuilder) getReleaseFiles(tmpdir string, baseUrl *url.URL, files []string) (paths []string, err error) {
+	for _, f := range files {
+		dlUrl := *baseUrl
+		dlUrl.Path = filepath.Join(dlUrl.Path, "bin/linux", b.arch, f)
+		dlpath := filepath.Join(tmpdir, f)
+		b.logger.V(10).Infof("Downloading %s to %s", dlUrl.String(), dlpath)
+		err = getReleaseContent(dlpath, dlUrl.String())
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, dlpath)
+	}
+	return paths, nil
+
+}
+
+func getReleaseContent(file, url string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return errors.Wrapf(err, "error getting file %s", file)
+	}
+	defer resp.Body.Close()
+
+	dst, err := os.Create(file)
+	if err != nil {
+		return errors.Wrapf(err, "error creating temporary file %s", file)
+	}
+	defer dst.Close()
+
+	_, err = io.Copy(dst, resp.Body)
+	return errors.Wrapf(err, "error writing content to %s", file)
+}

--- a/pkg/build/nodeimage/options.go
+++ b/pkg/build/nodeimage/options.go
@@ -63,6 +63,14 @@ func WithKuberoot(root string) Option {
 	})
 }
 
+// WithReleaseURL sets the release URL to fetch the necessary binaries and image tars from
+func WithReleaseURL(releaseUrl string) Option {
+	return optionAdapter(func(b *buildContext) error {
+		b.releaseUrl = releaseUrl
+		return nil
+	})
+}
+
 // WithLogger sets the logger
 func WithLogger(logger log.Logger) Option {
 	return optionAdapter(func(b *buildContext) error {

--- a/pkg/cmd/kind/build/nodeimage/nodeimage.go
+++ b/pkg/cmd/kind/build/nodeimage/nodeimage.go
@@ -26,11 +26,12 @@ import (
 )
 
 type flagpole struct {
-	Source    string
-	BuildType string
-	Image     string
-	BaseImage string
-	KubeRoot  string
+	Source     string
+	BuildType  string
+	Image      string
+	BaseImage  string
+	KubeRoot   string
+	ReleaseURL string
 }
 
 // NewCommand returns a new cobra.Command for building the node image
@@ -48,7 +49,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	}
 	cmd.Flags().StringVar(
 		&flags.BuildType, "type",
-		"docker", "build type, one of [bazel, docker]",
+		"docker", "build type, one of [bazel, docker, release]",
 	)
 	cmd.Flags().StringVar(
 		&flags.Image, "image",
@@ -56,9 +57,14 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		"name:tag of the resulting image to be built",
 	)
 	cmd.Flags().StringVar(
+		&flags.ReleaseURL, "release-url",
+		"",
+		"A Kubernetes release URL to fetch binaries and container image tars from. Only used with the release type. Ex: https://dl.k8s.io/v1.20.0",
+	)
+	cmd.Flags().StringVar(
 		&flags.KubeRoot, "kube-root",
 		"",
-		"path to the Kubernetes source directory (if empty, the path is autodetected)",
+		"path to the Kubernetes source directory (if empty, the path is autodetected). Used with bazel and docker types",
 	)
 	cmd.Flags().StringVar(
 		&flags.BaseImage, "base-image",
@@ -74,6 +80,7 @@ func runE(logger log.Logger, flags *flagpole) error {
 		nodeimage.WithImage(flags.Image),
 		nodeimage.WithBaseImage(flags.BaseImage),
 		nodeimage.WithKuberoot(flags.KubeRoot),
+		nodeimage.WithReleaseURL(flags.ReleaseURL),
 		nodeimage.WithLogger(logger),
 	); err != nil {
 		return errors.Wrap(err, "error building node image")


### PR DESCRIPTION
The release builder fetches pre-built Kubernetes artifacts for a node image from a standard upstream release URL.


**Reviewer notes**: 

* I modified the `New{Docker,Bazel,Release}Builder()` signature to include the `releaseUrl` parameter. This parameter is unused in Docker/Bazel, but the `kubeRoot` param is unused in the ReleaseBuilder. I did this to simplify the diff so that `nameToImpl` could just add `"release"` as one more item in the switch statement.  Let me know if a larger refactor is preferred.
* I did not add any tests, as the rest of the package doesn't include any. I'd be happy to add tests if desired