### PR TITLE
reduce image sizes

### DIFF
--- a/hack/release/build/push-node.sh
+++ b/hack/release/build/push-node.sh
@@ -56,6 +56,7 @@ if [ -z "${GOFLAGS}" ]; then
         ;;
     esac
 fi
+export GOFLAGS
 
 # build for each arch
 IMAGE="kindest/node:${kube_version}"

--- a/hack/release/build/push-node.sh
+++ b/hack/release/build/push-node.sh
@@ -28,13 +28,6 @@ KUBEROOT="${KUBEROOT:-${GOPATH}/src/k8s.io/kubernetes}"
 # ensure we have qemu setup (de-duped logic with setting up buildx for multi-arch)
 "${REPO_ROOT}/hack/build/init-buildx.sh"
 
-# kubernetes build option(s)
-GOFLAGS="${GOFLAGS:-}"
-if [ -z "${GOFLAGS}" ]; then
-    # TODO: add dockerless when 1.19 or greater
-    GOFLAGS="-tags=providerless"
-fi
-
 # NOTE: adding platforms is costly in terms of build time
 # we will consider expanding this in the future, for now the aim is to prove
 # multi-arch and enable developers working on commonly available hardware
@@ -49,6 +42,20 @@ set -x
 # get kubernetes version
 version_line="$(cd "${KUBEROOT}"; ./hack/print-workspace-status.sh | grep 'gitVersion')"
 kube_version="${version_line#"gitVersion "}"
+
+# kubernetes build option(s)
+GOFLAGS="${GOFLAGS:-}"
+if [ -z "${GOFLAGS}" ]; then
+    # TODO: add dockerless when 1.19 or greater
+    case "${kube_version}" in
+    v1.1[0-8].*)
+        GOFLAGS="-tags=providerless"
+        ;;
+    *)
+        GOFLAGS="-tags=providerless,dockerless"
+        ;;
+    esac
+fi
 
 # build for each arch
 IMAGE="kindest/node:${kube_version}"

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -20,7 +20,7 @@
 # start from ubuntu 20.10, this image is reasonably small as a starting point
 # for a kubernetes node image, it doesn't contain much we don't need
 ARG BASE_IMAGE=ubuntu:21.04
-FROM $BASE_IMAGE
+FROM $BASE_IMAGE as build
 
 # `docker buildx` automatically sets this arg value, but we add the arg for
 # regular `docker bulid` invocations to force a selection
@@ -80,7 +80,7 @@ COPY --chmod=0644 files/etc/systemd/system/kubelet.service.d/* /etc/systemd/syst
 #
 # First we must ensure that our util scripts are executable.
 #
-# The base image already has: ssh, apt, snapd, but we need to install more packages.
+# The base image already has a basic userspace + apt but we need to install more packages.
 # Packages installed are broken down into (each on a line):
 # - packages needed to run services (systemd)
 # - packages needed for kubernetes components
@@ -104,10 +104,11 @@ COPY --chmod=0644 files/etc/systemd/system/kubelet.service.d/* /etc/systemd/syst
 # Finally we adjust tempfiles cleanup to be 1 minute after "boot" instead of 15m
 # This is plenty after we've done initial setup for a node, but before we are
 # likely to try to export logs etc.
+
 RUN echo "Installing Packages ..." \
     && DEBIAN_FRONTEND=noninteractive clean-install \
       systemd \
-      conntrack iptables iproute2 ethtool socat util-linux mount ebtables udev kmod \
+      conntrack iptables iproute2 ethtool socat util-linux mount ebtables kmod \
       libseccomp2 pigz \
       bash ca-certificates curl rsync \
       nfs-common fuse-overlayfs \
@@ -119,10 +120,12 @@ RUN echo "Installing Packages ..." \
     && rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
     && rm -f /lib/systemd/system/basic.target.wants/* \
     && echo "ReadKMsg=no" >> /etc/systemd/journald.conf \
-    && ln -s "$(which systemd)" /sbin/init \
- && echo "Enabling kubelet ... " \
-    && systemctl enable kubelet.service \
- && echo "Installing containerd ..." \
+    && ln -s "$(which systemd)" /sbin/init
+
+RUN echo "Enabling kubelet ... " \
+    && systemctl enable kubelet.service
+
+RUN echo "Installing containerd ..." \
     && curl -sSL --retry 5 --output /tmp/containerd.${TARGETARCH}.tgz "${CONTAINERD_URL}" \
     && echo "${CONTAINERD_AMD64_SHA256SUM}  /tmp/containerd.amd64.tgz" | tee /tmp/containerd.sha256 \
     && echo "${CONTAINERD_ARM64_SHA256SUM}  /tmp/containerd.arm64.tgz" | tee -a /tmp/containerd.sha256 \
@@ -141,8 +144,9 @@ RUN echo "Installing Packages ..." \
     && chmod 755 /usr/local/sbin/runc \
     && containerd --version \
     && runc --version \
-    && systemctl enable containerd \
- && echo "Installing crictl ..." \
+    && systemctl enable containerd 
+
+RUN echo "Installing crictl ..." \
     && curl -sSL --retry 5 --output /tmp/crictl.${TARGETARCH}.tgz "${CRICTL_URL}" \
     && echo "${CRICTL_AMD64_SHA256SUM}  /tmp/crictl.amd64.tgz" | tee /tmp/crictl.sha256 \
     && echo "${CRICTL_ARM64_SHA256SUM}  /tmp/crictl.arm64.tgz" | tee -a /tmp/crictl.sha256 \
@@ -150,8 +154,9 @@ RUN echo "Installing Packages ..." \
     && sha256sum --ignore-missing -c /tmp/crictl.sha256 \
     && rm -f /tmp/crictl.sha256 \
     && tar -C /usr/local/bin -xzvf /tmp/crictl.${TARGETARCH}.tgz \
-    && rm -rf /tmp/crictl.${TARGETARCH}.tgz \
- && echo "Installing CNI plugin binaries ..." \
+    && rm -rf /tmp/crictl.${TARGETARCH}.tgz
+
+RUN echo "Installing CNI plugin binaries ..." \
     && curl -sSL --retry 5 --output /tmp/cni.${TARGETARCH}.tgz "${CNI_PLUGINS_URL}" \
     && echo "${CNI_PLUGINS_AMD64_SHA256SUM}  /tmp/cni.amd64.tgz" | tee /tmp/cni.sha256 \
     && echo "${CNI_PLUGINS_ARM64_SHA256SUM}  /tmp/cni.arm64.tgz" | tee -a /tmp/cni.sha256 \
@@ -167,8 +172,9 @@ RUN echo "Installing Packages ..." \
          -o -iname portmap \
          -o -iname loopback \
       \) \
-      -delete \
- && echo "Installing containerd-fuse-overlayfs ..." \
+      -delete
+
+RUN echo "Installing containerd-fuse-overlayfs ..." \
     && curl -sSL --retry 5 --output /tmp/containerd-fuse-overlayfs.${TARGETARCH}.tgz "${CONTAINERD_FUSE_OVERLAYFS_URL}" \
     && echo "${CONTAINERD_FUSE_OVERLAYFS_AMD64_SHA256SUM}  /tmp/containerd-fuse-overlayfs.amd64.tgz" | tee /tmp/containerd-fuse-overlayfs.sha256 \
     && echo "${CONTAINERD_FUSE_OVERLAYFS_ARM64_SHA256SUM}  /tmp/containerd-fuse-overlayfs.arm64.tgz" | tee -a /tmp/containerd-fuse-overlayfs.sha256 \
@@ -176,13 +182,13 @@ RUN echo "Installing Packages ..." \
     && sha256sum --ignore-missing -c /tmp/containerd-fuse-overlayfs.sha256 \
     && rm -f /tmp/containerd-fuse-overlayfs.sha256 \
     && tar -C /usr/local/bin -xzvf /tmp/containerd-fuse-overlayfs.${TARGETARCH}.tgz \
-    && rm -rf /tmp/containerd-fuse-overlayfs.${TARGETARCH}.tgz \
- && echo "Ensuring /etc/kubernetes/manifests" \
-    && mkdir -p /etc/kubernetes/manifests \
- && echo "Adjusting systemd-tmpfiles timer" \
-    && sed -i /usr/lib/systemd/system/systemd-tmpfiles-clean.timer -e 's#OnBootSec=.*#OnBootSec=1min#' \
- && echo "Disabling udev" \
-    && systemctl disable udev.service
+    && rm -rf /tmp/containerd-fuse-overlayfs.${TARGETARCH}.tgz
+
+RUN echo "Ensuring /etc/kubernetes/manifests" \
+    && mkdir -p /etc/kubernetes/manifests 
+
+RUN echo "Adjusting systemd-tmpfiles timer" \
+    && sed -i /usr/lib/systemd/system/systemd-tmpfiles-clean.timer -e 's#OnBootSec=.*#OnBootSec=1min#'
 
 # tell systemd that it is in docker (it will check for the container env)
 # https://systemd.io/CONTAINER_INTERFACE/
@@ -192,3 +198,7 @@ ENV container docker
 STOPSIGNAL SIGRTMIN+3
 # NOTE: this is *only* for documentation, the entrypoint is overridden later
 ENTRYPOINT [ "/usr/local/bin/entrypoint", "/sbin/init" ]
+
+# squash
+FROM scratch
+COPY --from=build / /

--- a/images/base/files/usr/local/bin/clean-install
+++ b/images/base/files/usr/local/bin/clean-install
@@ -35,5 +35,6 @@ rm -rf \
    /tmp/* \
    /var/tmp/* \
    /usr/share/doc/* \
+   /usr/share/doc-base/* \
    /usr/share/man/* \
    /usr/share/local/*

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -205,7 +205,7 @@ fix_cgroup() {
   local current_cgroup
   current_cgroup=$(grep -E '^[^:]*:([^:]*,)?cpu(,[^,:]*)?:.*' /proc/self/cgroup | cut -d: -f3)
   local cgroup_subsystems
-  cgroup_subsystems=$(findmnt -lun -o source,target -t cgroup | grep "${current_cgroup}" | awk '{print $2}')
+  cgroup_subsystems=$(findmnt -lun -o source,target -t cgroup | grep "${current_cgroup}" | cut -d' ' -f2)
   # For each cgroup subsystem, Docker does a bind mount from the current
   # cgroup to the root of the cgroup subsystem. For instance:
   #   /sys/fs/cgroup/memory/docker/<cid> -> /sys/fs/cgroup/memory

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.21.1@sha256:80773e2069dd4a80a4929fdef050c1e463e1d5578c2cd9af3962cfbc230e1500"
+const Image = "kindest/node:v1.21.1@sha256:8b228e4357cb86893543e64602d00757a605a6befbfcba4ff1ebf3d59296988e"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,4 +20,4 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "docker.io/kindest/base:v20210528-52724f0d"
+const DefaultBaseImage = "docker.io/kindest/base:v20210616-32023073"


### PR DESCRIPTION
see commits

Improvement:

| image | size (dockerhub / compressed) | size (local) |
|-------|--------------------------------|------------|
| `kindest/base:v20210604-57a96b9c` | 107.84 MB | 308 MB |
| `kindest/base:v20210616-32023073` |  103.72 MB | 287 MB |

(all sizes for linux/amd64, but the delta is similar for other architectures)

... this is not as much as I hoped, but it's not nothing.

crictl appears to be rather massive for a CLI at 44M, might be worth looking into at some point.

After adding #1528 and fixing up `push-build.sh` to leverage providerless+dockerless tags properly when available:
```
$ docker images kindest/node
REPOSITORY     TAG        IMAGE ID       CREATED              SIZE
kindest/node   latest     3ccd0683248a   About a minute ago   931MB
kindest/node   v1.21.1    32b8b755dee8   3 weeks ago          1.12GB
```