### PR TITLE
don't use loopback addresses on the nodes resolv.conf file

### DIFF
--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -337,7 +337,8 @@ enable_network_magic(){
   # first we need to detect an IP to use for reaching the docker host
   local docker_host_ip
   docker_host_ip="$( (getent ahostsv4 'host.docker.internal' | head -n1 | cut -d' ' -f1) || true)"
-  if [[ -z "${docker_host_ip}" ]]; then
+  # if the ip doesn't exist or is a loopback address use the default gateway
+  if [[ -z "${docker_host_ip}" ]] || [[ $docker_host_ip =~ ^127\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     docker_host_ip=$(ip -4 route show default | cut -d' ' -f3)
   fi
 

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,4 +20,4 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "kindest/base:v20210327-a8dff87f@sha256:d25665e921b61ab44d0627ce5a0ef82145e4c2c126e1a938d003bf4087349542"
+const DefaultBaseImage = "kindest/base:v20210328-c17ca167@sha256:0311870f4d35b0f68e2fedb5d703a552a8e7eb438acc67a3bd13982c2bda7487"


### PR DESCRIPTION
we were using the well known name host.docker.internal to get the
host IP address, however, it seems that in some systems it resolves
to a loopback address. We use this address to replace the embedded
docker dns IP address in the resolv.conf.
We can't use a loopback address, because coredns obtains the upstream
dns resolvers from the resolv.conf, and evidentelly, it crashes if the
upstream DNS resolver is a loopback, because it meains that is itself,
and that is a loop.

Fixes: #1975 