### PR TITLE
switch all CI to make

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -265,11 +265,11 @@ main() {
   kind version
 
   # build kubernetes
-  if [ "${BUILD_TYPE:-}" = "bazel" ]; then
-    build_with_bazel
-  else
+  #if [ "${BUILD_TYPE:-}" = "bazel" ]; then
+  #  build_with_bazel
+  #else
     build
-  fi
+  #fi
 
   # in CI attempt to release some memory after building
   if [ -n "${KUBETEST_IN_DOCKER:-}" ]; then


### PR DESCRIPTION
xref: https://github.com/kubernetes/enhancements/issues/2420

building should be fine on previous branches, we still have plenty of bazel coverage for those in other jobs, after this goes through we can wind down our own bazel tech-debt here.

bazel already doesn't work for some older branches with kind