### PR TITLE
change http to https websites

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -94,7 +94,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [go]: https://golang.org/
 [go-supported]: https://golang.org/doc/devel/release.html#policy
 [docker]: https://www.docker.com/
-[community page]: http://kubernetes.io/community/
+[community page]: https://kubernetes.io/community/
 [Kubernetes Code of Conduct]: https://github.com/kubernetes/community/blob/master/code-of-conduct.md
 [Go Report Card Badge]: https://goreportcard.com/badge/sigs.k8s.io/kind
 [Go Report Card]: https://goreportcard.com/report/sigs.k8s.io/kind
@@ -111,7 +111,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [SIG-Testing Mailing List]: https://groups.google.com/forum/#!forum/kubernetes-sig-testing
 [issue tracker]: https://github.com/kubernetes-sigs/kind/issues
 [filing an issue]: https://github.com/kubernetes-sigs/kind/issues/new
-[Kubernetes Slack]: http://slack.k8s.io/
+[Kubernetes Slack]: https://slack.k8s.io/
 [#kind]: https://kubernetes.slack.com/messages/CEKK1KTN2/
 [1.0 roadmap]: /docs/contributing/1.0-roadmap
 [install docker]: https://docs.docker.com/install/

--- a/site/content/docs/contributing/getting-started.md
+++ b/site/content/docs/contributing/getting-started.md
@@ -145,13 +145,13 @@ You'll specifically want to see the [documentation section] of the development g
 [install docker]: https://docs.docker.com/install/#supported-platforms
 [community]: https://github.com/kubernetes/community
 [contributor]: https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
-[Kubernetes Slack]: http://slack.k8s.io/
+[Kubernetes Slack]: https://slack.k8s.io/
 [#kind]: https://kubernetes.slack.com/messages/CEKK1KTN2/
 [@BenTheElder]: https://github.com/BenTheElder
 [@munnerz]: https://github.com/munnerz
 [@aojea]: https://github.com/aojea
 [@amwat]: https://github.com/amwat
-[community page]: http://kubernetes.io/community/
+[community page]: https://kubernetes.io/community/
 [modules]: https://github.com/golang/go/wiki/Modules
 [SIG-Testing Mailing List]: https://groups.google.com/forum/#!forum/kubernetes-sig-testing
 [CNCF]: https://www.cncf.io/

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -17,7 +17,7 @@ description: |-
   [issue tracker]: https://github.com/kubernetes-sigs/kind/issues
   [file an issue]: https://github.com/kubernetes-sigs/kind/issues/new
   [#kind]: https://kubernetes.slack.com/messages/CEKK1KTN2/
-  [kubernetes slack]: http://slack.k8s.io/
+  [kubernetes slack]: https://slack.k8s.io/
 ---
 
 
@@ -337,7 +337,7 @@ Although the policy has been fixed in Fedora 34, the fix has not been backported
 [issue tracker]: https://github.com/kubernetes-sigs/kind/issues
 [file an issue]: https://github.com/kubernetes-sigs/kind/issues/new
 [#kind]: https://kubernetes.slack.com/messages/CEKK1KTN2/
-[kubernetes slack]: http://slack.k8s.io/
+[kubernetes slack]: https://slack.k8s.io/
 [kind#136]: https://github.com/kubernetes-sigs/kind/issues/136
 [kind#136-docker]: https://github.com/kubernetes-sigs/kind/issues/136#issuecomment-457015838
 [kind#156]: https://github.com/kubernetes-sigs/kind/issues/156


### PR DESCRIPTION
Some links are http.

Notes:

* `http://slack.k8s.io/` does not redirect to https
* Not sure about license file which has links with http schema
* SVG's also have http for dtd