### PR TITLE
examples/kind-with-registry.sh now also works with other than reg_port='5000'

### DIFF
--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -18,7 +18,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
-    endpoint = ["http://${reg_name}:${reg_port}"]
+    endpoint = ["http://${reg_name}:5000"]
 EOF
 
 # connect the registry to the cluster network


### PR DESCRIPTION
Try changing reg_port to something other than 5000 and see that the local registry doesn't work without this PR.

The fix:

```diff
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
-    endpoint = ["http://${reg_name}:${reg_port}"]
+    endpoint = ["http://${reg_name}:5000"]
```

illustrates the problem: `kind-registry` is accessed from inside docker, so regardless of what port is used when starting it with:

    -p "127.0.0.1:${reg_port}:5000"

It must always be accessed as `kind-registry:5000` and not `kind-registry:${reg_port}`.

Without this PR, one gets this error:

```
  Normal   Pulling           8s                 kubelet            Pulling image "localhost:50000/hello-app:1.0"
  Warning  Failed            8s                 kubelet            Failed to pull image "localhost:50000/hello-app:1.0": rpc error: code = Unknown desc = failed to pull and unpack image "localhost:50000/hello-app:1.0": failed to resolve reference "localhost:50000/hello-app:1.0": failed to do request: Head "http://kind-registry:50000/v2/hello-app/manifests/1.0?ns=localhost%3A50000": dial tcp 172.18.0.3:50000: connect: connection refused
```
