### PR TITLE
Validate: check conflicting ipfamily and pods / services subnet

### DIFF
--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -51,14 +51,13 @@ func (c *Cluster) Validate() error {
 		}
 	}
 
-	isDualStack := c.Networking.IPFamily == DualStackFamily
 	// podSubnet should be a valid CIDR
-	if err := validateSubnets(c.Networking.PodSubnet, isDualStack); err != nil {
+	if err := validateSubnets(c.Networking.PodSubnet, c.Networking.IPFamily); err != nil {
 		errs = append(errs, errors.Errorf("invalid pod subnet %v", err))
 	}
 
 	// serviceSubnet should be a valid CIDR
-	if err := validateSubnets(c.Networking.ServiceSubnet, isDualStack); err != nil {
+	if err := validateSubnets(c.Networking.ServiceSubnet, c.Networking.IPFamily); err != nil {
 		errs = append(errs, errors.Errorf("invalid service subnet %v", err))
 	}
 
@@ -140,7 +139,7 @@ func validatePort(port int32) error {
 	return nil
 }
 
-func validateSubnets(subnetStr string, dualstack bool) error {
+func validateSubnets(subnetStr string, ipFamily ClusterIPFamily) error {
 	allErrs := []error{}
 
 	cidrsString := strings.Split(subnetStr, ",")
@@ -153,7 +152,11 @@ func validateSubnets(subnetStr string, dualstack bool) error {
 		subnets = append(subnets, cidr)
 	}
 
+	dualstack := ipFamily == DualStackFamily
 	switch {
+	// if no subnets are defined
+	case len(subnets) == 0:
+		allErrs = append(allErrs, errors.New("no subnets defined"))
 	// if DualStack only 2 CIDRs allowed
 	case dualstack && len(subnets) > 2:
 		allErrs = append(allErrs, errors.New("expected one (IPv4 or IPv6) CIDR or two CIDRs from each family for dual-stack networking"))
@@ -168,6 +171,10 @@ func validateSubnets(subnetStr string, dualstack bool) error {
 	// if not DualStack only one CIDR allowed
 	case !dualstack && len(subnets) > 1:
 		allErrs = append(allErrs, errors.New("only one CIDR allowed for single-stack networking"))
+	case ipFamily == IPv4Family && subnets[0].IP.To4() == nil:
+		allErrs = append(allErrs, errors.New("expected IPv4 CIDR for IPv4 family"))
+	case ipFamily == IPv6Family && subnets[0].IP.To4() != nil:
+		allErrs = append(allErrs, errors.New("expected IPv6 CIDR for IPv6 family"))
 	}
 
 	if len(allErrs) > 0 {

--- a/pkg/internal/apis/config/validate_test.go
+++ b/pkg/internal/apis/config/validate_test.go
@@ -177,6 +177,54 @@ func TestClusterValidate(t *testing.T) {
 			ExpectErrors: 2,
 		},
 		{
+			Name: "ipv6 family and ipv4 podSubnet",
+			Cluster: func() Cluster {
+				c := Cluster{}
+				SetDefaultsCluster(&c)
+				c.Networking.PodSubnet = "192.168.0.2/24"
+				c.Networking.ServiceSubnet = "192.168.0.2/24"
+				c.Networking.IPFamily = IPv6Family
+				return c
+			}(),
+			ExpectErrors: 2,
+		},
+		{
+			Name: "ipv4 family and ipv6 podSubnet",
+			Cluster: func() Cluster {
+				c := Cluster{}
+				SetDefaultsCluster(&c)
+				c.Networking.PodSubnet = "fd00:1::/25"
+				c.Networking.ServiceSubnet = "fd00:1::/25"
+				c.Networking.IPFamily = IPv4Family
+				return c
+			}(),
+			ExpectErrors: 2,
+		},
+		{
+			// This test validates the empty podsubnet check. It should never happen
+			// in real world since defaulting is happening before the validation step.
+			Name: "no pod subnet",
+			Cluster: func() Cluster {
+				c := Cluster{}
+				SetDefaultsCluster(&c)
+				c.Networking.PodSubnet = ""
+				return c
+			}(),
+			ExpectErrors: 1,
+		},
+		{
+			// This test validates the empty servicesubnet check. It should never happen
+			// in real world since defaulting is happening before the validation step.
+			Name: "no service subnet",
+			Cluster: func() Cluster {
+				c := Cluster{}
+				SetDefaultsCluster(&c)
+				c.Networking.ServiceSubnet = ""
+				return c
+			}(),
+			ExpectErrors: 1,
+		},
+		{
 			Name: "missing control-plane",
 			Cluster: func() Cluster {
 				c := Cluster{}


### PR DESCRIPTION
When choosing a single stack ip family, we must ensure that the pod subnet / service subnet belong to the same family.

Fixes https://github.com/kubernetes-sigs/kind/issues/2468