### PR TITLE
base: config.toml: fix "snapshotter" location

### DIFF
--- a/images/base/files/etc/containerd/config.toml
+++ b/images/base/files/etc/containerd/config.toml
@@ -4,6 +4,8 @@ version = 2
 [plugins."io.containerd.grpc.v1.cri".containerd]
   # save disk space when using a single snapshotter
   discard_unpacked_layers = true
+  # explicitly use default snapshotter so we can sed it in entrypoint
+  snapshotter = "overlayfs"
   # explicit default here, as we're configuring it below
   default_runtime_name = "runc"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
@@ -21,7 +23,5 @@ version = 2
   # allow hugepages controller to be missing
   # see https://github.com/containerd/cri/pull/1501
   tolerate_missing_hugepages_controller = true
-  # explicitly use default snapshotter so we can sed it in entrypoint
-  snapshotter = "overlayfs"
   # restrict_oom_score_adj needs to be true when running inside UserNS (rootless)
   restrict_oom_score_adj = false


### PR DESCRIPTION
"snapshotter" was in a wrong place. (Please see `containerd config default` or https://github.com/containerd/containerd/blob/2755ead927bbdc5b042990964332d78a0fdaddf4/pkg/cri/config/config.go#L63  to confirm.)

- - -
Split from https://github.com/kubernetes-sigs/kind/pull/2127 for ease of reviewing and merging.

Blocker toward adding CI for rootless with Fedora 33 (requires `s/overlayfs/native/`)