### PR TITLE
doc: add kubeadm ClusterConfiguration spec usage.

### DIFF
--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -340,8 +340,8 @@ spec:
 
 KIND uses [`kubeadm`](/docs/design/principles/#leverage-existing-tooling) 
 to configure cluster nodes.
-Formally  KIND runs `kubeadm init` on the first control-plane node 
-which can be customized by using the kubeadm
+
+Formally  KIND runs `kubeadm init` on the first control-plane node, we can customize the flags by using the kubeadm
 [InitConfiguration](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file) 
 ([spec](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2#InitConfiguration))
 
@@ -358,7 +358,7 @@ nodes:
         node-labels: "my-label=true"
 {{< /codeFromInline >}}
 
-Besides, there are four configuration types available during `kubeadm init`: `InitConfiguration`, `ClusterConfiguration`, `KubeProxyConfiguration`, `KubeletConfiguration`. For example, we could override the apiserver flags by using the kubeadm [ClusterConfiguration](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/)([spec](https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2#ClusterConfiguration)):
+If you want to do more customization, there are four configuration types available during `kubeadm init`: `InitConfiguration`, `ClusterConfiguration`, `KubeProxyConfiguration`, `KubeletConfiguration`. For example, we could override the apiserver flags by using the kubeadm [ClusterConfiguration](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/) ([spec](https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2#ClusterConfiguration)):
 
 {{< codeFromInline lang="yaml" >}}
 kind: Cluster

--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -358,12 +358,26 @@ nodes:
         node-labels: "my-label=true"
 {{< /codeFromInline >}}
 
+Besides, the kubeadm `ClusterConfiguration` object exposes the field extraArgs that can override the default flags passed to control plane components such as the APIServer, ControllerManager and Scheduler. For KIND, we could override these configurations by adding the [ClusterConfiguration](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-config/)([spec](https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2#ClusterConfiguration)):
+
+{{< codeFromInline lang="yaml" >}}
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+        extraArgs:
+          enable-admission-plugins: NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+{{< /codeFromInline >}}
+
 On every additional node configured in the KIND cluster, 
 worker or control-plane (in HA mode),
 KIND runs `kubeadm join` which can be configured using the 
 [JoinConfiguration](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-join/#config-file)
 ([spec](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2#JoinConfiguration))
-
 
 {{< codeFromInline lang="yaml" >}}
 kind: Cluster

--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -358,7 +358,7 @@ nodes:
         node-labels: "my-label=true"
 {{< /codeFromInline >}}
 
-Besides, the kubeadm `ClusterConfiguration` object exposes the field extraArgs that can override the default flags passed to control plane components such as the APIServer, ControllerManager and Scheduler. For KIND, we could override these configurations by adding the [ClusterConfiguration](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-config/)([spec](https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2#ClusterConfiguration)):
+Besides, there are four configuration types available during `kubeadm init`: `InitConfiguration`, `ClusterConfiguration`, `KubeProxyConfiguration`, `KubeletConfiguration`. For example, we could override the apiserver flags by using the kubeadm [ClusterConfiguration](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/)([spec](https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2#ClusterConfiguration)):
 
 {{< codeFromInline lang="yaml" >}}
 kind: Cluster


### PR DESCRIPTION
I met issue #2151 while applying custom configurations against APIServer, and I found the [right answer](https://github.com/kubernetes-sigs/kind/issues/2151#issuecomment-805468230) after diving into the logs.

To avoid more confusion, I'd like to propose this PR to fill out the missing document about `Kubeadm ClusterConfiguration` usage.

Thanks!
