### PR TITLE
Cli: add the cluster name to the error message

### DIFF
--- a/pkg/cluster/internal/kubeconfig/kubeconfig.go
+++ b/pkg/cluster/internal/kubeconfig/kubeconfig.go
@@ -63,7 +63,7 @@ func Get(p providers.Provider, name string, external bool) (string, error) {
 }
 
 // ContextForCluster returns the context name for a kind cluster based on
-// it's name. This key is used for all list entries of kind clusters
+// its name. This key is used for all list entries of kind clusters
 func ContextForCluster(kindClusterName string) string {
 	return kubeconfig.KINDClusterKey(kindClusterName)
 }
@@ -80,7 +80,8 @@ func get(p providers.Provider, name string, external bool) (*kubeconfig.Config, 
 		return nil, err
 	}
 	if len(nodes) < 1 {
-		return nil, errors.New("could not locate any control plane nodes")
+		return nil, errors.Errorf("could not locate any control plane nodes for cluster named '%s'. "+
+			"Use the --name option to select a different cluster", name)
 	}
 	node := nodes[0]
 


### PR DESCRIPTION
- When you ask for a kubeconfig file for a named
cluster (i..e not the default "kind"), instead of
getting the (cryptic) message:
"could not locate any control plane nodes",
also return the name of the cluster, and a hint
to what the user should maybe supply (the --name
option).
- Note: Did not find any existing tests for this file, nor which mock
libraries we should use to mock the dependencies?

Testing Done: Create a named cluster and tested the `get kubeconfig` option:
```
$ make build unit verify
$ ./bin/kind create cluster --name mytest

$ ./bin/kind get kubeconfig
ERROR: could not locate any control plane nodes for cluster named 'kind'. Use the --name option to select a different cluster

$ ./bin/kind get kubeconfig --name mytest
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: LS0tLS[...]
```

Bug Number: https://github.com/kubernetes-sigs/kind/issues/2205