### PR TITLE
Add depricated comment for kube-root flag to build node-image help

### DIFF
--- a/pkg/cmd/kind/build/nodeimage/nodeimage.go
+++ b/pkg/cmd/kind/build/nodeimage/nodeimage.go
@@ -68,7 +68,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(
 		&flags.KubeRoot, "kube-root",
 		"",
-		"path to the Kubernetes source directory (if empty, the path is autodetected)",
+		"DEPRECATED: please switch to just the argument. path to the Kubernetes source directory (if empty, the path is autodetected)",
 	)
 	cmd.Flags().StringVar(
 		&flags.BaseImage, "base-image",

--- a/pkg/cmd/kind/build/nodeimage/nodeimage.go
+++ b/pkg/cmd/kind/build/nodeimage/nodeimage.go
@@ -68,7 +68,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(
 		&flags.KubeRoot, "kube-root",
 		"",
-		"DEPRECATED: please switch to just the argument. path to the Kubernetes source directory (if empty, the path is autodetected)",
+		"DEPRECATED: please switch to just the argument. Path to the Kubernetes source directory (if empty, the path is autodetected)",
 	)
 	cmd.Flags().StringVar(
 		&flags.BaseImage, "base-image",


### PR DESCRIPTION
This PR adds comment related to depricated for kube-root flag on `build node-image` help.

Current code mentions about this deprecated on execute:
```
$ kind build node-image --kube-root ./xxx
--kube-root is deprecated, please switch to passing this as an argument
...
...
```

But it's more friendly if it is said in help description.