### PR TITLE
don't allow _ in cluster names

### DIFF
--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -29,7 +29,7 @@ import (
 // and suffix this name, we can relax it a little
 // see NewContext() for usage
 // https://godoc.org/github.com/docker/docker/daemon/names#pkg-constants
-var validNameRE = regexp.MustCompile(`^[a-z0-9_.-]+$`)
+var validNameRE = regexp.MustCompile(`^[a-z0-9.-]+$`)
 
 // Validate returns a ConfigErrors with an entry for each problem
 // with the config, or nil if there are none


### PR DESCRIPTION
basically the trivial change in https://github.com/kubernetes-sigs/kind/pull/2196/ but passing the CLA ...
fixes https://github.com/kubernetes-sigs/kind/issues/2195 https://github.com/kubernetes-sigs/kind/pull/2196