### PR TITLE
Fix `container` envvar and StopSignal are not set in kindest/node:v1.21.2

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -190,6 +190,10 @@ RUN echo "Ensuring /etc/kubernetes/manifests" \
 RUN echo "Adjusting systemd-tmpfiles timer" \
     && sed -i /usr/lib/systemd/system/systemd-tmpfiles-clean.timer -e 's#OnBootSec=.*#OnBootSec=1min#'
 
+# squash
+FROM scratch
+COPY --from=build / /
+
 # tell systemd that it is in docker (it will check for the container env)
 # https://systemd.io/CONTAINER_INTERFACE/
 ENV container docker
@@ -198,7 +202,3 @@ ENV container docker
 STOPSIGNAL SIGRTMIN+3
 # NOTE: this is *only* for documentation, the entrypoint is overridden later
 ENTRYPOINT [ "/usr/local/bin/entrypoint", "/sbin/init" ]
-
-# squash
-FROM scratch
-COPY --from=build / /

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.21.2@sha256:8a0b572d3e5c24fe516cfc612ce6e5d707b4b6b2f97a4943ece85673f91f853d"
+const Image = "kindest/node:v1.21.2@sha256:0fda882e43d425622f045b492f8bd83c2e0b4984fc03e2e05ec101ca1a685fb7"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,4 +20,4 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "docker.io/kindest/base:v20210629-45c5aa40"
+const DefaultBaseImage = "docker.io/kindest/base:v20210712-e05318fb"


### PR DESCRIPTION
In a recently released node image, `container` environment variable and `StopSignal` configuration are disabled.

```console
$ docker inspect -f 'Env: {{ .Config.Env }}, StopSignal: {{ .Config.StopSignal }}' kindest/node:v1.21.2@sha256:de73899439c77a4bb6609b10d4eb8b8c22c2d483fa569b112039e652fe4bf81f
Env: [PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin], StopSignal: 
```

In the older version, these configurations were enabled.

```console
$ docker inspect -f 'Env: {{ .Config.Env }}, StopSignal: {{ .Config.StopSignal }}' kindest/node:v1.20.7@sha256:4c68efafa97d278a75a5b4677fb27e4986b03301739f1f87575af32202da9cfe
Env: [PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin container=docker], StopSignal: SIGRTMIN+3
```

Because of this, `kind create cluster` will fail when using kind with the `main` version of containerd:

```
Jul 06 02:06:34 7eceeb9-control-plane containerd[188]: time="2021-07-06T02:06:34.012977745Z" level=error msg="CreateContainer within sandbox \"5b7f060e5088d97bfb09c6423d40be3828743cacff13daa2117137c16dd0a22d\" for &ContainerMetadata{Name:kube-apiserver,Attempt:0,} failed" error="failed to create containerd container: get apparmor_parser version: exec: \"apparmor_parser\": executable file not found in $PATH"
```

(current `kindest/node:v1.21.1` uses containerd v1.5.2 so this doesn't encounter this failure because of [a bug in containerd which is fixed recently](https://github.com/containerd/containerd/pull/5519))

This is because `ENV` and `STOPSIGNAL` are not set in the final stage of `images/base/Dockerfile`.
This commit fixes this issue.
