### PR TITLE
Add ability to specify log format for componentManager and apiServer.

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -90,27 +90,16 @@ create_cluster() {
   fi
 
   scheduler_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
-  SCHEDULER_LOG_FORMAT=${SCHEDULER_LOG_FORMAT:-$CLUSTER_LOG_FORMAT}
-  if [ -n "$SCHEDULER_LOG_FORMAT" ]; then
+  controllerManager_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
+  apiServer_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
+  if [ -n "$CLUSTER_LOG_FORMAT" ]; then
       check_log_format
       scheduler_extra_args="${scheduler_extra_args}
-      \"logging-format\": \"${SCHEDULER_LOG_FORMAT}\""
-  fi
-
-  controllerManager_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
-  CONTROLLERMANAGER_LOG_FORMAT=${CONTROLLERMANAGER_LOG_FORMAT:-$CLUSTER_LOG_FORMAT}
-  if [ -n "$CONTROLLERMANAGER_LOG_FORMAT" ]; then
-      check_log_format
+      \"logging-format\": \"${CLUSTER_LOG_FORMAT}\""
       controllerManager_extra_args="${controllerManager_extra_args}
-      \"logging-format\": \"${CONTROLLERMANAGER_LOG_FORMAT}\""
-  fi
-
-  apiServer_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
-  APISERVER_LOG_FORMAT=${APISERVER_LOG_FORMAT:-$CLUSTER_LOG_FORMAT}
-  if [ -n "$APISERVER_LOG_FORMAT" ]; then
-      check_log_format
+      \"logging-format\": \"${CLUSTER_LOG_FORMAT}\""
       apiServer_extra_args="${apiServer_extra_args}
-      \"logging-format\": \"${APISERVER_LOG_FORMAT}\""
+      \"logging-format\": \"${CLUSTER_LOG_FORMAT}\""
   fi
 
   # JSON map injected into featureGates config

--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -62,10 +62,10 @@ build() {
   make all WHAT='cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo'
 }
 
-check_log_format() {
+check_structured_log_support() {
 	case "${KUBE_VERSION}" in
 		v1.1[0-8].*)
-			echo "KUBELET_LOG_FORMAT is only supported on versions >= v1.19, got ${KUBE_VERSION}"
+			echo "$1 is only supported on versions >= v1.19, got ${KUBE_VERSION}"
 			exit 1
 			;;
 	esac
@@ -79,27 +79,26 @@ create_cluster() {
   # Default Log level for all components in test clusters
   KIND_CLUSTER_LOG_LEVEL=${KIND_CLUSTER_LOG_LEVEL:-4}
 
-  CLUSTER_LOG_FORMAT=${CLUSTER_LOG_FORMAT:-} 
   # potentially enable --logging-format
-  kubelet_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
-  KUBELET_LOG_FORMAT=${KUBELET_LOG_FORMAT:-$CLUSTER_LOG_FORMAT}
-  if [ -n "$KUBELET_LOG_FORMAT" ]; then
-      check_log_format
-      kubelet_extra_args="${kubelet_extra_args}
-      \"logging-format\": \"${KUBELET_LOG_FORMAT}\""
-  fi
-
+  CLUSTER_LOG_FORMAT=${CLUSTER_LOG_FORMAT:-}
   scheduler_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
   controllerManager_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
   apiServer_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
   if [ -n "$CLUSTER_LOG_FORMAT" ]; then
-      check_log_format
+      check_structured_log_support "CLUSTER_LOG_FORMAT"
       scheduler_extra_args="${scheduler_extra_args}
       \"logging-format\": \"${CLUSTER_LOG_FORMAT}\""
       controllerManager_extra_args="${controllerManager_extra_args}
       \"logging-format\": \"${CLUSTER_LOG_FORMAT}\""
       apiServer_extra_args="${apiServer_extra_args}
       \"logging-format\": \"${CLUSTER_LOG_FORMAT}\""
+  fi
+  kubelet_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
+  KUBELET_LOG_FORMAT=${KUBELET_LOG_FORMAT:-$CLUSTER_LOG_FORMAT}
+  if [ -n "$KUBELET_LOG_FORMAT" ]; then
+      check_structured_log_support "KUBECTL_LOG_FORMAT"
+      kubelet_extra_args="${kubelet_extra_args}
+      \"logging-format\": \"${KUBELET_LOG_FORMAT}\""
   fi
 
   # JSON map injected into featureGates config


### PR DESCRIPTION
This PR adds the ability to specify the log format for control-plane components, componentManager and apiServer. 

Reference: [kubernetes/kubernetes#100748 ](https://github.com/kubernetes/kubernetes/issues/100748)

