### PR TITLE
Update Ingress apiVersion

### DIFF
--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -46,7 +46,7 @@ spec:
   # Default port used by the image
   - port: 5678
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress


### PR DESCRIPTION
Update ingress apiVersion from v1beta1 to v1 to fix this warning:
`Warning: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress`