### PR TITLE
Adds SCTP to comment of protocol in PortMapping

### DIFF
--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -277,7 +277,7 @@ type PortMapping struct {
 	HostPort int32 `yaml:"hostPort,omitempty"`
 	// TODO: add protocol (tcp/udp) and port-ranges
 	ListenAddress string `yaml:"listenAddress,omitempty"`
-	// Protocol (TCP/UDP)
+	// Protocol (TCP/UDP/SCTP)
 	Protocol PortMappingProtocol `yaml:"protocol,omitempty"`
 }
 

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -235,7 +235,7 @@ type PortMapping struct {
 	HostPort int32
 	// TODO: add protocol (tcp/udp) and port-ranges
 	ListenAddress string
-	// Protocol (TCP/UDP)
+	// Protocol (TCP/UDP/SCTP)
 	Protocol PortMappingProtocol
 }
 


### PR DESCRIPTION
This PR updates comments of protocol in PortMapping, because protocol supports "SCTP" also.