### PR TITLE
Added SHA256 checksums to node base image downloads

### DIFF
--- a/hack/build/update-base-image-shasums.sh
+++ b/hack/build/update-base-image-shasums.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+CONTAINERD_VERSION="1.4.0-106-gce4439a8"
+
+ARCHITECTURES=(
+    "amd64"
+    "arm64"
+    "ppc64le"
+)
+
+CONTAINERD_DEFAULT_VERSION="1.4.0-106-gce4439a8"
+read -r -p "What version of containerd? (defaults to $CONTAINERD_DEFAULT_VERSION) " CONTAINERD_VERSION
+CONTAINERD_VERSION=${CONTAINERD_VERSION:-${CONTAINERD_DEFAULT_VERSION}}
+
+CNI_DEFAULT_VERSION="v0.9.0"
+read -r -p "What version of CNI? (defaults to $CNI_DEFAULT_VERSION) " CNI_VERSION
+CNI_VERSION=${CNI_VERSION:-${CNI_DEFAULT_VERSION}}
+
+CRICTL_DEFAULT_VERSION="v1.19.0"
+read -r -p "What version of crictl: (defaults to $CRICTL_DEFAULT_VERSION) " CRICTL_VERSION
+CRICTL_VERSION=${CRICTL_VERSION:-${CRICTL_DEFAULT_VERSION}}
+
+echo
+CONTAINERD_BASE_URL="https://github.com/kind-ci/containerd-nightlies/releases/download/containerd-${CONTAINERD_VERSION}"
+for ARCH in "${ARCHITECTURES[@]}"; do
+    CONTAINERD_URL="${CONTAINERD_BASE_URL}/containerd-${CONTAINERD_VERSION}.linux-${ARCH}.tar.gz.sha256sum"
+    SHASUM=$(curl -sSL --retry 5 "${CONTAINERD_URL}" | awk '{print $1}')
+    ARCH_UPPER=$(echo "$ARCH" | tr '[:lower:]' '[:upper:]')
+    echo "ARG CONTAINERD_${ARCH_UPPER}_SHA256SUM=${SHASUM}"
+done
+
+echo
+# TODO (micahhausler): Once kind-ci/containerd-nightlies adds .sha256sum files, just fetch those
+for ARCH in "${ARCHITECTURES[@]}"; do
+    RUNC_URL="${CONTAINERD_BASE_URL}/runc.${ARCH}"
+    curl -sSL --retry 5 --output "/tmp/runc.${ARCH}" "${RUNC_URL}"
+    SHASUM=$(sha256sum "/tmp/runc.${ARCH}" | awk '{print $1}')
+    ARCH_UPPER=$(echo "$ARCH" | tr '[:lower:]' '[:upper:]')
+    echo "ARG RUNC_${ARCH_UPPER}_SHA256SUM=${SHASUM}"
+    rm "/tmp/runc.${ARCH}"
+done
+
+echo
+# TODO (micahhausler): Once https://github.com/kubernetes-sigs/cri-tools/issues/716 is resolved, just fetch the sha256
+for ARCH in "${ARCHITECTURES[@]}"; do
+    CRICTL_URL="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCH}.tar.gz"
+    curl -sSL --retry 5 --output "/tmp/crictl.${ARCH}.tgz" "${CRICTL_URL}"
+    SHASUM=$(sha256sum "/tmp/crictl.${ARCH}.tgz" | awk '{print $1}')
+    ARCH_UPPER=$(echo "$ARCH" | tr '[:lower:]' '[:upper:]')
+    echo "ARG CRICTL_${ARCH_UPPER}_SHA256SUM=${SHASUM}"
+    rm "/tmp/crictl.${ARCH}.tgz"
+done
+
+echo
+for ARCH in "${ARCHITECTURES[@]}"; do
+    CNI_TARBALL="${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz"
+    CNI_URL="https://github.com/containernetworking/plugins/releases/download/${CNI_TARBALL}"
+    SHASUM=$(curl -sSL --retry 5 "${CNI_URL}.sha256" | awk '{print $1}')
+    ARCH_UPPER=$(echo "$ARCH" | tr '[:lower:]' '[:upper:]')
+    echo "ARG CNI_${ARCH_UPPER}_SHA256SUM=${SHASUM}"
+done

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -19,15 +19,41 @@
 
 # start from ubuntu 20.10, this image is reasonably small as a starting point
 # for a kubernetes node image, it doesn't contain much we don't need
-FROM ubuntu:20.10
+ARG BASE_IMAGE=ubuntu:20.10
+FROM $BASE_IMAGE
+
+# `docker buildx` automatically sets this arg value, but we add the arg for
+# regular `docker bulid` invocations to force a selection
+ARG TARGETARCH
 
 # Configure containerd and runc binaries from kind-ci/containerd-nightlies repository
 # The repository contains latest stable releases and nightlies built for multiple architectures
-ARG CONTAINERD_VERSION="v1.4.0-106-gce4439a8"
-# Configure CNI binaries
-ARG CNI_VERSION="v0.9.0"
+ARG CONTAINERD_VERSION="1.4.0-106-gce4439a8"
+ARG CONTAINERD_BASE_URL="https://github.com/kind-ci/containerd-nightlies/releases/download/containerd-${CONTAINERD_VERSION}"
+ARG CONTAINERD_URL="${CONTAINERD_BASE_URL}/containerd-${CONTAINERD_VERSION}.linux-${TARGETARCH}.tar.gz"
+ARG CONTAINERD_AMD64_SHA256SUM=69ce75857abb424b243d3442eb9d1e96a1e853595a8562c3c03ccbdaf8fd6e59
+ARG CONTAINERD_ARM64_SHA256SUM=7fc4a886466a8f0ecc80299cec03cdaca3e8b9ddf4aaa60deb9cb2b7ea0575aa
+ARG CONTAINERD_PPC64LE_SHA256SUM=6536f22c38186b3826c4841d836191254ffbbab033356faebf6635778e856dd0
+
+ARG RUNC_URL="${CONTAINERD_BASE_URL}/runc.${TARGETARCH}"
+ARG RUNC_AMD64_SHA256SUM=64c2742b89fe0364f360b816a3c72dd8f067f49761002c5f2072c1f1e76cbad7
+ARG RUNC_ARM64_SHA256SUM=91dac17a62fada7db2eb10592099f5e999e9ac1d2daf1988620656f534dee94c
+ARG RUNC_PPC64LE_SHA256SUM=3ff250698360d3953a8c153e2f715d3653c58b51ecdb156f8d4cf5f17b1ece49
+
 # Configure crictl binary from upstream
 ARG CRICTL_VERSION="v1.19.0"
+ARG CRICTL_URL="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${TARGETARCH}.tar.gz"
+ARG CRICTL_AMD64_SHA256SUM=87d8ef70b61f2fe3d8b4a48f6f712fd798c6e293ed3723c1e4bbb5052098f0ae
+ARG CRICTL_ARM64_SHA256SUM=ec040d14ca03e8e4e504a85dae5353e04b5d9d8aea3df68699258992c0eb8d88
+ARG CRICTL_PPC64LE_SHA256SUM=72107c58960ee9405829c3366dbfcd86f163a990ea2102f3ed63a709096bc7ba
+
+# Configure CNI binaries
+ARG CNI_VERSION="v0.9.0"
+ARG CNI_TARBALL="${CNI_VERSION}/cni-plugins-linux-${TARGETARCH}-${CNI_VERSION}.tgz"
+ARG CNI_URL="https://github.com/containernetworking/plugins/releases/download/${CNI_TARBALL}"
+ARG CNI_AMD64_SHA256SUM=58a58d389895ba9f9bbd3ef330f186c0bb7484136d0bfb9b50152eed55d9ec24
+ARG CNI_ARM64_SHA256SUM=49bdf1d3c852a831964aea8c9d12340b36107ee756d8328403905ff599abc6f5
+ARG CNI_PPC64LE_SHA256SUM=d37829b5eeca0c941b4478203c75c6cc26d9cfc1d6c8bb451c0008e0c02a025f
 
 # copy in static files (configs, scripts)
 COPY files/ /
@@ -79,32 +105,47 @@ RUN echo "Ensuring scripts are executable ..." \
     && rm -f /lib/systemd/system/basic.target.wants/* \
     && echo "ReadKMsg=no" >> /etc/systemd/journald.conf \
     && ln -s "$(which systemd)" /sbin/init \
-    && export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') \
  && echo "Enabling kubelet ... " \
     && systemctl enable kubelet.service \
  && echo "Installing containerd ..." \
-    && export CONTAINERD_BASE_URL="https://github.com/kind-ci/containerd-nightlies/releases/download/containerd-${CONTAINERD_VERSION#v}" \
-    && curl -sSL --retry 5 --output /tmp/containerd.tgz "${CONTAINERD_BASE_URL}/containerd-${CONTAINERD_VERSION#v}.linux-${ARCH}.tar.gz" \
-    && tar -C /usr/local -xzvf /tmp/containerd.tgz \
-    && rm -rf /tmp/containerd.tgz \
+    && curl -sSL --retry 5 --output /tmp/containerd.${TARGETARCH}.tgz "${CONTAINERD_URL}" \
+    && echo "${CONTAINERD_AMD64_SHA256SUM}  /tmp/containerd.amd64.tgz" | tee /tmp/containerd.sha256 \
+    && echo "${CONTAINERD_ARM64_SHA256SUM}  /tmp/containerd.arm64.tgz" | tee -a /tmp/containerd.sha256 \
+    && echo "${CONTAINERD_PPC64LE_SHA256SUM}  /tmp/containerd.ppc64le.tgz" | tee -a /tmp/containerd.sha256 \
+    && sha256sum --ignore-missing -c /tmp/containerd.sha256 \
+    && rm -f /tmp/containerd.sha256 \
+    && tar -C /usr/local -xzvf /tmp/containerd.${TARGETARCH}.tgz \
+    && rm -rf /tmp/containerd.${TARGETARCH}.tgz \
     && rm -f /usr/local/bin/containerd-stress /usr/local/bin/containerd-shim-runc-v1 \
-    && curl -sSL --retry 5 --output /usr/local/sbin/runc "${CONTAINERD_BASE_URL}/runc.${ARCH}" \
+    && curl -sSL --retry 5 --output /tmp/runc.${TARGETARCH} "${RUNC_URL}" \
+    && echo "${RUNC_AMD64_SHA256SUM}  /tmp/runc.amd64" | tee /tmp/runc.sha256 \
+    && echo "${RUNC_ARM64_SHA256SUM}  /tmp/runc.arm64" | tee -a /tmp/runc.sha256 \
+    && echo "${RUNC_PPC64LE_SHA256SUM}  /tmp/runc.ppc64le" | tee -a /tmp/runc.sha256 \
+    && sha256sum --ignore-missing -c /tmp/runc.sha256 \
+    && mv /tmp/runc.${TARGETARCH} /usr/local/sbin/runc \
     && chmod 755 /usr/local/sbin/runc \
     && containerd --version \
     && runc --version \
     && systemctl enable containerd \
  && echo "Installing crictl ..." \
-    && export CRICTL_URL="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCH}.tar.gz" \
-    && curl -sSL --retry 5 --output /tmp/crictl.tgz "${CRICTL_URL}" \
-    && tar -C /usr/local/bin -xzvf /tmp/crictl.tgz \
-    && rm -rf /tmp/crictl.tgz \
+    && curl -sSL --retry 5 --output /tmp/crictl.${TARGETARCH}.tgz "${CRICTL_URL}" \
+    && echo "${CRICTL_AMD64_SHA256SUM}  /tmp/crictl.amd64.tgz" | tee /tmp/crictl.sha256 \
+    && echo "${CRICTL_ARM64_SHA256SUM}  /tmp/crictl.arm64.tgz" | tee -a /tmp/crictl.sha256 \
+    && echo "${CRICTL_PPC64LE_SHA256SUM}  /tmp/crictl.ppc64le.tgz" | tee -a /tmp/crictl.sha256 \
+    && sha256sum --ignore-missing -c /tmp/crictl.sha256 \
+    && rm -f /tmp/crictl.sha256 \
+    && tar -C /usr/local/bin -xzvf /tmp/crictl.${TARGETARCH}.tgz \
+    && rm -rf /tmp/crictl.${TARGETARCH}.tgz \
  && echo "Installing CNI binaries ..." \
-    && export CNI_TARBALL="${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz" \
-    && export CNI_URL="https://github.com/containernetworking/plugins/releases/download/${CNI_TARBALL}" \
-    && curl -sSL --retry 5 --output /tmp/cni.tgz "${CNI_URL}" \
+    && curl -sSL --retry 5 --output /tmp/cni.${TARGETARCH}.tgz "${CNI_URL}" \
+    && echo "${CNI_AMD64_SHA256SUM}  /tmp/cni.amd64.tgz" | tee /tmp/cni.sha256 \
+    && echo "${CNI_ARM64_SHA256SUM}  /tmp/cni.arm64.tgz" | tee -a /tmp/cni.sha256 \
+    && echo "${CNI_PPC64LE_SHA256SUM}  /tmp/cni.ppc64le.tgz" | tee -a /tmp/cni.sha256 \
+    && sha256sum --ignore-missing -c /tmp/cni.sha256 \
+    && rm -f /tmp/cni.sha256 \
     && mkdir -p /opt/cni/bin \
-    && tar -C /opt/cni/bin -xzvf /tmp/cni.tgz \
-    && rm -rf /tmp/cni.tgz \
+    && tar -C /opt/cni/bin -xzvf /tmp/cni.${TARGETARCH}.tgz \
+    && rm -rf /tmp/cni.${TARGETARCH}.tgz \
     && find /opt/cni/bin -type f -not \( \
          -iname host-local \
          -o -iname ptp \

--- a/images/base/README.md
+++ b/images/base/README.md
@@ -7,14 +7,53 @@ The image can be built with `make quick`.
 
 ## Maintenance
 
-This image needs to do a number of unusual things to support running systemd, 
-nested containers, and Kubernetes. All of what we do and why we do it 
+This image needs to do a number of unusual things to support running systemd,
+nested containers, and Kubernetes. All of what we do and why we do it
 is documented inline in the [Dockerfile](./Dockerfile).
 
-If you make any changes to this image, please continue to document exactly 
+If you make any changes to this image, please continue to document exactly
 why we do what we do, citing upstream documentation where possible.
 
 See also [`pkg/cluster`](./../../pkg/cluster) for logic that interacts with this image.
+
+## Updating dependencies
+
+If you need to change a version of containerd, crictl, or CNI, you can use the
+provided script `/hack/build/update-base-image-shasums.sh` to specify the
+versions and generate the Dockerfile `ARG` values for you. The script will fetch
+the sha256sums from GitHub releases, or will download the artifact and generate
+a sha256sum.
+
+```
+$ hack/build/update-base-image-shasums.sh
+What version of containerd? (defaults to 1.4.0-106-gce4439a8)
+What version of CNI? (defaults to v0.9.0)
+What version of crictl: (defaults to v1.19.0)
+
+ARG CONTAINERD_AMD64_SHA256SUM=69ce75857abb424b243d3442eb9d1e96a1e853595a8562c3c03ccbdaf8fd6e59
+ARG CONTAINERD_ARM64_SHA256SUM=7fc4a886466a8f0ecc80299cec03cdaca3e8b9ddf4aaa60deb9cb2b7ea0575aa
+ARG CONTAINERD_PPC64LE_SHA256SUM=6536f22c38186b3826c4841d836191254ffbbab033356faebf6635778e856dd0
+
+ARG RUNC_AMD64_SHA256SUM=64c2742b89fe0364f360b816a3c72dd8f067f49761002c5f2072c1f1e76cbad7
+ARG RUNC_ARM64_SHA256SUM=91dac17a62fada7db2eb10592099f5e999e9ac1d2daf1988620656f534dee94c
+ARG RUNC_PPC64LE_SHA256SUM=3ff250698360d3953a8c153e2f715d3653c58b51ecdb156f8d4cf5f17b1ece49
+
+ARG CRICTL_AMD64_SHA256SUM=87d8ef70b61f2fe3d8b4a48f6f712fd798c6e293ed3723c1e4bbb5052098f0ae
+ARG CRICTL_ARM64_SHA256SUM=ec040d14ca03e8e4e504a85dae5353e04b5d9d8aea3df68699258992c0eb8d88
+ARG CRICTL_PPC64LE_SHA256SUM=72107c58960ee9405829c3366dbfcd86f163a990ea2102f3ed63a709096bc7ba
+
+ARG CNI_AMD64_SHA256SUM=58a58d389895ba9f9bbd3ef330f186c0bb7484136d0bfb9b50152eed55d9ec24
+ARG CNI_ARM64_SHA256SUM=49bdf1d3c852a831964aea8c9d12340b36107ee756d8328403905ff599abc6f5
+ARG CNI_PPC64LE_SHA256SUM=d37829b5eeca0c941b4478203c75c6cc26d9cfc1d6c8bb451c0008e0c02a025f
+```
+
+## Alternate Sources
+
+Kind frequently picks up new releases of dependent projects including
+containerd, runc, cni, and crictl. If you choose to use the provided Dockerfile
+but use build arguments to specify a different base image or application version
+for dependencies, be aware that you may possibly encounter bugs and undesired
+behavior.
 
 ## Design
 


### PR DESCRIPTION
Resolves #2030

* Add checksums and verification to base node image Dockerfile
* Add script to generate checksums Dockerfile args for new version

I ran `make build` locally and all 3 architectures built successfully. I did not build kind clusters with these images, but there aren't any functional changes to test.

If builders were relying on a configurable `CONTAINERD_VERSION` build arg and expecting the tag to include a `v` prefix, they'll need to drop the `v`. Docker build args don't perform bash variable manipulation (ex: `${CONTAINERD_VERSION#v}`).

The kind-ci/containerd-nightlies build artifacts did not contain sha256 checksums for `runc`, so I used the checksums from a download I did myself.  Would generating checksums for `runc` that require a change in the github action file in kind-ci/containerd-nightlies?

Other than that, consumers will not see any difference with this change.