### PR TITLE
Cross off ARM support from Roadmap

### DIFF
--- a/site/content/docs/contributing/1.0-roadmap.md
+++ b/site/content/docs/contributing/1.0-roadmap.md
@@ -43,8 +43,7 @@ for managing clusters in test harnesses
 
 To reach "GA" [grade][deprecation-policy] kind needs to at minimum:
 
-- [ ] Support non-AMD64 architectures (namely ARM) - [#166]
-  - TODO: move this to post GA? This is expensive and has relatively low demand so far.
+- [x] Support non-AMD64 architectures (namely ARM) - [#166]
 - [ ] Automated publishing of Kubernetes release based kind "node" images - [#197]
 - [x] Support for runtimes other than docker/default including podman, ignite etc.
 - [ ] Enable audit-logging


### PR DESCRIPTION
ARM support is provided according to https://github.com/kubernetes-sigs/kind/issues/166 - It hasn't been crossed off the roadmap yet.