### PR TITLE
implemented --internal on export kubeconfig

### DIFF
--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -151,7 +151,7 @@ func Cluster(logger log.Logger, p providers.Provider, opts *ClusterOptions) erro
 	var err error
 	for _, b := range []time.Duration{0, time.Millisecond, time.Millisecond * 50, time.Millisecond * 100} {
 		time.Sleep(b)
-		if err = kubeconfig.Export(p, opts.Config.Name, opts.KubeconfigPath); err == nil {
+		if err = kubeconfig.Export(p, opts.Config.Name, opts.KubeconfigPath, true); err == nil {
 			break
 		}
 	}

--- a/pkg/cluster/internal/kubeconfig/kubeconfig.go
+++ b/pkg/cluster/internal/kubeconfig/kubeconfig.go
@@ -32,8 +32,8 @@ import (
 
 // Export exports the kubeconfig given the cluster context and a path to write it to
 // This will always be an external kubeconfig
-func Export(p providers.Provider, name, explicitPath string) error {
-	cfg, err := get(p, name, true)
+func Export(p providers.Provider, name, explicitPath string, external bool) error {
+	cfg, err := get(p, name, external)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/provider.go
+++ b/pkg/cluster/provider.go
@@ -204,8 +204,8 @@ func (p *Provider) KubeConfig(name string, internal bool) (string, error) {
 // it into the selected file, following the rules from
 // https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#config
 // where explicitPath is the --kubeconfig value.
-func (p *Provider) ExportKubeConfig(name string, explicitPath string) error {
-	return kubeconfig.Export(p.provider, defaultName(name), explicitPath)
+func (p *Provider) ExportKubeConfig(name string, explicitPath string, internal bool) error {
+	return kubeconfig.Export(p.provider, defaultName(name), explicitPath, !internal)
 }
 
 // ListNodes returns the list of container IDs for the "nodes" in the cluster

--- a/pkg/cmd/kind/export/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kind/export/kubeconfig/kubeconfig.go
@@ -31,6 +31,7 @@ import (
 type flagpole struct {
 	Name       string
 	Kubeconfig string
+	Internal   bool
 }
 
 // NewCommand returns a new cobra.Command for exporting the kubeconfig
@@ -58,6 +59,12 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		"",
 		"sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config",
 	)
+	cmd.Flags().BoolVar(
+		&flags.Internal,
+		"internal",
+		false,
+		"use internal address instead of external",
+	)
 	return cmd
 }
 
@@ -66,7 +73,7 @@ func runE(logger log.Logger, flags *flagpole) error {
 		cluster.ProviderWithLogger(logger),
 		runtime.GetDefault(logger),
 	)
-	if err := provider.ExportKubeConfig(flags.Name, flags.Kubeconfig); err != nil {
+	if err := provider.ExportKubeConfig(flags.Name, flags.Kubeconfig, flags.Internal); err != nil {
 		return err
 	}
 	// TODO: get kind-name from a method? OTOH we probably want to keep this


### PR DESCRIPTION
I implemented this so that I can test KubeFed with kind, and without the need to manually edit or merge files. Please let me know what you think about it.

I have not (yet) signed CLA, but I will if there is a chance that this may be merged.

Enhancement #2217
Further discussion: #2205 