### PR TITLE
add additional-images flag to build command

### DIFF
--- a/pkg/build/nodeimage/build.go
+++ b/pkg/build/nodeimage/build.go
@@ -83,9 +83,10 @@ func supportedArch(arch string) bool {
 // build configuration
 type buildContext struct {
 	// option fields
-	image     string
-	baseImage string
-	logger    log.Logger
+	image                  string
+	baseImage              string
+	logger                 log.Logger
+	additionalImagesToPull []string
 	// non-option fields
 	arch     string // TODO(bentheelder): this should be an option
 	kubeRoot string

--- a/pkg/build/nodeimage/build_impl.go
+++ b/pkg/build/nodeimage/build_impl.go
@@ -255,6 +255,9 @@ func (c *buildContext) prePullImages(bits kube.Bits, dir, containerID string) ([
 	// all builds should install the default storage driver images currently
 	requiredImages = append(requiredImages, defaultStorageImages...)
 
+	// include additional images passed in by the user
+	requiredImages = append(requiredImages, c.additionalImagesToPull...)
+
 	// Create "images" subdir.
 	imagesDir := path.Join(dir, "bits", "images")
 	if err := os.MkdirAll(imagesDir, 0777); err != nil {

--- a/pkg/build/nodeimage/options.go
+++ b/pkg/build/nodeimage/options.go
@@ -62,3 +62,10 @@ func WithLogger(logger log.Logger) Option {
 		return nil
 	})
 }
+
+func WithAdditionalImagesToPull(images []string) Option {
+	return optionAdapter(func(b *buildContext) error {
+		b.additionalImagesToPull = images
+		return nil
+	})
+}

--- a/pkg/cmd/kind/build/nodeimage/nodeimage.go
+++ b/pkg/cmd/kind/build/nodeimage/nodeimage.go
@@ -26,11 +26,12 @@ import (
 )
 
 type flagpole struct {
-	Source    string
-	BuildType string
-	Image     string
-	BaseImage string
-	KubeRoot  string
+	Source                 string
+	BuildType              string
+	Image                  string
+	BaseImage              string
+	KubeRoot               string
+	AdditionalImagesToPull []string
 }
 
 // NewCommand returns a new cobra.Command for building the node image
@@ -68,6 +69,11 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		nodeimage.DefaultBaseImage,
 		"name:tag of the base image to use for the build",
 	)
+	cmd.Flags().StringSliceVar(
+		&flags.AdditionalImagesToPull, "additional-images",
+		[]string{},
+		"list of additional images to pull",
+	)
 	return cmd
 }
 
@@ -77,6 +83,7 @@ func runE(logger log.Logger, flags *flagpole) error {
 		nodeimage.WithBaseImage(flags.BaseImage),
 		nodeimage.WithKuberoot(flags.KubeRoot),
 		nodeimage.WithLogger(logger),
+		nodeimage.WithAdditionalImagesToPull(flags.AdditionalImagesToPull),
 	); err != nil {
 		return errors.Wrap(err, "error building node image")
 	}


### PR DESCRIPTION
A solution for https://github.com/kubernetes-sigs/kind/issues/2063

Add a way to specify additional images to pull when running `kind build node-image` with a new flag `--additional-images`.

My use-case is to have a `kind` image that is used in an air-gapped cluster that includes a few additional images.
There is no easy way to extend the existing `kindest/node` images (please correct me here if there is some process), `kind load` is an option but its less desirable for my use case since it would require to package and ship around multiple images instead of just the one `kindest/node` image.