### PR TITLE
Exit with non-zero codes when user input is invalid

### DIFF
--- a/cmd/kind/app/main_test.go
+++ b/cmd/kind/app/main_test.go
@@ -18,6 +18,8 @@ package app
 
 import (
 	"testing"
+
+	"sigs.k8s.io/kind/pkg/cmd"
 )
 
 func TestCheckQuiet(t *testing.T) {
@@ -74,6 +76,62 @@ func TestCheckQuiet(t *testing.T) {
 			result := checkQuiet(tc.Args)
 			if result != tc.ExpectQuiet {
 				t.Fatalf("fooo")
+			}
+		})
+	}
+}
+
+func Test_CommandErrReturn(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		Name       string
+		Command    string
+		Subcommand string
+	}{
+		{
+			Name:       "misspelled subcommand for build",
+			Command:    "build",
+			Subcommand: "nod-image",
+		},
+		{
+			Name:       "misspelled subcommand for completion",
+			Command:    "completion",
+			Subcommand: "zzsh",
+		},
+		{
+			Name:       "misspelled subcommand for create",
+			Command:    "create",
+			Subcommand: "clunster",
+		},
+		{
+			Name:       "misspelled subcommand for delete",
+			Command:    "delete",
+			Subcommand: "clust",
+		},
+		{
+			Name:       "misspelled subcommand for export",
+			Command:    "export",
+			Subcommand: "kubecfg",
+		},
+		{
+			Name:       "misspelled subcommand for get",
+			Command:    "get",
+			Subcommand: "nods",
+		},
+		{
+			Name:       "misspelled subcommand for load",
+			Command:    "load",
+			Subcommand: "dokker-image",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			err := Run(cmd.NewLogger(), cmd.StandardIOStreams(), []string{tc.Command, tc.Subcommand})
+			if err == nil {
+				t.Errorf("Subcommand should raise an error if not called with correct params")
 			}
 		})
 	}

--- a/pkg/cmd/kind/build/build.go
+++ b/pkg/cmd/kind/build/build.go
@@ -18,6 +18,8 @@ limitations under the License.
 package build
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cmd"
@@ -33,6 +35,13 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Use:   "build",
 		Short: "Build one of [node-image]",
 		Long:  "Build one of [node-image]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cmd.Help()
+			if err != nil {
+				return err
+			}
+			return errors.New("Subcommand is required")
+		},
 	}
 	// add subcommands
 	cmd.AddCommand(nodeimage.NewCommand(logger, streams))

--- a/pkg/cmd/kind/completion/completion.go
+++ b/pkg/cmd/kind/completion/completion.go
@@ -18,6 +18,8 @@ limitations under the License.
 package completion
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cmd"
@@ -34,6 +36,13 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Use:   "completion",
 		Short: "Output shell completion code for the specified shell (bash, zsh or fish)",
 		Long:  longDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cmd.Help()
+			if err != nil {
+				return err
+			}
+			return errors.New("Subcommand is required")
+		},
 	}
 	cmd.AddCommand(zsh.NewCommand(logger, streams))
 	cmd.AddCommand(bash.NewCommand(logger, streams))

--- a/pkg/cmd/kind/create/create.go
+++ b/pkg/cmd/kind/create/create.go
@@ -18,6 +18,8 @@ limitations under the License.
 package create
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cmd"
@@ -32,6 +34,13 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Use:   "create",
 		Short: "Creates one of [cluster]",
 		Long:  "Creates one of local Kubernetes cluster (cluster)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cmd.Help()
+			if err != nil {
+				return err
+			}
+			return errors.New("Subcommand is required")
+		},
 	}
 	cmd.AddCommand(createcluster.NewCommand(logger, streams))
 	return cmd

--- a/pkg/cmd/kind/delete/delete.go
+++ b/pkg/cmd/kind/delete/delete.go
@@ -18,6 +18,8 @@ limitations under the License.
 package delete
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cmd"
@@ -34,6 +36,13 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Use:   "delete",
 		Short: "Deletes one of [cluster]",
 		Long:  "Deletes one of [cluster]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cmd.Help()
+			if err != nil {
+				return err
+			}
+			return errors.New("Subcommand is required")
+		},
 	}
 	cmd.AddCommand(deletecluster.NewCommand(logger, streams))
 	cmd.AddCommand(deleteclusters.NewCommand(logger, streams))

--- a/pkg/cmd/kind/export/export.go
+++ b/pkg/cmd/kind/export/export.go
@@ -18,6 +18,8 @@ limitations under the License.
 package export
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cmd"
@@ -34,6 +36,13 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Use:   "export",
 		Short: "Exports one of [kubeconfig, logs]",
 		Long:  "Exports one of [kubeconfig, logs]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cmd.Help()
+			if err != nil {
+				return err
+			}
+			return errors.New("Subcommand is required")
+		},
 	}
 	// add subcommands
 	cmd.AddCommand(logs.NewCommand(logger, streams))

--- a/pkg/cmd/kind/get/get.go
+++ b/pkg/cmd/kind/get/get.go
@@ -18,6 +18,8 @@ limitations under the License.
 package get
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cmd"
@@ -35,6 +37,13 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Use:   "get",
 		Short: "Gets one of [clusters, nodes, kubeconfig]",
 		Long:  "Gets one of [clusters, nodes, kubeconfig]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cmd.Help()
+			if err != nil {
+				return err
+			}
+			return errors.New("Subcommand is required")
+		},
 	}
 	// add subcommands
 	cmd.AddCommand(clusters.NewCommand(logger, streams))

--- a/pkg/cmd/kind/load/load.go
+++ b/pkg/cmd/kind/load/load.go
@@ -18,6 +18,8 @@ limitations under the License.
 package load
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cmd"
@@ -33,6 +35,13 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Use:   "load",
 		Short: "Loads images into nodes",
 		Long:  "Loads images into node from an archive or image on host",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cmd.Help()
+			if err != nil {
+				return err
+			}
+			return errors.New("Subcommand is required")
+		},
 	}
 	// add subcommands
 	cmd.AddCommand(dockerimage.NewCommand(logger, streams))


### PR DESCRIPTION
This pr contains my attempt of fixing the exit codes of invalid CLI commands (as defined in the issue #2087).

As you can probably see from the submission I'm no golang expert so this will probably need a bit more or less tuning.

One thing that comes to mind is the philosophical question whether we should consider an incomplete but correct command (like `kind delete`) as a success or a failure. The current implementation in this PR considers it as a failure (I think this way just seemed right).

Closes #2087