### PR TITLE
Improve entrypoint cgroup handling

### DIFF
--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -104,10 +104,17 @@ fix_cgroup() {
   fi
   echo 'INFO: detected cgroup v1'
   echo 'INFO: fix cgroup mounts for all subsystems'
-  # see: https://d2iq.com/blog/running-kind-inside-a-kubernetes-cluster-for-continuous-integration
-  # capture initial state before modifying
+  # See: https://d2iq.com/blog/running-kind-inside-a-kubernetes-cluster-for-continuous-integration
+  # Capture initial state before modifying
+  #
+  # Basically we're looking for the cgroup-path for the cpu controller for the
+  # current process. this tells us what cgroup-path the container is in.
+  # Then we collect the subsystems that are active on this path.
+  # We assume the cpu controller is in use on all node containers.
+  #
+  # See: https://man7.org/linux/man-pages/man7/cgroups.7.html
   local current_cgroup
-  current_cgroup=$(grep systemd /proc/self/cgroup | cut -d: -f3)
+  current_cgroup=$(grep -E '^[^:]*:([^:]*,)?cpu(,[^,:]*)?:.*' /proc/self/cgroup | cut -d: -f3)
   local cgroup_subsystems
   cgroup_subsystems=$(findmnt -lun -o source,target -t cgroup | grep "${current_cgroup}" | awk '{print $2}')
   # For each cgroup subsystem, Docker does a bind mount from the current

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,7 +20,7 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20210223-609a941a"
+const DefaultBaseImage = "kindest/base:v20210225-d7774569"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
We don't need to depend on the systemd named heirarchy for this. Also we can more robustly match the target controller (in this case I chose `cpu`.