### PR TITLE
promote amwat, aojea to full maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,5 +8,7 @@ reviewers:
   - munnerz
   - neolit123
 approvers:
+  - amwat
+  - aojea
   - BenTheElder
   - munnerz

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The maintainers of this project are reachable via:
 - [filing an issue] against this repo
 - The Kubernetes [SIG-Testing Mailing List]
 
-Current maintainers are [@BenTheElder] and [@munnerz] - feel free to
+Current maintainers are [@BenTheElder], [@munnerz], [@aojea], and [@amwat] - feel free to
 reach out if you have any questions!
 
 Pull Requests are very welcome!  
@@ -150,6 +150,8 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [install docker]: https://docs.docker.com/install/
 [@BenTheElder]: https://github.com/BenTheElder
 [@munnerz]: https://github.com/munnerz
+[@aojea]: https://github.com/aojea
+[@amwat]: https://github.com/amwat
 [contributor guide]: https://kind.sigs.k8s.io/docs/contributing/getting-started
 [releases]: https://github.com/kubernetes-sigs/kind/releases
 [install guide]: https://kind.sigs.k8s.io/docs/user/quick-start/#installation

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -66,8 +66,8 @@ The maintainers of this project are reachable via:
 - [filing an issue] against this repo
 - The Kubernetes [SIG-Testing Mailing List]
 
-Current maintainers are [@BenTheElder] and [@munnerz] - feel free to
-reach out if you have any questions!
+Current maintainers are [@BenTheElder], [@munnerz], [@aojea], and [@amwat] -- feel free to
+reach out directly if you have any questions!
 
 Pull Requests are very welcome!  
 If you're planning a new feature, please file an issue to discuss first.
@@ -117,4 +117,6 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [install docker]: https://docs.docker.com/install/
 [@BenTheElder]: https://github.com/BenTheElder
 [@munnerz]: https://github.com/munnerz
+[@aojea]: https://github.com/aojea
+[@amwat]: https://github.com/amwat
 [contributor guide]: /docs/contributing/getting-started

--- a/site/content/docs/contributing/getting-started.md
+++ b/site/content/docs/contributing/getting-started.md
@@ -115,7 +115,7 @@ The maintainers of this project are reachable via:
 - The issue tracker by [filing an issue][file an issue]
 - The Kubernetes [SIG-Testing][SIG-Testing] [Mailing List][SIG-Testing Mailing List]
 
-Current maintainers are [@BenTheElder] and [@munnerz] -- feel free to
+Current maintainers are [@BenTheElder], [@munnerz], [@aojea], and [@amwat] -- feel free to
 reach out directly if you have any questions!
 
 See also: the Kubernetes [community page].
@@ -149,6 +149,8 @@ You'll specifically want to see the [documentation section] of the development g
 [#kind]: https://kubernetes.slack.com/messages/CEKK1KTN2/
 [@BenTheElder]: https://github.com/BenTheElder
 [@munnerz]: https://github.com/munnerz
+[@aojea]: https://github.com/aojea
+[@amwat]: https://github.com/amwat
 [community page]: http://kubernetes.io/community/
 [modules]: https://github.com/golang/go/wiki/Modules
 [SIG-Testing Mailing List]: https://groups.google.com/forum/#!forum/kubernetes-sig-testing


### PR DESCRIPTION
As discussed previously, rolling this out now ahead of v0.10.0 / going into v0.11.0, see also: https://github.com/kubernetes-sigs/kind/issues/2024 with more details.

/cc @aojea @munnerz @amwat 

Followups will be made regarding github administration, the image registry, etc.