### PR TITLE
support cross-compiling node-image

### DIFF
--- a/hack/release/build/push-node.sh
+++ b/hack/release/build/push-node.sh
@@ -25,6 +25,9 @@ make build
 # path to kubernetes sources
 KUBEROOT="${KUBEROOT:-${GOPATH}/src/k8s.io/kubernetes}"
 
+# ensure we have qemu setup (de-duped logic with setting up buildx for multi-arch)
+"${REPO_ROOT}/hack/build/init-buildx.sh"
+
 # kubernetes build option(s)
 GOFLAGS="${GOFLAGS:-}"
 if [ -z "${GOFLAGS}" ]; then
@@ -50,7 +53,7 @@ IMAGE="kindest/node:${kube_version}"
 images=()
 for arch in "${__arches__[@]}"; do
     image="kindest/node-${arch}:${kube_version}"
-    "${REPO_ROOT}/bin/kind" build node-image --image="${image}" --kube-root="${KUBEROOT}" --arch="${arch}"
+    "${REPO_ROOT}/bin/kind" build node-image --image="${image}" --arch="${arch}" "${KUBEROOT}"
     images+=("${image}")
 done
 

--- a/hack/release/build/push-node.sh
+++ b/hack/release/build/push-node.sh
@@ -22,12 +22,10 @@ cd "${REPO_ROOT}"
 # ensure we have up to date kind
 make build
 
-# generate tag
-DATE="$(date +v%Y%m%d)"
-
-# build
+# path to kubernetes sources
 KUBEROOT="${KUBEROOT:-${GOPATH}/src/k8s.io/kubernetes}"
 
+# kubernetes build option(s)
 GOFLAGS="${GOFLAGS:-}"
 if [ -z "${GOFLAGS}" ]; then
     # TODO: add dockerless when 1.19 or greater
@@ -40,7 +38,7 @@ fi
 # Other users are free to build their own images on additional platforms using
 # their own time and resources. Please see our docs.
 ARCHES="${ARCHES:-amd64 arm64}"
-__arches__=(${ARCHES})
+IFS=" " read -r -a __arches__ <<< "$ARCHES"
 
 set -x
 # get kubernetes version

--- a/hack/release/build/push-node.sh
+++ b/hack/release/build/push-node.sh
@@ -24,7 +24,6 @@ make build
 
 # generate tag
 DATE="$(date +v%Y%m%d)"
-TAG="${DATE}-$(git describe --always --dirty)"
 
 # build
 KUBEROOT="${KUBEROOT:-${GOPATH}/src/k8s.io/kubernetes}"
@@ -34,13 +33,35 @@ if [ -z "${GOFLAGS}" ]; then
     # TODO: add dockerless when 1.19 or greater
     GOFLAGS="-tags=providerless"
 fi
+
+# NOTE: adding platforms is costly in terms of build time
+# we will consider expanding this in the future, for now the aim is to prove
+# multi-arch and enable developers working on commonly available hardware
+# Other users are free to build their own images on additional platforms using
+# their own time and resources. Please see our docs.
+ARCHES="${ARCHES:-amd64 arm64}"
+__arches__=(${ARCHES})
+
 set -x
-"${REPO_ROOT}/bin/kind" build node-image --image="kindest/node:${TAG}" --kube-root="${KUBEROOT}"
+# get kubernetes version
+version_line="$(cd "${KUBEROOT}"; ./hack/print-workspace-status.sh | grep 'gitVersion')"
+kube_version="${version_line#"gitVersion "}"
 
-# re-tag with kubernetes version
-IMG="kindest/node:${TAG}"
-KUBE_VERSION="$(docker run --rm --entrypoint=cat "${IMG}" /kind/version)"
-docker tag "${IMG}" "kindest/node:${KUBE_VERSION}"
+# build for each arch
+image="kindest/node:${kube_version}"
+images=()
+for arch in "${__arches__[@]}"; do
+    image="kindest/node-${arch}:${kube_version}"
+    "${REPO_ROOT}/bin/kind" build node-image --image="${image}" --kube-root="${KUBEROOT}" --arch="${arch}"
+    images+=("${image}")
+done
 
-# push
-docker push kindest/node:"${KUBE_VERSION}"
+# combine to manifest list tagged with kubernetes version
+export DOCKER_CLI_EXPERIMENTAL=enabled
+# images must be pushed to be referenced by docker manifest
+# we push only after all builds have succeeded
+for image in "${images[@]}"; do
+    docker push "${image}"
+done
+docker manifest create "${image}" "${images[@]}"
+docker manifest push "${image}"

--- a/hack/release/build/push-node.sh
+++ b/hack/release/build/push-node.sh
@@ -48,7 +48,7 @@ version_line="$(cd "${KUBEROOT}"; ./hack/print-workspace-status.sh | grep 'gitVe
 kube_version="${version_line#"gitVersion "}"
 
 # build for each arch
-image="kindest/node:${kube_version}"
+IMAGE="kindest/node:${kube_version}"
 images=()
 for arch in "${__arches__[@]}"; do
     image="kindest/node-${arch}:${kube_version}"
@@ -63,5 +63,5 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 for image in "${images[@]}"; do
     docker push "${image}"
 done
-docker manifest create "${image}" "${images[@]}"
-docker manifest push "${image}"
+docker manifest create "${IMAGE}" "${images[@]}"
+docker manifest push "${IMAGE}"

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.20.2@sha256:15d3b5c4f521a84896ed1ead1b14e4774d02202d5c65ab68f30eeaf310a3b1a7"
+const Image = "kindest/node:v1.21.1@sha256:c6eead46eaba71017e290f696fa675187133d7953e9291900e384f711b6cf8ed"

--- a/pkg/build/nodeimage/build.go
+++ b/pkg/build/nodeimage/build.go
@@ -31,8 +31,7 @@ func Build(options ...Option) error {
 		image:     DefaultImage,
 		baseImage: DefaultBaseImage,
 		logger:    log.NoopLogger{},
-		// TODO: only host arch supported. changing this will be tricky
-		arch: runtime.GOARCH,
+		arch:      runtime.GOARCH,
 	}
 
 	// apply user options
@@ -44,7 +43,7 @@ func Build(options ...Option) error {
 
 	// verify that we're using a supported arch
 	if !supportedArch(ctx.arch) {
-		return errors.Errorf("unsupported architecture %q", ctx.arch)
+		ctx.logger.Warnf("unsupported architecture %q", ctx.arch)
 	}
 
 	// locate sources if no kubernetes source was specified
@@ -77,17 +76,4 @@ func supportedArch(arch string) bool {
 	case "ppc64le":
 	}
 	return true
-}
-
-// buildContext is used to build the kind node image, and contains
-// build configuration
-type buildContext struct {
-	// option fields
-	image     string
-	baseImage string
-	logger    log.Logger
-	// non-option fields
-	arch     string // TODO(bentheelder): this should be an option
-	kubeRoot string
-	builder  kube.Builder
 }

--- a/pkg/build/nodeimage/buildcontext.go
+++ b/pkg/build/nodeimage/buildcontext.go
@@ -295,13 +295,17 @@ func (c *buildContext) prePullImages(bits kube.Bits, dir, containerID string) ([
 		image := image // https://golang.org/doc/faq#closures_and_goroutines
 		fns = append(fns, func() error {
 			if !builtImages.Has(image) {
-				err := importer.Pull(image, dockerBuildOsAndArch(c.arch))
-				if err != nil {
-					c.logger.Warnf("Failed to pull %s with error: %v", image, err)
-					runE := exec.RunErrorForError(err)
-					c.logger.Warn(string(runE.Output))
-				}
-				// TODO(bentheelder): generate a friendlier name
+				/*
+					TODO: show errors when we have real errors. See comments in
+					importer implementation
+					err := importer.Pull(image, dockerBuildOsAndArch(c.arch))
+					if err != nil {
+						c.logger.Warnf("Failed to pull %s with error: %v", image, err)
+						runE := exec.RunErrorForError(err)
+						c.logger.Warn(string(runE.Output))
+					}
+				*/
+				_ = importer.Pull(image, dockerBuildOsAndArch(c.arch))
 			}
 			return nil
 		})

--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -20,7 +20,7 @@ package nodeimage
 The default CNI manifest and images are our own tiny kindnet
 */
 
-var defaultCNIImages = []string{"kindest/kindnetd:v20210326-1e038dc5"}
+var defaultCNIImages = []string{"docker.io/kindest/kindnetd:v20210326-1e038dc5"}
 
 // TODO: migrate to fully patching and deprecate the template
 const defaultCNIManifest = `
@@ -94,7 +94,7 @@ spec:
       serviceAccountName: kindnet
       containers:
       - name: kindnet-cni
-        image: kindest/kindnetd:v20210326-1e038dc5
+        image: docker.io/kindest/kindnetd:v20210326-1e038dc5
         env:
         - name: HOST_IP
           valueFrom:

--- a/pkg/build/nodeimage/const_storage.go
+++ b/pkg/build/nodeimage/const_storage.go
@@ -25,7 +25,7 @@ NOTE: we have customized it in the following ways:
 - install as the default storage class
 */
 
-var defaultStorageImages = []string{"rancher/local-path-provisioner:v0.0.14", "k8s.gcr.io/build-image/debian-base:v2.1.0"}
+var defaultStorageImages = []string{"docker.io/rancher/local-path-provisioner:v0.0.14", "k8s.gcr.io/build-image/debian-base:v2.1.0"}
 
 const defaultStorageManifest = `
 # kind customized https://github.com/rancher/local-path-provisioner manifest
@@ -95,7 +95,7 @@ spec:
       serviceAccountName: local-path-provisioner-service-account
       containers:
       - name: local-path-provisioner
-        image: rancher/local-path-provisioner:v0.0.14
+        image: docker.io/rancher/local-path-provisioner:v0.0.14
         imagePullPolicy: IfNotPresent
         command:
         - local-path-provisioner

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,4 +20,4 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "docker.io/kindest/base:v20210513-60cf6961@sha256:2b96d0b11c80e7cb1096ea89e2ffbe26ae72b2b08a177e088fa0edeff9fad516"
+const DefaultBaseImage = "docker.io/kindest/base:v20210513-60cf6961"

--- a/pkg/build/nodeimage/imageimporter.go
+++ b/pkg/build/nodeimage/imageimporter.go
@@ -20,24 +20,15 @@ import (
 	"sigs.k8s.io/kind/pkg/exec"
 )
 
-type imageImporter interface {
-	Prepare() error
-	LoadCommand() exec.Cmd
-	ListImported() ([]string, error)
-	End() error
-}
-
 type containerdImporter struct {
 	containerCmder exec.Cmder
 }
 
-func newContainerdImporter(containerCmder exec.Cmder) imageImporter {
+func newContainerdImporter(containerCmder exec.Cmder) *containerdImporter {
 	return &containerdImporter{
 		containerCmder: containerCmder,
 	}
 }
-
-var _ imageImporter = &containerdImporter{}
 
 func (c *containerdImporter) Prepare() error {
 	if err := c.containerCmder.Command(
@@ -51,6 +42,12 @@ func (c *containerdImporter) Prepare() error {
 
 func (c *containerdImporter) End() error {
 	return c.containerCmder.Command("pkill", "containerd").Run()
+}
+
+func (c *containerdImporter) Pull(image, platform string) error {
+	return c.containerCmder.Command(
+		"ctr", "--namespace=k8s.io", "images", "pull", "--platform="+platform, image,
+	).Run()
 }
 
 func (c *containerdImporter) LoadCommand() exec.Cmd {

--- a/pkg/build/nodeimage/imageimporter.go
+++ b/pkg/build/nodeimage/imageimporter.go
@@ -17,6 +17,8 @@ limitations under the License.
 package nodeimage
 
 import (
+	"io/ioutil"
+
 	"sigs.k8s.io/kind/pkg/exec"
 )
 
@@ -45,9 +47,11 @@ func (c *containerdImporter) End() error {
 }
 
 func (c *containerdImporter) Pull(image, platform string) error {
+	// TODO: this should exist with a --no-unpack and some way to operate quietly
+	// without discarding output
 	return c.containerCmder.Command(
 		"ctr", "--namespace=k8s.io", "images", "pull", "--platform="+platform, image,
-	).Run()
+	).SetStdout(ioutil.Discard).SetStderr(ioutil.Discard).Run()
 }
 
 func (c *containerdImporter) LoadCommand() exec.Cmd {

--- a/pkg/build/nodeimage/internal/kube/builder_docker.go
+++ b/pkg/build/nodeimage/internal/kube/builder_docker.go
@@ -21,11 +21,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/version"
+
 	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/exec"
 	"sigs.k8s.io/kind/pkg/log"
-
-	"k8s.io/apimachinery/pkg/util/version"
 )
 
 // TODO(bentheelder): plumb through arch

--- a/pkg/build/nodeimage/options.go
+++ b/pkg/build/nodeimage/options.go
@@ -62,3 +62,13 @@ func WithLogger(logger log.Logger) Option {
 		return nil
 	})
 }
+
+// WithArch sets the architecture to build for
+func WithArch(arch string) Option {
+	return optionAdapter(func(b *buildContext) error {
+		if arch != "" {
+			b.arch = arch
+		}
+		return nil
+	})
+}

--- a/pkg/cmd/kind/build/nodeimage/nodeimage.go
+++ b/pkg/cmd/kind/build/nodeimage/nodeimage.go
@@ -31,6 +31,7 @@ type flagpole struct {
 	Image     string
 	BaseImage string
 	KubeRoot  string
+	Arch      string
 }
 
 // NewCommand returns a new cobra.Command for building the node image
@@ -74,6 +75,11 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		nodeimage.DefaultBaseImage,
 		"name:tag of the base image to use for the build",
 	)
+	cmd.Flags().StringVar(
+		&flags.Arch, "arch",
+		"",
+		"architecture to build for, defaults to the host architecture",
+	)
 	return cmd
 }
 
@@ -87,6 +93,7 @@ func runE(logger log.Logger, flags *flagpole, args []string) error {
 		nodeimage.WithBaseImage(flags.BaseImage),
 		nodeimage.WithKuberoot(kubeRoot),
 		nodeimage.WithLogger(logger),
+		nodeimage.WithArch(flags.Arch),
 	); err != nil {
 		return errors.Wrap(err, "error building node image")
 	}


### PR DESCRIPTION
specifically intended to resolve #166 

changes:
- deprecate `--kube-root` in favor of making it a require argument (this is not strictly related, but I am reworking node image build bit by bit and started there)
- switch to pulling images with containerd in the running base, instead of to the host. this breaks offline kubernetes development but the previous approach with docker pull / save / export cannot be used reliably for multi-arch
  - fully qualify images to prepull (needed by ctr)
- fix image architecture in upstream built images, some of which are have the wrong metadata
- move architecture support to warning (not strictly necessary, but when people ask for new architectures to be possible to build we can allow it without explicitly supporting them, initially)
- add `--arch` flag to `kind build node-image`
- update push-build.sh to push a multi-arch image using this cross compile mechanism
- update the default node image to a multi-arch image