### PR TITLE
explicitly set cgroupDriver

### DIFF
--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -223,6 +223,11 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 metadata:
   name: config
+# explicitly set default cgroup driver
+# unblocks https://github.com/kubernetes/kubernetes/pull/99471
+# TODO: consider switching to systemd instead
+# tracked in: https://github.com/kubernetes-sigs/kind/issues/1726
+cgroupDriver: cgroupfs
 # configure ipv6 addresses in IPv6 mode
 {{ if .IPv6 -}}
 address: "::"
@@ -343,6 +348,11 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 metadata:
   name: config
+# explicitly set default cgroup driver
+# unblocks https://github.com/kubernetes/kubernetes/pull/99471
+# TODO: consider switching to systemd instead
+# tracked in: https://github.com/kubernetes-sigs/kind/issues/1726
+cgroupDriver: cgroupfs
 # configure ipv6 addresses in IPv6 mode
 {{ if .IPv6 -}}
 address: "::"


### PR DESCRIPTION
unblocks https://github.com/kubernetes/kubernetes/pull/99471

will likely follow up switching everything to systemd, but for now keeping status quo, as the minimal patch to unblock.