### PR TITLE
api: fix comment about ipvs mode

### DIFF
--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -209,7 +209,7 @@ type ProxyMode string
 const (
 	// IPTablesProxyMode sets ProxyMode to iptables
 	IPTablesProxyMode ProxyMode = "iptables"
-	// IPVSProxyMode sets ProxyMode to iptables
+	// IPVSProxyMode sets ProxyMode to ipvs
 	IPVSProxyMode ProxyMode = "ipvs"
 )
 

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -170,7 +170,7 @@ type ProxyMode string
 const (
 	// IPTablesProxyMode sets ProxyMode to iptables
 	IPTablesProxyMode ProxyMode = "iptables"
-	// IPVSProxyMode sets ProxyMode to iptables
+	// IPVSProxyMode sets ProxyMode to ipvs
 	IPVSProxyMode ProxyMode = "ipvs"
 	// NoneProxyMode disables kube-proxy
 	NoneProxyMode ProxyMode = "none"


### PR DESCRIPTION
This patch fix the comment regarding kube-proxy ipvs mode.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>