### PR TITLE
mirror docker images

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,24 @@
+name: Mirror
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  release:
+    types: [published]
+
+  
+jobs:
+  mirror:
+    name: Mirror images
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Mirror docker images to Github Registry
+        run: |
+          skopeo sync --src docker --dest docker docker.io/kindest/node ghcr.io/kind-ci
+
+      - name: Mirror docker images to quay.io
+        run: |
+          skopeo sync --src docker --dest docker docker.io/kindest/node quay.io/kind
+


### PR DESCRIPTION
Kind is publishing the official in dockerhub, however, since
the docker decision to rate limit the images, this causes issues
with CIs.

Switching completely the images is complicated, and can be very
disruptive.

Meanwhile we don't have a final decision we can mirror the images
to different public registries.

Fixes: https://github.com/kubernetes-sigs/kind/issues/1895