### PR TITLE
switch ci runners to ubuntu 20.04

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   docker:
     name: Docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   podman:
     name: Podman
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Setup podman
         run: |
           podman version
+          # podman requires dnsmasq for custom networks
+          # https://github.com/actions/virtual-environments/issues/2708
+          sudo apt-get -y install dnsmasq
 
       - name: Create single node cluster
         if: ${{ matrix.deployment == 'singleNode' }}


### PR DESCRIPTION
instead of depending on the ubuntnu-latest tag used by Github, we can specify the version directly so we have more control on the CI environment