### PR TITLE
Update pause container

### DIFF
--- a/images/base/files/etc/containerd/config.toml
+++ b/images/base/files/etc/containerd/config.toml
@@ -19,7 +19,7 @@ version = 2
 
 [plugins."io.containerd.grpc.v1.cri"]
   # use fixed sandbox image
-  sandbox_image = "k8s.gcr.io/pause:3.4.1"
+  sandbox_image = "k8s.gcr.io/pause:3.5"
   # allow hugepages controller to be missing
   # see https://github.com/containerd/cri/pull/1501
   tolerate_missing_hugepages_controller = true


### PR DESCRIPTION
After kubernetes/k8s.io#1793 is promoted, update the pause image in KinD

