### PR TITLE
docs: switch to `legacy` branch of ingress-nginx

### DIFF
--- a/site/content/docs/user/ingress.md
+++ b/site/content/docs/user/ingress.md
@@ -116,7 +116,7 @@ Additional information about Contour can be found at: [projectcontour.io](https:
 ### Ingress NGINX
 
 {{< codeFromInline lang="bash" >}}
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/legacy/deploy/static/provider/kind/deploy.yaml
 {{< /codeFromInline >}}
 
 The manifests contains kind specific patches to forward the hostPorts to the


### PR DESCRIPTION
The master branch contains a "release v1.0.0" commit.

https://github.com/kubernetes/ingress-nginx/pull/7535/files#diff-f3875840bc792db4552edd11518c98846b1ab25e21930492aeb454a1fa02cb79R250-R288

With kind version 0.11.1, this causes:

````
unable to recognize "https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml": no matches for kind "IngressClass" in version "networking.k8s.io/v1"
Error from server (Invalid): error when creating "https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml": Service "ingress-nginx-controller-admission" is invalid: spec.ports[0].appProtocol: Forbidden: This field can be enabled with the ServiceAppProtocol feature gate
Error from server (Invalid): error when creating "https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml": Service "ingress-nginx-controller" is invalid: [spec.ports[0].appProtocol: Forbidden: This field can be enabled with the ServiceAppProtocol feature gate, spec.ports[1].appProtocol: Forbidden: This field can be enabled with the ServiceAppProtocol feature gate]
```

As a work-around, I used a commit from `legacy` branch locally.