### PR TITLE
Use correct module names iptable_nat, ip6table_nat

### DIFF
--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
     sh.inline = <<~SHELL
     set -eux -o pipefail
     # Ensure network-related modules to be loaded
-    modprobe tap ip_tables iptables_nat ip6_tables ip6tables_nat
+    modprobe tap ip_tables iptable_nat ip6_tables ip6table_nat
 
     # The moby-engine package included in Fedora lacks support for rootless,
     # So we need to install docker-ce and docker-ce-rootless-extras from the upstream.

--- a/site/content/docs/user/rootless.md
+++ b/site/content/docs/user/rootless.md
@@ -29,8 +29,8 @@ Delegate=yes
 
 - Create `/etc/modules-load.d/iptables.conf` with the following content:
 ```
-iptables_nat
-ip6tables_nat
+iptable_nat
+ip6table_nat
 ```
 
 ## Restrictions


### PR DESCRIPTION
iptables_nat and ip6tables_nat seem to be typos. Correct names don't have the `s`