### PR TITLE
reduce node CRI disk usage

### DIFF
--- a/images/base/files/etc/containerd/config.toml
+++ b/images/base/files/etc/containerd/config.toml
@@ -1,10 +1,13 @@
 # explicitly use v2 config format
 version = 2
 
-# set default runtime handler to v2, which has a per-pod shim
 [plugins."io.containerd.grpc.v1.cri".containerd]
+  # save disk space when using a single snapshotter
+  discard_unpacked_layers = true
+  # explicit default here, as we're configuring it below
   default_runtime_name = "runc"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  # set default runtime handler to v2, which has a per-pod shim
   runtime_type = "io.containerd.runc.v2"
 
 # Setup a runtime with the magic name ("test-handler") used for Kubernetes

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,7 +20,7 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20210310-fb133a07"
+const DefaultBaseImage = "kindest/base:v20210310-d7b7eefd"
 
 // DefaultMode is the default kubernetes build mode for the built image
 // see pkg/build/kube.Bits


### PR DESCRIPTION
Enable `discard_unpacked_layers`. You don't want this enabled if you intend to share layers under multiple snapshotters. That's not the case for kind by default. If someone is enabling multiple snapshotters somehow they can also disable this.