### PR TITLE
Revert "use runc for podman ci"

### DIFF
--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -51,10 +51,6 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install dnsmasq
 
-      - name: Setup runc as runtime to temporary fix #2085
-        run: |
-          echo -e "[engine]\nruntime = \"runc\"" | sudo tee /etc/containers/containers.conf
-
       - name: Create single node cluster
         if: ${{ matrix.deployment == 'singleNode' }}
         run: |


### PR DESCRIPTION
This reverts commit b0c9b4b9209912a28cd7a53e527a20c423521f40.

Github fixed the issue 
https://github.com/actions/virtual-environments/issues/2759#issuecomment-790774977