### PR TITLE
kindnetd don't wait for kube-proxy

### DIFF
--- a/images/kindnetd/Dockerfile
+++ b/images/kindnetd/Dockerfile
@@ -17,7 +17,7 @@
 FROM golang:1.13
 WORKDIR /go/src
 # make deps fetching cacheable
-COPY go.mod go.sum .
+COPY go.mod go.sum ./
 RUN go mod download
 # build
 COPY . .

--- a/images/kindnetd/Dockerfile
+++ b/images/kindnetd/Dockerfile
@@ -24,6 +24,6 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o ./kindnetd ./cmd/kindnetd
 
 # build real kindnetd image
-FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.3.0
+FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.5.0
 COPY --from=0 --chown=root:root ./go/src/kindnetd /bin/kindnetd
 CMD ["/bin/kindnetd"]

--- a/images/kindnetd/README.md
+++ b/images/kindnetd/README.md
@@ -12,9 +12,9 @@ We use this to implement KIND's standard CNI / cluster networking configuration.
 
 ## Building
 
-cd to this directory on mac / linux with docker installed and run `./build.sh`.
+cd to this directory on mac / linux with docker installed and run `make quick`.
 
-To push an image run `./push-cross.sh`.
+To push an image run `make push`.
 
 [ptp]: https://github.com/containernetworking/plugins/tree/master/plugins/main/ptp/README.md
 [host-local]: https://github.com/containernetworking/plugins/blob/master/plugins/ipam/host-local/README.md

--- a/images/kindnetd/cmd/kindnetd/main.go
+++ b/images/kindnetd/cmd/kindnetd/main.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"os"
+	"syscall"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,7 +30,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/net"
+	utilsnet "k8s.io/utils/net"
+)
+
+const (
+	probeTCPtimeout = 1 * time.Second
 )
 
 // kindnetd is a simple networking daemon to complete kind's CNI implementation
@@ -40,6 +46,7 @@ import (
 // - HOST_IP: should be populated by downward API
 // - POD_IP: should be populated by downward API
 // - CNI_CONFIG_TEMPLATE: the cni .conflist template, run with {{ .PodCIDR }}
+// - CONTROL_PLANE_ENDPOINT: control-plane endpoint format host:port
 
 // TODO: improve logging & error handling
 
@@ -54,10 +61,31 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
+
+	// override the internal apiserver endpoint to avoid
+	// waiting for kube-proxy to install the services rules.
+	// If the endpoint is not reachable, fallback the internal endpoint
+	controlPlaneEndpoint := os.Getenv("CONTROL_PLANE_ENDPOINT")
+	if controlPlaneEndpoint != "" {
+		// check that the apiserver is reachable before continue
+		// to fail fast and avoid waiting until the client operations timeout
+		var ok bool
+		for i := 0; i < 5; i++ {
+			ok = probeTCP(controlPlaneEndpoint, probeTCPtimeout)
+			if ok {
+				config.Host = "https://" + controlPlaneEndpoint
+				break
+			}
+			klog.Infof("apiserver not reachable, attempt %d ... retrying", i)
+			time.Sleep(time.Second * time.Duration(i))
+		}
+	}
+	// create the clientset to connect the apiserver
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		panic(err.Error())
 	}
+	klog.Infof("connected to apiserver: %s", config.Host)
 
 	// obtain the host and pod ip addresses
 	// if both ips are different we are not using the host network
@@ -83,7 +111,7 @@ func main() {
 
 	// enforce ip masquerade rules
 	// TODO: dual stack...?
-	masqAgent, err := NewIPMasqAgent(net.IsIPv6String(hostIP), []string{os.Getenv("POD_SUBNET")})
+	masqAgent, err := NewIPMasqAgent(utilsnet.IsIPv6String(hostIP), []string{os.Getenv("POD_SUBNET")})
 	if err != nil {
 		panic(err.Error())
 	}
@@ -193,4 +221,33 @@ func internalIP(node corev1.Node) string {
 		}
 	}
 	return ""
+}
+
+// Modified from agnhost connect command in k/k
+// https://github.com/kubernetes/kubernetes/blob/c241a237f9a635286c76c20d07b103a663b1cfa4/test/images/agnhost/connect/connect.go#L66
+func probeTCP(address string, timeout time.Duration) bool {
+	klog.Infof("probe TCP address %s", address)
+	if _, err := net.ResolveTCPAddr("tcp", address); err != nil {
+		klog.Warningf("DNS problem %s: %v", address, err)
+		return false
+	}
+
+	conn, err := net.DialTimeout("tcp", address, timeout)
+	if err == nil {
+		conn.Close()
+		return true
+	}
+	if opErr, ok := err.(*net.OpError); ok {
+		if opErr.Timeout() {
+			klog.Warningf("TIMEOUT %s", address)
+		} else if syscallErr, ok := opErr.Err.(*os.SyscallError); ok {
+			if syscallErr.Err == syscall.ECONNREFUSED {
+				klog.Warningf("REFUSED %s", address)
+			}
+		}
+		return false
+	}
+
+	klog.Warningf("OTHER %s: %v", address, err)
+	return false
 }

--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -22,9 +22,11 @@ The default CNI manifest and images are our own tiny kindnet
 
 var defaultCNIImages = []string{"kindest/kindnetd:v20210119-d5ef916d"}
 
+// TODO: migrate to fully patching and deprecate the template
 const defaultCNIManifest = `
 # kindnetd networking manifest
 # would you kindly template this file
+# would you kindly patch this file
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -20,7 +20,7 @@ package nodeimage
 The default CNI manifest and images are our own tiny kindnet
 */
 
-var defaultCNIImages = []string{"kindest/kindnetd:v20210119-d5ef916d"}
+var defaultCNIImages = []string{"kindest/kindnetd:v20210220-5b7e6d01"}
 
 // TODO: migrate to fully patching and deprecate the template
 const defaultCNIManifest = `
@@ -95,7 +95,7 @@ spec:
       serviceAccountName: kindnet
       containers:
       - name: kindnet-cni
-        image: kindest/kindnetd:v20210119-d5ef916d
+        image: kindest/kindnetd:v20210220-5b7e6d01
         env:
         - name: HOST_IP
           valueFrom:


### PR DESCRIPTION
We can override the apiserver address used for incluster config, that is the service address, with the internal apiserver address, so we don´t have to wait for  kube-proxy to install the iptables//ipvs rules 