### PR TITLE
Fix init-buildx.sh

### DIFF
--- a/hack/build/init-buildx.sh
+++ b/hack/build/init-buildx.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 #!/usr/bin/env bash
 # Copyright 2020 The Kubernetes Authors.
 #


### PR DESCRIPTION
The first bash being overwritten does not work, just leave one.
See discussion for details: [bash compare](https://stackoverflow.com/questions/16365130/what-is-the-difference-between-usr-bin-env-bash-and-usr-bin-bash)