### PR TITLE
only wait for mult-user system for cgroupsv2

### DIFF
--- a/pkg/cluster/internal/providers/common/provision.go
+++ b/pkg/cluster/internal/providers/common/provision.go
@@ -43,8 +43,8 @@ func WithWaitUntilLogRegexpMatches(re *regexp.Regexp) RunContainerOpt {
 }
 
 // WithWaitUntilSystemdReachesMultiUserSystem waits until the systemd in the container
-// reaches "Multi-User System" target, so that `docker exec` can be executed safely without
-// breaking cgroup v2 hierarchy.
+// reaches "Multi-User System" target if is using cgroups v2, so that `docker exec` can be
+// executed safely without breaking cgroup v2 hierarchy.
 //
 // This is implemented by grepping `docker logs` with "Reached target .*Multi-User System.*"
 // message from systemd.
@@ -53,7 +53,7 @@ func WithWaitUntilLogRegexpMatches(re *regexp.Regexp) RunContainerOpt {
 // Needed for avoiding "ERROR: this script needs /sys/fs/cgroup/cgroup.procs to be empty (for writing the top-level cgroup.subtree_control)"
 // See https://github.com/kubernetes-sigs/kind/issues/2409
 func WithWaitUntilSystemdReachesMultiUserSystem() RunContainerOpt {
-	re, err := regexp.Compile("Reached target .*Multi-User System.*")
+	re, err := regexp.Compile("Reached target .*Multi-User System.*|detected cgroup v1")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
My understanding is that we don't really need to wait for the Multi-user systemd target if we are using cgroupsv1, we can bail out soon if we know that we are using cgroups v1, saving some precious time on boot time.

However, this doesn't fully fixes #2460 ,  on cases where systemd logs doesn't show up on `docker logs`, I was wondering if we can add a systemd service that runs After=multi-user.target and logs our own message to make this more reliable