### PR TITLE
ProxyMode: Add userspace for proxy mode

### DIFF
--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -211,6 +211,8 @@ const (
 	IPTablesProxyMode ProxyMode = "iptables"
 	// IPVSProxyMode sets ProxyMode to iptables
 	IPVSProxyMode ProxyMode = "ipvs"
+	// UserSpaceProxyMode sets ProxyMode to userspace (legacy)
+	UserSpaceProxyMode ProxyMode = "userspace"
 )
 
 // PatchJSON6902 represents an inline kustomize json 6902 patch

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -55,7 +55,7 @@ type ConfigData struct {
 	// The Token for TLS bootstrap
 	Token string
 
-	// KubeProxyMode defines the kube-proxy mode between iptables or ipvs
+	// KubeProxyMode defines the kube-proxy mode: userspace (legacy), iptables or ipvs
 	KubeProxyMode string
 	// The subnet used for pods
 	PodSubnet string

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -168,6 +168,8 @@ const (
 type ProxyMode string
 
 const (
+	// UserSpaceProxyMode sets ProxyMode to userspace (legacy)
+	UserSpaceProxyMode ProxyMode = "userspace"
 	// IPTablesProxyMode sets ProxyMode to iptables
 	IPTablesProxyMode ProxyMode = "iptables"
 	// IPVSProxyMode sets ProxyMode to iptables

--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -64,7 +64,7 @@ func (c *Cluster) Validate() error {
 
 	// KubeProxyMode should be iptables or ipvs
 	if c.Networking.KubeProxyMode != IPTablesProxyMode && c.Networking.KubeProxyMode != IPVSProxyMode &&
-		c.Networking.KubeProxyMode != NoneProxyMode {
+		c.Networking.KubeProxyMode != NoneProxyMode && c.Networking.KubeProxyMode != UserSpaceProxyMode {
 		errs = append(errs, errors.Errorf("invalid kubeProxyMode: %s", c.Networking.KubeProxyMode))
 	}
 

--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -213,7 +213,7 @@ networking:
 
 #### kube-proxy mode
 
-You can configure the kube-proxy mode that will be used, between iptables and ipvs. By
+You can configure the kube-proxy mode that will be used, userspace (legacy), iptables or ipvs. By
 default iptables is used
 
 {{< codeFromInline lang="yaml" >}}


### PR DESCRIPTION
kube-proxy has three modes: userspace, iptables and ipvs.
Currently, we are making conformance tests to compare
outputs from all modes. Adding userspace mode to kind
will speedup deploys and tests regarding kube-proxy.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>