### PR TITLE
Change Ingress NGINX script to use stable version

### DIFF
--- a/site/content/docs/user/ingress.md
+++ b/site/content/docs/user/ingress.md
@@ -116,7 +116,8 @@ Additional information about Contour can be found at: [projectcontour.io](https:
 ### Ingress NGINX
 
 {{< codeFromInline lang="bash" >}}
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
+VERSION=$(curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/stable.txt)
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/${VERSION}/deploy/static/provider/kind/deploy.yaml
 {{< /codeFromInline >}}
 
 The manifests contains kind specific patches to forward the hostPorts to the


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

We have a bunch of users complaining (with reason) about the new non-released deploy manifest.

Examples: 
https://github.com/kubernetes/ingress-nginx/issues/7306
https://github.com/kubernetes/ingress-nginx/issues/7305

This change adds a stable.txt file that might be used as part of the install script in KinD