### PR TITLE
api version v1beta1 deprecated

### DIFF
--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -46,7 +46,7 @@ spec:
   # Default port used by the image
   - port: 5678
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress


### PR DESCRIPTION
Ingrsss api version vebeta1 deprecated for version 1.19 and higher.
kind latest version is using 1.21 so it needs to be updated to v1