### PR TITLE
Update link to cncf.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ See also: our own [contributor guide] and the Kubernetes [community page].
 - kind supports building Kubernetes release builds from source
   - support for make / bash / docker or bazel, in addition to pre-published builds
 - kind supports Linux, macOS and Windows
-- kind is a [CNCF certified conformant Kubernetes installer](https://landscape.cncf.io/selected=kind)
+- kind is a [CNCF certified conformant Kubernetes installer](https://landscape.cncf.io/?selected=kind)
 
 ### Code of conduct
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -83,7 +83,7 @@ See also: our own [contributor guide] and the Kubernetes [community page].
 - kind supports building Kubernetes release builds from source
   - support for make / bash / docker, or bazel, in addition to pre-published builds
 - kind supports Linux, macOS and Windows
-- kind is a [CNCF certified conformant Kubernetes installer](https://landscape.cncf.io/selected=kind)
+- kind is a [CNCF certified conformant Kubernetes installer](https://landscape.cncf.io/?selected=kind)
 
 ### Code of conduct
 


### PR DESCRIPTION
link without question mark is deprecated and results in redirects
which makes it difficult to the back button