### PR TITLE
Ship Stargz Snapshotter

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -67,6 +67,15 @@ ARG CONTAINERD_FUSE_OVERLAYFS_ARM64_SHA256SUM="68ef0896f3d5c0af73ad3d13b1b9a27f9
 ARG CONTAINERD_FUSE_OVERLAYFS_PPC64LE_SHA256SUM="49679827fa2b46dd28899bdc53c2926e83f42d305ad7ee31aeaf50dbb774a840"
 ARG CONTAINERD_FUSE_OVERLAYFS_S390X_SHA256SUM="ed74e26de3215a62154b47be67953a25a15e02f7a8550408fec541d6799bc7ad"
 
+# Configure stargz-snapshotter binary from upstream
+ARG STARGZ_SNAPSHOTTER_VERSION="v0.11.1"
+ARG STARGZ_SNAPSHOTTER_BASE_URL="https://github.com/containerd/stargz-snapshotter/releases/download/${STARGZ_SNAPSHOTTER_VERSION}"
+ARG STARGZ_SNAPSHOTTER_URL="${STARGZ_SNAPSHOTTER_BASE_URL}/stargz-snapshotter-${STARGZ_SNAPSHOTTER_VERSION}-linux-${TARGETARCH}.tar.gz"
+ARG STARGZ_SNAPSHOTTER_AMD64_SHA256SUM="f958a77b9cc639620af78208b34213fbd17fe28699708a7d3a9c7862025a7a4c"
+ARG STARGZ_SNAPSHOTTER_ARM64_SHA256SUM="37559fc5b62757ae148efed1070c319ad0323aae91a1d83edce1e157644e29ea"
+ARG STARGZ_SNAPSHOTTER_PPC64LE_SHA256SUM="5a8641b1cae0b3096a6104e4831e7ae5a4ed9d7f293bf45f13e9c5f3c048af9e"
+ARG STARGZ_SNAPSHOTTER_S390X_SHA256SUM="ca0a166e3475d3e9e0880e3018a39d68a77de6f21523d9a95eeb31bdbec7c715"
+
 # copy in static files
 # all scripts are 0755 (rwx r-x r-x)
 COPY --chmod=0755 files/usr/local/bin/* /usr/local/bin/
@@ -74,6 +83,7 @@ COPY --chmod=0755 files/usr/local/bin/* /usr/local/bin/
 # all configs are 0644 (rw- r-- r--)
 COPY --chmod=0644 files/etc/* /etc/
 COPY --chmod=0644 files/etc/containerd/* /etc/containerd/
+COPY --chmod=0644 files/etc/containerd-stargz-grpc/* /etc/containerd-stargz-grpc/
 COPY --chmod=0644 files/etc/default/* /etc/default/
 COPY --chmod=0644 files/etc/sysctl.d/* /etc/sysctl.d/
 COPY --chmod=0644 files/etc/systemd/system/* /etc/systemd/system/
@@ -115,7 +125,7 @@ RUN echo "Installing Packages ..." \
       conntrack iptables iproute2 ethtool socat util-linux mount ebtables kmod \
       libseccomp2 pigz \
       bash ca-certificates curl rsync \
-      nfs-common fuse-overlayfs \
+      nfs-common fuse-overlayfs fuse3 \
       jq \
     && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-tmpfiles-setup.service" -delete \
     && rm -f /lib/systemd/system/multi-user.target.wants/* \
@@ -197,6 +207,18 @@ RUN echo "Installing containerd-fuse-overlayfs ..." \
     && rm -f /tmp/containerd-fuse-overlayfs.sha256 \
     && tar -C /usr/local/bin -xzvf /tmp/containerd-fuse-overlayfs.${TARGETARCH}.tgz \
     && rm -rf /tmp/containerd-fuse-overlayfs.${TARGETARCH}.tgz
+
+RUN echo "Installing stargz-snapshotter ..." \
+    && curl -sSL --retry 5 --output /tmp/stargz-snapshotter.${TARGETARCH}.tgz "${STARGZ_SNAPSHOTTER_URL}" \
+    && echo "${STARGZ_SNAPSHOTTER_AMD64_SHA256SUM}  /tmp/stargz-snapshotter.amd64.tgz" | tee /tmp/stargz-snapshotter.sha256 \
+    && echo "${STARGZ_SNAPSHOTTER_ARM64_SHA256SUM}  /tmp/stargz-snapshotter.arm64.tgz" | tee -a /tmp/stargz-snapshotter.sha256 \
+    && echo "${STARGZ_SNAPSHOTTER_PPC64LE_SHA256SUM}  /tmp/stargz-snapshotter.ppc64le.tgz" | tee -a /tmp/stargz-snapshotter.sha256 \
+    && echo "${STARGZ_SNAPSHOTTER_S390X_SHA256SUM}  /tmp/stargz-snapshotter.s390x.tgz" | tee -a /tmp/stargz-snapshotter.sha256 \
+    && sha256sum --ignore-missing -c /tmp/stargz-snapshotter.sha256 \
+    && rm -f /tmp/stargz-snapshotter.sha256 \
+    && tar -C /usr/local/bin/ -xzvf /tmp/stargz-snapshotter.${TARGETARCH}.tgz containerd-stargz-grpc \
+    && rm -f /tmp/stargz-snapshotter.${TARGETARCH}.tgz \
+    && containerd-stargz-grpc --version
 
 RUN echo "Ensuring /etc/kubernetes/manifests" \
     && mkdir -p /etc/kubernetes/manifests

--- a/images/base/files/etc/containerd-stargz-grpc/config.toml
+++ b/images/base/files/etc/containerd-stargz-grpc/config.toml
@@ -1,0 +1,3 @@
+[cri_keychain]
+enable_keychain = true
+image_service_path = "/run/containerd/containerd.sock"

--- a/images/base/files/etc/containerd/config.toml
+++ b/images/base/files/etc/containerd/config.toml
@@ -6,12 +6,18 @@ version = 2
 [proxy_plugins."fuse-overlayfs"]
   type = "snapshot"
   address = "/run/containerd-fuse-overlayfs.sock"
+# stargz is used for lazy pulling
+[proxy_plugins.stargz]
+  type = "snapshot"
+  address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
 
 [plugins."io.containerd.grpc.v1.cri".containerd]
   # save disk space when using a single snapshotter
   discard_unpacked_layers = true
   # explicitly use default snapshotter so we can sed it in entrypoint
   snapshotter = "overlayfs"
+  # pass additional snapshotter labels to remote snapshotter
+  disable_snapshot_annotations = false
   # explicit default here, as we're configuring it below
   default_runtime_name = "runc"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]

--- a/images/base/files/etc/systemd/system/stargz-snapshotter.service
+++ b/images/base/files/etc/systemd/system/stargz-snapshotter.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Stargz Snapshotter
+PartOf=containerd.service
+
+[Service]
+Environment=HOME=/root
+ExecStart=/usr/local/bin/containerd-stargz-grpc --config=/etc/containerd-stargz-grpc/config.toml
+Type=notify
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -113,6 +113,13 @@ configure_containerd() {
     if [[ "$snapshotter" = "fuse-overlayfs" ]]; then
       echo 'INFO: enabling containerd-fuse-overlayfs service'
       systemctl enable containerd-fuse-overlayfs
+    elif [[ "$snapshotter" = "stargz" ]]; then
+      echo 'INFO: enabling stargz-snapshotter service'
+      # start stargz-snapshotter service and allow it to proxy CRI image service
+      # so that the snapshotter can handle registry auth for snapshots
+      sed -i -E 's|KUBELET_EXTRA_ARGS=(.*)|KUBELET_EXTRA_ARGS=\1 --image-service-endpoint=unix:///run/containerd-stargz-grpc/containerd-stargz-grpc.sock|' /etc/default/kubelet
+      echo "image-endpoint: unix:///run/containerd-stargz-grpc/containerd-stargz-grpc.sock" >> /etc/crictl.yaml
+      systemctl enable stargz-snapshotter
     fi
   fi
 }

--- a/images/base/update-shasums.sh
+++ b/images/base/update-shasums.sh
@@ -23,6 +23,7 @@ CONTAINERD_VERSION="$(sed -n 's/ARG CONTAINERD_VERSION="\(.*\)"/\1/p' ./images/b
 CNI_PLUGINS_VERSION="$(sed -n 's/ARG CNI_PLUGINS_VERSION="\(.*\)"/\1/p' ./images/base/Dockerfile)"
 CRICTL_VERSION="$(sed -n 's/ARG CRICTL_VERSION="\(.*\)"/\1/p' ./images/base/Dockerfile)"
 CONTAINERD_FUSE_OVERLAYFS_VERSION="$(sed -n 's/ARG CONTAINERD_FUSE_OVERLAYFS_VERSION="\(.*\)"/\1/p' ./images/base/Dockerfile)"
+STARGZ_SNAPSHOTTER_VERSION="$(sed -n 's/ARG STARGZ_SNAPSHOTTER_VERSION="\(.*\)"/\1/p' ./images/base/Dockerfile)"
 
 # darwin is great
 SED="sed"
@@ -88,4 +89,14 @@ for ARCH in "${ARCHITECTURES[@]}"; do
     ARCH_UPPER=$(echo "$ARCH" | tr '[:lower:]' '[:upper:]')
     echo "ARG CONTAINERD_FUSE_OVERLAYFS_${ARCH_UPPER}_SHA256SUM=${SHASUM}"
     $SED -i 's/ARG CONTAINERD_FUSE_OVERLAYFS_'"${ARCH_UPPER}"'_SHA256SUM=.*/ARG CONTAINERD_FUSE_OVERLAYFS_'"${ARCH_UPPER}"'_SHA256SUM="'"${SHASUM}"'"/' ./images/base/Dockerfile
+done
+
+echo
+STARGZ_SNAPSHOTTER_BASE_URL="https://github.com/containerd/stargz-snapshotter/releases/download/${STARGZ_SNAPSHOTTER_VERSION}"
+for ARCH in "${ARCHITECTURES[@]}"; do
+    STARGZ_SNAPSHOTTER_URL="${STARGZ_SNAPSHOTTER_BASE_URL}/stargz-snapshotter-${STARGZ_SNAPSHOTTER_VERSION}-linux-${ARCH}.tar.gz.sha256sum"
+    SHASUM=$(curl -sSL --retry 5 "${STARGZ_SNAPSHOTTER_URL}" | awk '{print $1}')
+    ARCH_UPPER=$(echo "$ARCH" | tr '[:lower:]' '[:upper:]')
+    echo "ARG STARGZ_SNAPSHOTTER_${ARCH_UPPER}_SHA256SUM=${SHASUM}"
+    $SED -i 's/ARG STARGZ_SNAPSHOTTER_'"${ARCH_UPPER}"'_SHA256SUM=.*/ARG STARGZ_SNAPSHOTTER_'"${ARCH_UPPER}"'_SHA256SUM="'"${SHASUM}"'"/' ./images/base/Dockerfile
 done


### PR DESCRIPTION
#1981

This commit adds stargz snapshotter to kind.

Stargz snapshotter can be enabled by using `KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER=stargz` environment variable. This envvar is propagated to each node container and the entrypoint script modifies `/etc/containerd/config.toml` for stargz snapshotter and enables stargz snapshotter systemd service.

~~For enabling private registry authentication, stargz snapshotter requires kubeconfig that has `watch` and `list` access to secrets on the cluster's API server. So when `KIND_CONTAINERD_SNAPSHOTTER=stargz`, `kind create cluster` creates a service account that has these permissions and distributes the kubeconfig that contains the [service account token](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens) to all nodes.~~ 
Since v0.6.1, additional kubeconfig is no longer needed for registry authentication because snapshotter aquires creds through CRI (https://github.com/containerd/stargz-snapshotter/pull/323).

## How to test

- base image built from this PR is available on: ghcr.io/ktock/kind-base:bda5c8b9
- node image built from this PR is available on: ghcr.io/ktock/kind-node:bda5c8b9

```
$ KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER=stargz kind create cluster --image ghcr.io/ktock/kind-node:bda5c8b9
```

Layers are mounted as FUSE instead of downloaded from the registry.

```
$ kubectl run test --restart=Never -it --image=ghcr.io/stargz-containers/python:3.7-esgz -- echo "hello"
$ docker exec kind-control-plane mount | grep "stargz on"
stargz on /var/lib/containerd-stargz-grpc/snapshotter/snapshots/51/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
stargz on /var/lib/containerd-stargz-grpc/snapshotter/snapshots/52/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
stargz on /var/lib/containerd-stargz-grpc/snapshotter/snapshots/53/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
stargz on /var/lib/containerd-stargz-grpc/snapshotter/snapshots/54/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
stargz on /var/lib/containerd-stargz-grpc/snapshotter/snapshots/55/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
stargz on /var/lib/containerd-stargz-grpc/snapshotter/snapshots/56/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
stargz on /var/lib/containerd-stargz-grpc/snapshotter/snapshots/57/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
stargz on /var/lib/containerd-stargz-grpc/snapshotter/snapshots/58/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
stargz on /var/lib/containerd-stargz-grpc/snapshotter/snapshots/59/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
```

## Image size comparison

### additions by this PR

- base image
  - `containerd-stargz-grpc` (stargz snapshotter binary, v0.8.0) around 39 MB
  - fuse3 around 1 MB including deps (https://packages.ubuntu.com/focal/fuse3)
  - negligable static file changes
    - /etc/systemd/system/stargz-snapshotter.service
    - added few lines to /usr/local/bin/entrypoint
    - added few lines to /etc/containerd/config.toml

### size comparison with the `main` (f8e6aa66) and this PR (bda5c8b9) (around 39 MB addition)

**base image**

|version|image|size|
---|---|---
|main|ghcr.io/ktock/kind-base:f8e6aa66|around 279 MB
|this PR|ghcr.io/ktock/kind-base:bda5c8b9|around 318 MB|

**node image**

|version|image|size|
---|---|---
|main|ghcr.io/ktock/kind-node:f8e6aa66|around 1091 MB|
|this PR|ghcr.io/ktock/kind-node:bda5c8b9|around 1130 MB|
