### PR TITLE
stop setting providerless/dockerless tags by default

### DIFF
--- a/hack/release/build/push-node.sh
+++ b/hack/release/build/push-node.sh
@@ -28,6 +28,12 @@ TAG="${DATE}-$(git describe --always --dirty)"
 
 # build
 KUBEROOT="${KUBEROOT:-${GOPATH}/src/k8s.io/kubernetes}"
+
+GOFLAGS="${GOFLAGS:-}"
+if [ -z "${GOFLAGS}" ]; then
+    # TODO: add dockerless when 1.19 or greater
+    GOFLAGS="-tags=providerless"
+fi
 set -x
 "${REPO_ROOT}/bin/kind" build node-image --image="kindest/node:${TAG}" --kube-root="${KUBEROOT}"
 

--- a/pkg/build/nodeimage/internal/kube/builder_docker.go
+++ b/pkg/build/nodeimage/internal/kube/builder_docker.go
@@ -24,8 +24,6 @@ import (
 	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/exec"
 	"sigs.k8s.io/kind/pkg/log"
-
-	"k8s.io/apimachinery/pkg/util/version"
 )
 
 // TODO(bentheelder): plumb through arch
@@ -71,20 +69,6 @@ func (b *dockerBuilder) Build() (Bits, error) {
 		return nil, err
 	}
 
-	// check for version specific workarounds
-	ver, err := version.ParseSemantic(sourceVersionRaw)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse source version")
-	}
-	// leverage in-tree-cloud-provider-free builds by default
-	// https://github.com/kubernetes/kubernetes/pull/80353
-	// leverage dockershim free builds by default
-	// https://github.com/kubernetes/kubernetes/pull/87746
-	goflags := "GOFLAGS=-tags=providerless,dockerless"
-	if ver.LessThan(version.MustParseSemantic("v1.19.0")) {
-		goflags = "GOFLAGS=-tags=providerless"
-	}
-
 	// we will pass through the environment variables, prepending defaults
 	// NOTE: if env are specified multiple times the last one wins
 	env := append(
@@ -96,8 +80,6 @@ func (b *dockerBuilder) Build() (Bits, error) {
 			"KUBE_BUILD_CONFORMANCE=n",
 			// build for the host platform
 			"KUBE_BUILD_PLATFORMS=" + dockerBuildOsAndArch(b.arch),
-			// pass goflags
-			goflags,
 		},
 		os.Environ()...,
 	)


### PR DESCRIPTION
unless we're pushing an image for end-users (TODO: reconsider this, for multi-arch we're probably going to want to use pre-existing binaries anyhow to make these cheaper to build).

we want to cover identical binaries to cloudy CI, especially now that we actually use this builder in kubernetes CI

we don't want confusing failures for developers where the build only fails under kind as well.

if we need to cover these tags, we can add dedicated CI that set them easily by just setting GOFLAGS env which will pass through to the build.