### PR TITLE
fix getSubnets for podman

### DIFF
--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -281,7 +281,7 @@ func getProxyEnv(cfg *config.Cluster) (map[string]string, error) {
 }
 
 func getSubnets(networkName string) ([]string, error) {
-	format := '{{ range (index (index (index (index . "plugins") 0 ) "ipam" ) "ranges")}}{{ index ( index . 0 ) "subnet" }} {{end}}'
+	format := `{{ range (index (index (index (index . "plugins") 0 ) "ipam" ) "ranges")}}{{ index ( index . 0 ) "subnet" }} {{end}}`
 	cmd := exec.Command("podman", "network", "inspect", "-f", format, networkName)
 	lines, err := exec.OutputLines(cmd)
 	if err != nil {

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -281,7 +281,7 @@ func getProxyEnv(cfg *config.Cluster) (map[string]string, error) {
 }
 
 func getSubnets(networkName string) ([]string, error) {
-	format := `{{index (index  .plugins  0).ipam.ranges 0 0 "subnet"}}`
+	format := '{{ range (index (index (index (index . "plugins") 0 ) "ipam" ) "ranges")}}{{ index ( index . 0 ) "subnet" }} {{end}}'
 	cmd := exec.Command("podman", "network", "inspect", "-f", format, networkName)
 	lines, err := exec.OutputLines(cmd)
 	if err != nil {

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -281,7 +281,7 @@ func getProxyEnv(cfg *config.Cluster) (map[string]string, error) {
 }
 
 func getSubnets(networkName string) ([]string, error) {
-	format := `{{range (index (index . "IPAM") "Config")}}{{index . "Subnet"}} {{end}}`
+	format := `{{index (index  .plugins  0).ipam.ranges 0 0 "subnet"}}`
 	cmd := exec.Command("podman", "network", "inspect", "-f", format, networkName)
 	lines, err := exec.OutputLines(cmd)
 	if err != nil {


### PR DESCRIPTION
The command to getSubnets for  podman isn't the same as the one for docker.