### PR TITLE
Link Go struct godoc for Cluster type

### DIFF
--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -36,6 +36,9 @@ To use this config, place the contents in a file `config.yaml` and then run
 
 You can also include a full file path like `kind create cluster --config=/foo/bar/config.yaml`.
 
+The structure of the `Cluster` type is defined by a Go struct, which is described
+[here](https://pkg.go.dev/sigs.k8s.io/kind/pkg/apis/config/v1alpha4#Cluster).
+
 ### A Note On CLI Parameters and Configuration Files
 
 Unless otherwise noted, parameters passed to the CLI take precedence over their


### PR DESCRIPTION
I'm not sure of a better complete document describing the full structure of the type, e.g., swagger or openAPI. If there's a better place to send people, let me know. In the meantime, being able to see the full struct all at once seemed helpful.