### PR TITLE
Fix "Page Not Found" link about relative path

### DIFF
--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -309,11 +309,11 @@ spec:
     app: foo
 {{< /codeFromInline >}}
 
-[Ingress Guide]: ./../ingress
+[Ingress Guide]: /docs/user/ingress
 
 ### Kubeadm Config Patches
 
-KIND uses [`kubeadm`](./../../design/principles/#leverage-existing-tooling) 
+KIND uses [`kubeadm`](/docs/design/principles/#leverage-existing-tooling) 
 to configure cluster nodes.
 Formally  KIND runs `kubeadm init` on the first control-plane node 
 which can be customized by using the kubeadm

--- a/site/content/docs/user/loadbalancer.md
+++ b/site/content/docs/user/loadbalancer.md
@@ -19,8 +19,8 @@ description: |-
     [installation docs]: https://metallb.universe.tf/installation/
     [configuration docs]: https://metallb.universe.tf/configuration/
 
-    [Ingress Guide]: ./../ingress
-    [Configuration Guide]: ./../configuration#extra-port-mappings
+    [Ingress Guide]: /docs/user/ingress
+    [Configuration Guide]: /docs/user/configuration#extra-port-mappings
 
 ---
 

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -306,8 +306,8 @@ Note: binding the `listenAddress` to `127.0.0.1` may affect your ability to acce
 
 You may want to see the [Ingress Guide] and [LoadBalancer Guide].
 
-[Ingress Guide]: ./../ingress
-[LoadBalancer Guide]: ./../loadbalancer
+[Ingress Guide]: /docs/user/ingress
+[LoadBalancer Guide]: /docs/user/loadbalancer
 
 #### Setting Kubernetes version
 You can also set a specific Kubernetes version by setting the `node`'s container image. You can find available image tags on the [releases page](https://github.com/kubernetes-sigs/kind/releases). Please use the `sha256` shasum for your desired kubernetes version, as seen in this example:


### PR DESCRIPTION
This commit fixes some "Page Not Found" links on kind website.

The cause of this is that part of links use relative path link style like `./..`.
This commit changes link of `./..` with `/docs/user` style.

Please see #2109 for detail about bug reproduce etc..

Fix: #2109