### PR TITLE
Revert workarounds for CI(rootless podman)

### DIFF
--- a/.github/workflows/cgroup2.yaml
+++ b/.github/workflows/cgroup2.yaml
@@ -39,11 +39,6 @@ jobs:
             sleep $i
           done
 
-      - name: Reboot (workaround for https://github.com/containers/podman/issues/10928)
-        run: |
-          vagrant halt
-          vagrant up
-
       - name: Set up Rootless Docker
         if: ${{ matrix.provider == 'docker' && matrix.rootless == 'rootless' }}
         run: |

--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -20,9 +20,6 @@ Vagrant.configure("2") do |config|
     # Ensure network-related modules to be loaded
     modprobe tap ip_tables iptable_nat ip6_tables ip6table_nat
 
-    # Workaround for https://github.com/containers/podman/issues/10928
-    dnf upgrade -y
-
     # The moby-engine package included in Fedora lacks support for rootless,
     # So we need to install docker-ce and docker-ce-rootless-extras from the upstream.
     curl -fsSL https://get.docker.com | sh


### PR DESCRIPTION
Revert this PR https://github.com/kubernetes-sigs/kind/pull/2367  

Because podman v3.3.0 is released, we don't need these workarounds anymore, and I think it might cover up some problems?



cc @AkihiroSuda