### PR TITLE
feat(cmd/load): auto pull images if not exist

### DIFF
--- a/pkg/build/nodeimage/buildcontext.go
+++ b/pkg/build/nodeimage/buildcontext.go
@@ -28,11 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
 
-	"sigs.k8s.io/kind/pkg/build/nodeimage/internal/container/docker"
 	"sigs.k8s.io/kind/pkg/build/nodeimage/internal/kube"
 	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/exec"
 	"sigs.k8s.io/kind/pkg/fs"
+	"sigs.k8s.io/kind/pkg/internal/container/docker"
 	"sigs.k8s.io/kind/pkg/log"
 )
 

--- a/pkg/internal/runtime/runtime.go
+++ b/pkg/internal/runtime/runtime.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"os"
+	"runtime"
 
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/log"
@@ -22,4 +23,9 @@ func GetDefault(logger log.Logger) cluster.ProviderOption {
 		logger.Warnf("ignoring unknown value %q for KIND_EXPERIMENTAL_PROVIDER", p)
 		return nil
 	}
+}
+
+// GetDockerBuildOsAndArch returns the current linux architecture
+func GetDockerBuildOsAndArch() string {
+	return "linux/" + runtime.GOARCH
 }


### PR DESCRIPTION
Fixes #2424

We had to move `pkg/{build/nodeimage => }/internal/container/docker` package. We couldn't access the [Pull()](https://github.com/kubernetes-sigs/kind/blob/3e8741e4dc3a57ead78d63fa4cfa26d486690704/pkg/build/nodeimage/internal/container/docker/pull.go#L27) function in the `.../nodeimage/internal/container/docker` package due to Go `internal` package access limitations. How should we proceed here?

Signed-off-by: Furkan <furkan.turkal@trendyol.com>
Co-authored-by: Batuhan <batuhan.apaydin@trendyol.com>