### PR TITLE
rootless: fail early if prerequiresites are not satisfied

### DIFF
--- a/pkg/cluster/internal/providers/provider.go
+++ b/pkg/cluster/internal/providers/provider.go
@@ -51,5 +51,9 @@ type Provider interface {
 
 // ProviderInfo is the info of the provider
 type ProviderInfo struct {
-	Rootless bool
+	Rootless            bool
+	Cgroup2             bool
+	SupportsMemoryLimit bool
+	SupportsPidsLimit   bool
+	SupportsCPUShares   bool
 }


### PR DESCRIPTION
`kind create cluster` now prints errors before running the containers.
