### PR TITLE
correctly generate newline in e2e-k8s.sh

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -79,7 +79,7 @@ create_cluster() {
       exit 1
       ;;
     *)
-      kubelet_extra_args="${kubelet_extra_args}\n      \"logging-format\": \"${KUBELET_LOG_FORMAT}\""
+      kubelet_extra_args="${kubelet_extra_args}$(printf '\n')      \"logging-format\": \"${KUBELET_LOG_FORMAT}\""
       ;;
     esac
   fi


### PR DESCRIPTION
follow up to https://github.com/kubernetes-sigs/kind/pull/2145

shell does not support `\n`. bash can do it with strings prefixed with `$` but that's bash specific. `printf` is POSIX.