### PR TITLE
enable sysctl route_localnet

### DIFF
--- a/images/base/files/etc/sysctl.d/10-network-magic.conf
+++ b/images/base/files/etc/sysctl.d/10-network-magic.conf
@@ -1,0 +1,11 @@
+# Do not consider loopback addresses as martian source or destination while routing
+# - Docker with custom networks uses an embedded DNS server with address 172.0.0.11
+# - Kubernetes pods mount the node resolv.conf, so they can't use a loopack address
+# that is only reachable from the node.
+#
+# KIND rewrites the well-known docker DNS address 127.0.0.11 by a non-loopback address.
+# The DNS traffic coming from a pod will have to route to a localhost address to be NATed,
+# hence we have to enable route_localnet or pods DNS will not work.
+# Kubernetes mitigates the possible security issue caused by enabling this option.
+# ref: https://nvd.nist.gov/vuln/detail/CVE-2020-8558
+net.ipv4.conf.all.route_localnet=1

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,4 +20,4 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "docker.io/kindest/base:v20210729-fb821a4c"
+const DefaultBaseImage = "docker.io/kindest/base:v20210729-302b42d2"


### PR DESCRIPTION
Pods dns traffic is rewritten to localhost, hence we need to
enable route_localnet option.

docker for custom networks installs a custom dns server on the ip 172.17.0.11 and adds some iptables rules to redirect the traffic.
```
$ docker run -it ubuntu bash --network kind
root@e33b86fa05dd:/# iptables-save
# Generated by iptables-save v1.8.4 on Sun Jul 18 22:57:49 2021
*filter
:INPUT ACCEPT [1542:19090817]
:FORWARD ACCEPT [0:0]
:OUTPUT ACCEPT [1416:83722]
COMMIT
# Completed on Sun Jul 18 22:57:49 2021
# Generated by iptables-save v1.8.4 on Sun Jul 18 22:57:49 2021
*nat
:PREROUTING ACCEPT [19:1715]
:INPUT ACCEPT [0:0]
:OUTPUT ACCEPT [5:300]
:POSTROUTING ACCEPT [10:677]
:DOCKER_OUTPUT - [0:0]
:DOCKER_POSTROUTING - [0:0]
-A OUTPUT -d 127.0.0.11/32 -j DOCKER_OUTPUT
-A POSTROUTING -d 127.0.0.11/32 -j DOCKER_POSTROUTING
-A DOCKER_OUTPUT -d 127.0.0.11/32 -p tcp -m tcp --dport 53 -j DNAT --to-destination 127.0.0.11:39405
-A DOCKER_OUTPUT -d 127.0.0.11/32 -p udp -m udp --dport 53 -j DNAT --to-destination 127.0.0.11:44107
-A DOCKER_POSTROUTING -s 127.0.0.11/32 -p tcp -m tcp --sport 39405 -j SNAT --to-source :53
-A DOCKER_POSTROUTING -s 127.0.0.11/32 -p udp -m udp --sport 44107 -j SNAT --to-source :53
COMMIT

root@e33b86fa05dd:/# sysctl -a | grep localnet
net.ipv4.conf.all.route_localnet = 0
net.ipv4.conf.default.route_localnet = 0
net.ipv4.conf.eth0.route_localnet = 0
net.ipv4.conf.lo.route_localnet = 0

root@e33b86fa05dd:/# cat /etc/resolv.conf 
nameserver 127.0.0.11
nameserver 2001:4860:4860::8888
nameserver 2001:4860:4860::8844
options edns0 trust-ad ndots:0
```

Kubernetes can't use a localhost address as resolv.conf so kind rewrites the docker dns address by the gateway of the kind network, and uses it as nameserver on the resolv.conf
```
root@kind-control-plane:/# iptables-save | grep DOCKER
:DOCKER_OUTPUT - [0:0]
:DOCKER_POSTROUTING - [0:0]
-A PREROUTING -d 172.18.0.1/32 -j DOCKER_OUTPUT
-A OUTPUT -d 172.18.0.1/32 -j DOCKER_OUTPUT
-A POSTROUTING -d 172.18.0.1/32 -j DOCKER_POSTROUTING
-A DOCKER_OUTPUT -d 172.18.0.1/32 -p tcp -m tcp --dport 53 -j DNAT --to-destination 127.0.0.11:40457
-A DOCKER_OUTPUT -d 172.18.0.1/32 -p udp -m udp --dport 53 -j DNAT --to-destination 127.0.0.11:51490
-A DOCKER_POSTROUTING -s 127.0.0.11/32 -p tcp -m tcp --sport 40457 -j SNAT --to-source 172.18.0.1:53
-A DOCKER_POSTROUTING -s 127.0.0.11/32 -p udp -m udp --sport 51490 -j SNAT --to-source 172.18.0.1:53
root@kind-control-plane:/# cat /etc/resolv.conf
nameserver 172.18.0.1
nameserver 2001:4860:4860::8888
nameserver 2001:4860:4860::8844
options edns0 trust-ad ndots:0

```

then the traffic comes from a pod, it has to DNAT to a localhost, hence route_localnet is needed so pods can access the DNS

Fixes: #2326