### PR TITLE
Add cgroups v2 support to known issues

### DIFF
--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -32,7 +32,7 @@ description: |-
 * [Pod Errors Due to "too many open files"](#pod-errors-due-to-too-many-open-files) (likely [inotify] limits which are not namespaced)
 * [Docker Permission Denied](#docker-permission-denied) (ensure you have permission to use docker)
 * [Windows Containers](#windows-containers) (unsupported / infeasible)
-* [Non-AMD64 Architectures](#nonamd64-architectures) (images not pre-built yet)
+* [Non-AMD64 Architectures](#non-amd64-architectures) (images not pre-built yet)
 * [Unable to Pull Images](#unable-to-pull-images) (various)
 * [Chrome OS](#chrome-os) (unsupported)
 * [AppArmor](#apparmor) (may break things, consider disabling)
@@ -200,7 +200,7 @@ Dec 07 00:37:53 kind-1-control-plane kubelet[688]: I1207 00:37:53.229561     688
 Dec 07 00:37:53 kind-1-control-plane kubelet[688]: E1207 00:37:53.229638     688 eviction_manager.go:351] eviction manager: eviction thresholds have been met, but no pods are active to evict
 ```
 ## Failure to Create Cluster with Cgroups v2
-Host OS'es running Cgroups v2 are only supported for Kubernetes versions >= 1.19.
+Support for Cgroups v2 was introduced in Kubernetes 1.19 (see [release notes](https://v1-19.docs.kubernetes.io/docs/setup/release/notes/)). Accordingly, only Kubernetes versions >= 1.19 are supported on hosts using Cgroups v2.
 
 You can verify that you are hitting this issue by exporting the logs (`kind export logs`) and looking
 at the kubelet logs, which may have something like the following:

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -28,6 +28,7 @@ description: |-
 * [Docker Installed With Snap](#docker-installed-with-snap) (snap filesystem restrictions problematic)
 * [Failure to Build Node Image](#failure-to-build-node-image) (usually need to increase resources)
 * [Failing to Properly Start Cluster](#failing-to-properly-start-cluster) (various causes)
+* [Failure to Create Cluster with Cgroups v2](#failure-to-create-cluster-with-cgroups-v2) (only supported for Kubernetes >= 1.19)
 * [Pod Errors Due to "too many open files"](#pod-errors-due-to-too-many-open-files) (likely [inotify] limits which are not namespaced)
 * [Docker Permission Denied](#docker-permission-denied) (ensure you have permission to use docker)
 * [Windows Containers](#windows-containers) (unsupported / infeasible)
@@ -198,7 +199,15 @@ at the kubelet logs, which may have something like the following:
 Dec 07 00:37:53 kind-1-control-plane kubelet[688]: I1207 00:37:53.229561     688 eviction_manager.go:340] eviction manager: must evict pod(s) to reclaim ephemeral-storage
 Dec 07 00:37:53 kind-1-control-plane kubelet[688]: E1207 00:37:53.229638     688 eviction_manager.go:351] eviction manager: eviction thresholds have been met, but no pods are active to evict
 ```
+## Failure to Create Cluster with Cgroups v2
+Host OS'es running Cgroups v2 are only supported for Kubernetes versions >= 1.19.
 
+You can verify that you are hitting this issue by exporting the logs (`kind export logs`) and looking
+at the kubelet logs, which may have something like the following:
+```
+Feb 23 08:39:04 kind-control-plane kubelet[3031]: W0223 08:39:04.644052    3031 server.go:616] failed to get the kubelet's cgroup: mountpoint for cpu not found.  Kubelet system container metrics may be missing.
+Feb 23 08:39:04 kind-control-plane kubelet[3031]: F0223 08:39:04.644296    3031 server.go:274] failed to run Kubelet: mountpoint for  not found
+```
 ## Pod errors due to "too many open files"
 
 This may be caused by running out of [inotify](https://linux.die.net/man/7/inotify) resources. Resource limits are defined by `fs.inotify.max_user_watches` and `fs.inotify.max_user_instances` system variables. For example, in Ubuntu these default to 8192 and 128 respectively, which is not enough to create a cluster with many nodes.


### PR DESCRIPTION
#2082 
Adds a section to known issues page, which gives some details on which Kubernetes versions support cgroups v2, and how to identify this issue.

/sig testing
/kind documentation