### PR TITLE
Fix podman getSubnets()

### DIFF
--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -154,7 +154,7 @@ func commonArgs(cfg *config.Cluster, networkName string) ([]string, error) {
 	}
 
 	// pass proxy environment variables
-	proxyEnv, err := getProxyEnv(cfg)
+	proxyEnv, err := getProxyEnv(cfg, networkName)
 	if err != nil {
 		return nil, errors.Wrap(err, "proxy setup error")
 	}
@@ -257,12 +257,12 @@ func runArgsForLoadBalancer(cfg *config.Cluster, name string, args []string) ([]
 	return append(args, image), nil
 }
 
-func getProxyEnv(cfg *config.Cluster) (map[string]string, error) {
+func getProxyEnv(cfg *config.Cluster, networkName string) (map[string]string, error) {
 	envs := common.GetProxyEnvs(cfg)
 	// Specifically add the podman network subnets to NO_PROXY if we are using a proxy
 	if len(envs) > 0 {
-		// podman default bridge network is named "bridge" (https://docs.podman.com/network/bridge/#use-the-default-bridge-network)
-		subnets, err := getSubnets("bridge")
+		// kind default bridge is "kind"
+		subnets, err := getSubnets(networkName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -281,7 +281,8 @@ func getProxyEnv(cfg *config.Cluster, networkName string) (map[string]string, er
 }
 
 func getSubnets(networkName string) ([]string, error) {
-	format := `{{range (index (index . "IPAM") "Config")}}{{index . "Subnet"}} {{end}}`
+	// TODO: unmarshall json and get rid of this complex query
+	format := `{{ range (index (index (index (index . "plugins") 0 ) "ipam" ) "ranges")}}{{ index ( index . 0 ) "subnet" }} {{end}}`
 	cmd := exec.Command("podman", "network", "inspect", "-f", format, networkName)
 	lines, err := exec.OutputLines(cmd)
 	if err != nil {


### PR DESCRIPTION
Fix podman getSubnets()

Since we moved to custom networks, it has to get the information from the kind network
It also carries the fix in https://github.com/kubernetes-sigs/kind/pull/2199 that got stuck on CLA signing