### PR TITLE
Update ingress from v1beta1 to v1

### DIFF
--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -46,7 +46,7 @@ spec:
   # Default port used by the image
   - port: 5678
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress
@@ -54,12 +54,18 @@ spec:
   rules:
   - http:
       paths:
-      - path: /foo
+      - pathType: Prefix
+        path: "/foo"
         backend:
-          serviceName: foo-service
-          servicePort: 5678
-      - path: /bar
+          service:
+            name: foo-service
+            port:
+              number: 5678
+      - pathType: Prefix
+        path: "/bar"
         backend:
-          serviceName: bar-service
-          servicePort: 5678
+          service:
+            name: bar-service
+            port:
+              number: 5678
 ---


### PR DESCRIPTION
Update ingress from v1bet1 to v1 and update `Ingress.spec.rules[0].http.paths[0].backend` changes.
https://kubernetes.io/docs/concepts/services-networking/ingress/