### PR TITLE
explicitly opt nodes out of tini

### DIFF
--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -183,6 +183,9 @@ func commonArgs(cluster string, cfg *config.Cluster, networkName string, nodeNam
 		// however this _actually_ means the same thing as always
 		// so the closest thing is on-failure:1, which will retry *once*
 		"--restart=on-failure:1",
+		// this can be enabled by default in docker daemon.json, so we explicitly
+		// disable it, we want our entrypoint to be PID1, not docker-init / tini
+		"--init=false",
 	}
 
 	// enable IPv6 if necessary


### PR DESCRIPTION
fixes the problem documented in https://github.com/kubernetes-sigs/kind/pull/2028