### PR TITLE
fix kind export logs

### DIFF
--- a/pkg/cluster/internal/providers/common/logs.go
+++ b/pkg/cluster/internal/providers/common/logs.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
-	"sigs.k8s.io/kind/pkg/cmd/kind/version"
 	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/exec"
 )
@@ -23,24 +22,9 @@ func CollectLogs(n nodes.Node, dir string) error {
 			return cmd.SetStdout(f).SetStderr(f).Run()
 		}
 	}
-	writeToPathFn := func(s string, path string) func() error {
-		return func() error {
-			f, err := FileOnHost(path)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-			_, err = f.WriteString(s)
-			return err
-		}
-	}
 
 	return errors.AggregateConcurrent([]func() error{
 		// record info about the node container
-		writeToPathFn(
-			version.DisplayVersion(),
-			filepath.Join(dir, "kind-version.txt"),
-		),
 		execToPathFn(
 			n.Command("cat", "/kind/version"),
 			"kubernetes-version.txt",

--- a/pkg/cluster/provider.go
+++ b/pkg/cluster/provider.go
@@ -17,7 +17,12 @@ limitations under the License.
 package cluster
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"sort"
+
+	"sigs.k8s.io/kind/pkg/cmd/kind/version"
 
 	"sigs.k8s.io/kind/pkg/cluster/constants"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
@@ -226,5 +231,18 @@ func (p *Provider) CollectLogs(name, dir string) error {
 	if err != nil {
 		return err
 	}
+	// ensure directory
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return errors.Wrap(err, "failed to create logs directory")
+	}
+	// write kind version
+	if err := ioutil.WriteFile(
+		filepath.Join(dir, "kind-version.txt"),
+		[]byte(version.DisplayVersion()),
+		0666, // match os.Create
+	); err != nil {
+		return errors.Wrap(err, "failed to write kind-version.txt")
+	}
+	// collect and write cluster logs
 	return p.provider.CollectLogs(dir, n)
 }

--- a/pkg/cmd/kind/export/logs/logs.go
+++ b/pkg/cmd/kind/export/logs/logs.go
@@ -80,12 +80,11 @@ func runE(logger log.Logger, streams cmd.IOStreams, flags *flagpole, args []stri
 		dir = args[0]
 	}
 
-	// collect the logs
-	if err := provider.CollectLogs(flags.Name, dir); err != nil {
-		return err
-	}
-
-	logger.V(0).Infof("Exported logs for cluster %q to:", flags.Name)
+	// NOTE: the path is the output of this command to be captured by calling tools
+	// whereas "Exporting logs..." is info / debug (stderr)
+	logger.V(0).Infof("Exporting logs for cluster %q to:", flags.Name)
 	fmt.Fprintln(streams.Out, dir)
-	return nil
+
+	// collect the logs
+	return provider.CollectLogs(flags.Name, dir)
 }


### PR DESCRIPTION
- export kind-version.txt at the top level, instead of per node. it's not a property of the node
- always print the exported path so any logs that are exported can be debugged even if an error is encountered