### PR TITLE
allow to load container images from stdin

### DIFF
--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -93,8 +93,9 @@ jobs:
 
         # TODO: implement this
       - name: Load docker image
-        run: sudo KIND_EXPERIMENTAL_PROVIDER=podman kind load docker-image busybox:2
-        continue-on-error: true
+        run: |
+          podman pull busybox
+          podman save busybox | sudo KIND_EXPERIMENTAL_PROVIDER=podman kind load image-archive -
 
       - name: Export logs
         if: always()


### PR DESCRIPTION
add the option to pipe files to the kind load image-archive,
specifying "-" as the archive name.

This allows the users to load any kind of images using the common
container providers export tools, i.e. podman and docker save, or
 more specialized tools like skopeo.

Fixes: https://github.com/kubernetes-sigs/kind/issues/2038