### PR TITLE
Add a shortcode for inserting the stable version

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -66,6 +66,9 @@ baseName = "_redirects"
 [outputs]
 home = ["HTML", "REDIRECTS"]
 
+[params]
+stable = "v0.10.0"
+
 # privacy settings
 [privacy]
   [privacy.youtube]

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -6,7 +6,7 @@ title: kind
 [kind] is a tool for running local Kubernetes clusters using Docker container "nodes".  
 kind was primarily designed for testing Kubernetes itself, but may be used for local development or CI.
 
-If you have [go] \([1.11+][go-supported]) and [docker] installed `GO111MODULE="on" go get sigs.k8s.io/kind@v0.10.0 && kind create cluster` is all you need!
+If you have [go] \([1.11+][go-supported]) and [docker] installed `GO111MODULE="on" go get sigs.k8s.io/kind@{{< stableVersion >}} && kind create cluster` is all you need!
 
 <img src="images/kind-create-cluster.png" />
 

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -19,7 +19,7 @@ description: |-
 > but you will not be able to perform some of the examples in our docs without it.
 > To install `kubectl` see the upstream [kubectl installation docs](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
-You can either install kind with `GO111MODULE="on" go get sigs.k8s.io/kind@v0.10.0` or clone this repo 
+You can either install kind with `GO111MODULE="on" go get sigs.k8s.io/kind@{{< stableVersion >}}` or clone this repo 
 and run `make build` from the repository.
 
 Please use the latest Go when installing KIND from source, ideally go 1.14 or greater.
@@ -42,7 +42,7 @@ into your `$PATH`.
 On Linux:
 
 {{< codeFromInline lang="bash" >}}
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.10.0/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/{{< stableVersion >}}/kind-linux-amd64
 chmod +x ./kind
 mv ./kind /some-dir-in-your-PATH/kind
 {{< /codeFromInline >}}
@@ -54,13 +54,13 @@ brew install kind
 {{< /codeFromInline >}}
 or
 {{< codeFromInline lang="bash" >}}
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.10.0/kind-darwin-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/{{< stableVersion >}}/kind-darwin-amd64
 {{< /codeFromInline >}}
 
 On Windows:
 
 {{< codeFromInline lang="powershell" >}}
-curl.exe -Lo kind-windows-amd64.exe https://kind.sigs.k8s.io/dl/v0.10.0/kind-windows-amd64
+curl.exe -Lo kind-windows-amd64.exe https://kind.sigs.k8s.io/dl/{{< stableVersion >}}/kind-windows-amd64
 Move-Item .\kind-windows-amd64.exe c:\some-dir-in-your-PATH\kind.exe
 {{< /codeFromInline >}}
 

--- a/site/layouts/shortcodes/stableVersion.html
+++ b/site/layouts/shortcodes/stableVersion.html
@@ -1,0 +1,1 @@
+{{ site.Params.stable }}


### PR DESCRIPTION
Signed-off-by: rudeigerc <rudeigerc@gmail.com>

Closes #2118 

Add a shortcode for inserting the stable version, borrowed from the implementation of kubernetes/website.

I have tried fetching the latest tag through GitHub API,
```html
{{- $url := "https://api.github.com/repos/kubernetes-sigs/kind/releases/latest" -}}
{{- with getJSON $url -}}{{- .tag_name -}}{{- end -}}
```
but this may reach the request limit of API with intensive requests.

As a result, I think simply defining a parameter in `config.toml` would be better.