### PR TITLE
upgrade pause image to 3.6

### DIFF
--- a/images/base/files/etc/containerd/config.toml
+++ b/images/base/files/etc/containerd/config.toml
@@ -25,7 +25,7 @@ version = 2
 
 [plugins."io.containerd.grpc.v1.cri"]
   # use fixed sandbox image
-  sandbox_image = "k8s.gcr.io/pause:3.5"
+  sandbox_image = "k8s.gcr.io/pause:3.6"
   # allow hugepages controller to be missing
   # see https://github.com/containerd/cri/pull/1501
   tolerate_missing_hugepages_controller = true


### PR DESCRIPTION
Signed-off-by: kerthcet <kerthcet@gmail.com>
Upgrade pause image to 3.6, an notable change since 3.5 is the Windows Server 2022 support, mentioned on issue: https://github.com/kubernetes/kubernetes/pull/104711