### PR TITLE
cgroup2 CI: add Rootless Docker/Podman provider

### DIFF
--- a/.github/workflows/cgroup2.yaml
+++ b/.github/workflows/cgroup2.yaml
@@ -16,10 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         provider: [docker, podman]
+        rootless: ["rootful", "rootless"]
     env:
       KIND_EXPERIMENTAL_PROVIDER: "${{ matrix.provider }}"
+      ROOTLESS: "${{ matrix.rootless }}"
       HELPER: "./hack/ci/vagrant-helper.sh"
-      JOB_NAME: "cgroup2-${{ matrix.provider }}"
+      JOB_NAME: "cgroup2-${{ matrix.provider }}-${{ matrix.rootless }}"
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -33,8 +35,30 @@ jobs:
             if vagrant up; then
               break
             fi
+            vagrant destroy -f
             sleep $i
           done
+
+      - name: Set up Rootless Docker
+        if: ${{ matrix.provider == 'docker' && matrix.rootless == 'rootless' }}
+        run: |
+          # Disable SELinux for Rootless Docker, until the following PRs gets merged into Docker CE:
+          # - https://github.com/moby/moby/pull/42199 ("dockerd-rootless.sh: avoid /run/xtables.lock EACCES on SELinux hosts")
+          # - https://github.com/moby/moby/pull/42334 ("rootless: disable overlay2 if running with SELinux")
+          "$HELPER" sudo setenforce 0
+          # Disable the rootful daemon
+          "$HELPER" sudo systemctl disable --now docker
+          # Install the systemd unit
+          "$HELPER" dockerd-rootless-setuptool.sh install
+          # Modify the client config to use the rootless daemon by default
+          "$HELPER" docker context use rootless
+
+
+      - name: Set up Rootless Podman
+        if: ${{ matrix.provider == 'podman' && matrix.rootless == 'rootless' }}
+        run: |
+          # We have modprobe ip6_tables in Vagrantfile, but it seems we have to modprobe it once again
+          "$HELPER" sudo modprobe ip6_tables
 
       - name: Show provider info
         run: |
@@ -43,7 +67,7 @@ jobs:
 
       - name: Create a cluster
         run: |
-          "$HELPER" kind create cluster -v7 --wait 1m --retain
+          "$HELPER" kind create cluster -v7 --wait 10m --retain
 
       - name: Get Cluster status
         run: |

--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -17,12 +17,23 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-packages", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
     set -eux -o pipefail
-    dnf install -y golang-go make kubernetes-client podman
+    # Ensure network-related modules to be loaded
+    modprobe tap ip_tables iptables_nat ip6_tables ip6tables_nat
 
-    # The moby-engine package (v19.03) included in Fedora 33 does not support cgroup v2.
-    # So we need to install Docker 20.10 (or later) from the upstream.
+    # The moby-engine package included in Fedora lacks support for rootless,
+    # So we need to install docker-ce and docker-ce-rootless-extras from the upstream.
     curl -fsSL https://get.docker.com | sh
+    dnf install -y golang-go make kubernetes-client podman docker-ce-rootless-extras
     systemctl enable --now docker
+
+    # Configuration for rootless: https://kind.sigs.k8s.io/docs/user/rootless/
+    mkdir -p "/etc/systemd/system/user@.service.d"
+    cat <<EOF >"/etc/systemd/system/user@.service.d/delegate.conf"
+    [Service]
+    Delegate=yes
+    EOF
+    systemctl daemon-reload
+    loginctl enable-linger vagrant
     SHELL
   end
   config.vm.provision "install-kind", type: "shell", run: "once" do |sh|

--- a/hack/ci/vagrant-helper.sh
+++ b/hack/ci/vagrant-helper.sh
@@ -22,4 +22,10 @@ if [ ! -f "$SSH_CONFIG" ]; then
   vagrant ssh-config > "$SSH_CONFIG"
 fi
 
-exec ssh -F "$SSH_CONFIG" default sudo KIND_EXPERIMENTAL_PROVIDER="$KIND_EXPERIMENTAL_PROVIDER" "$@"
+sudo="sudo"
+if [ "$ROOTLESS" = "rootless" ]; then
+  sudo=
+fi
+
+# shellcheck disable=SC2086
+exec ssh -F "$SSH_CONFIG" default $sudo KIND_EXPERIMENTAL_PROVIDER="$KIND_EXPERIMENTAL_PROVIDER" "$@"


### PR DESCRIPTION
- The value of `matrix.rootless` ("rootful" or "rootless") is passed to `vagrant-helper.sh` as `$ROOTLESS`.
  The helper script removes sudo when `$ROOTLESS = "rootless"`.

- SELinux is disabled for Rootless Docker, until a couple of Moby PR   gets merged and cherry-picked into the Docker CE release.   (See the comment lines in the GHA yaml)
