### PR TITLE
Add possibility to disable kube-proxy

### DIFF
--- a/pkg/apis/config/v1alpha4/default.go
+++ b/pkg/apis/config/v1alpha4/default.go
@@ -68,7 +68,7 @@ func SetDefaultsCluster(obj *Cluster) {
 	}
 	// default the KubeProxyMode using iptables as it's already the default
 	if obj.Networking.KubeProxyMode == "" {
-		obj.Networking.KubeProxyMode = IPTablesMode
+		obj.Networking.KubeProxyMode = IPTablesProxyMode
 	}
 }
 

--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -202,10 +202,10 @@ const (
 type ProxyMode string
 
 const (
-	// IPTablesMode sets ProxyMode to iptables
-	IPTablesMode ProxyMode = "iptables"
-	// IPVSMode sets ProxyMode to iptables
-	IPVSMode ProxyMode = "ipvs"
+	// IPTablesProxyMode sets ProxyMode to iptables
+	IPTablesProxyMode ProxyMode = "iptables"
+	// IPVSProxyMode sets ProxyMode to iptables
+	IPVSProxyMode ProxyMode = "ipvs"
 )
 
 // PatchJSON6902 represents an inline kustomize json 6902 patch

--- a/pkg/cluster/internal/create/actions/kubeadminit/init.go
+++ b/pkg/cluster/internal/create/actions/kubeadminit/init.go
@@ -26,16 +26,19 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
 
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions"
+	"sigs.k8s.io/kind/pkg/internal/apis/config"
 )
 
 // kubeadmInitAction implements action for executing the kubeadm init
 // and a set of default post init operations like e.g. install the
 // CNI network plugin.
-type action struct{}
+type action struct {
+	skipKubeProxy bool
+}
 
 // NewAction returns a new action for kubeadm init
-func NewAction() actions.Action {
-	return &action{}
+func NewAction(cfg *config.Cluster) actions.Action {
+	return &action{skipKubeProxy: cfg.Networking.KubeProxyMode == config.NoneMode}
 }
 
 // Execute runs the action
@@ -56,13 +59,18 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		return err
 	}
 
+	// skip preflight checks, as these have undesirable side effects
+	// and don't tell us much. requires kubeadm 1.13+
+	skipPhases := "preflight"
+	if a.skipKubeProxy {
+		skipPhases += ",addon/kube-proxy"
+	}
+
 	// run kubeadm
 	cmd := node.Command(
 		// init because this is the control plane node
 		"kubeadm", "init",
-		// skip preflight checks, as these have undesirable side effects
-		// and don't tell us much. requires kubeadm 1.13+
-		"--skip-phases=preflight",
+		"--skip-phases="+skipPhases,
 		// specify our generated config file
 		"--config=/kind/kubeadm.conf",
 		"--skip-token-print",

--- a/pkg/cluster/internal/create/actions/kubeadminit/init.go
+++ b/pkg/cluster/internal/create/actions/kubeadminit/init.go
@@ -38,7 +38,7 @@ type action struct {
 
 // NewAction returns a new action for kubeadm init
 func NewAction(cfg *config.Cluster) actions.Action {
-	return &action{skipKubeProxy: cfg.Networking.KubeProxyMode == config.NoneMode}
+	return &action{skipKubeProxy: cfg.Networking.KubeProxyMode == config.NoneProxyMode}
 }
 
 // Execute runs the action

--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -108,7 +108,7 @@ func Cluster(logger log.Logger, p providers.Provider, opts *ClusterOptions) erro
 	}
 	if !opts.StopBeforeSettingUpKubernetes {
 		actionsToRun = append(actionsToRun,
-			kubeadminit.NewAction(), // run kubeadm init
+			kubeadminit.NewAction(opts.Config), // run kubeadm init
 		)
 		// this step might be skipped, but is next after init
 		if !opts.Config.Networking.DisableDefaultCNI {

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -240,6 +240,7 @@ evictionHard:
 {{ range $key := .SortedFeatureGateKeys }}
   "{{ $key }}": {{$.FeatureGates $key }}
 {{end}}{{end}}
+{{if ne .KubeProxyMode "None"}}
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
@@ -252,6 +253,7 @@ mode: "{{ .KubeProxyMode }}"
 {{end}}{{end}}
 iptables:
   minSyncPeriod: 1s
+{{end}}
 `
 
 // ConfigTemplateBetaV2 is the kubeadm config template for API version v1beta2
@@ -360,6 +362,7 @@ evictionHard:
 {{ range $key := .SortedFeatureGateKeys }}
   "{{ $key }}": {{ index $.FeatureGates $key }}
 {{end}}{{end}}
+{{if ne .KubeProxyMode "None"}}
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
@@ -372,6 +375,7 @@ mode: "{{ .KubeProxyMode }}"
 {{end}}{{end}}
 iptables:
   minSyncPeriod: 1s
+{{end}}
 `
 
 // Config returns a kubeadm config generated from config data, in particular

--- a/pkg/internal/apis/config/default.go
+++ b/pkg/internal/apis/config/default.go
@@ -82,7 +82,7 @@ func SetDefaultsCluster(obj *Cluster) {
 	}
 	// default the KubeProxyMode using iptables as it's already the default
 	if obj.Networking.KubeProxyMode == "" {
-		obj.Networking.KubeProxyMode = IPTablesMode
+		obj.Networking.KubeProxyMode = IPTablesProxyMode
 	}
 }
 

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -163,12 +163,12 @@ const (
 type ProxyMode string
 
 const (
-	// IPTablesMode sets ProxyMode to iptables
-	IPTablesMode ProxyMode = "iptables"
-	// IPVSMode sets ProxyMode to iptables
-	IPVSMode ProxyMode = "ipvs"
-	// NoneMode disables kube-proxy
-	NoneMode ProxyMode = "none"
+	// IPTablesProxyMode sets ProxyMode to iptables
+	IPTablesProxyMode ProxyMode = "iptables"
+	// IPVSProxyMode sets ProxyMode to iptables
+	IPVSProxyMode ProxyMode = "ipvs"
+	// NoneProxyMode disables kube-proxy
+	NoneProxyMode ProxyMode = "none"
 )
 
 // PatchJSON6902 represents an inline kustomize json 6902 patch

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -167,6 +167,8 @@ const (
 	IPTablesMode ProxyMode = "iptables"
 	// IPVSMode sets ProxyMode to iptables
 	IPVSMode ProxyMode = "ipvs"
+	// NoneMode disables kube-proxy
+	NoneMode ProxyMode = "none"
 )
 
 // PatchJSON6902 represents an inline kustomize json 6902 patch

--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -59,8 +59,8 @@ func (c *Cluster) Validate() error {
 	}
 
 	// KubeProxyMode should be iptables or ipvs
-	if c.Networking.KubeProxyMode != IPTablesMode && c.Networking.KubeProxyMode != IPVSMode &&
-		c.Networking.KubeProxyMode != NoneMode {
+	if c.Networking.KubeProxyMode != IPTablesProxyMode && c.Networking.KubeProxyMode != IPVSProxyMode &&
+		c.Networking.KubeProxyMode != NoneProxyMode {
 		errs = append(errs, errors.Errorf("invalid kubeProxyMode: %s", c.Networking.KubeProxyMode))
 	}
 

--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -59,7 +59,8 @@ func (c *Cluster) Validate() error {
 	}
 
 	// KubeProxyMode should be iptables or ipvs
-	if c.Networking.KubeProxyMode != IPTablesMode && c.Networking.KubeProxyMode != IPVSMode {
+	if c.Networking.KubeProxyMode != IPTablesMode && c.Networking.KubeProxyMode != IPVSMode &&
+		c.Networking.KubeProxyMode != NoneMode {
 		errs = append(errs, errors.Errorf("invalid kubeProxyMode: %s", c.Networking.KubeProxyMode))
 	}
 

--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -168,6 +168,8 @@ networking:
   kubeProxyMode: "ipvs"
 {{< /codeFromInline >}}
 
+To disable kube-proxy, set the mode to `"none"`.
+
 ### Nodes
 The `kind: Cluster` object has a `nodes` field containing a list of `node`
 objects. If unset this defaults to:


### PR DESCRIPTION
This commit introduces the new kube-proxy mode "none" which is used
to disable kube-proxy when provisioning (via kubeadm init's
skip-phase=addon/kube-proxy).

The motivation for the change is to use Kind for testing Cilium's
kube-proxy replacement \[1\].

\[1\]: https://docs.cilium.io/en/v1.9/gettingstarted/kubeproxy-free/