### PR TITLE
[WIP] Switch from Alpine to Ubuntu based haproxy image

### DIFF
--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 # standard haproxy image + minimal config so the container will not exit
-ARG BASE="haproxy:2.2.0-alpine"
+ARG BASE="haproxy:2.2.0"
 FROM ${BASE}
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg


### PR DESCRIPTION
should we get off of alpine? looks like there's a ubuntu based image we could go to

(since https://github.com/kubernetes/enhancements/blob/master/keps/sig-release/1729-rebase-images-to-distroless/README.md is preaching for debian-base and we don't have one of those)

Signed-off-by: Davanum Srinivas <davanum@gmail.com>