### PR TITLE
Updated QEMU image and added cross build support for s390x kind binary and associated images

### DIFF
--- a/hack/build/init-buildx.sh
+++ b/hack/build/init-buildx.sh
@@ -32,7 +32,7 @@ fi
 # We only need to do this setup on linux hosts
 if [ "$(uname)" == 'Linux' ]; then
   # NOTE: this is pinned to a digest for a reason!
-  docker run --rm --privileged tonistiigi/binfmt:qemu-v6.0.0@sha256:ce4d5a2a6ac4a189047fca2d71cbd901cc7beebacf538be95fccb3aca87cb2ec --install all
+  docker run --rm --privileged tonistiigi/binfmt:qemu-v6.1.0@sha256:11128304bc582dc7dbaa35947ff3e52e2610d23cecb410ddfa381a6ce74fa763 --install all
 fi
 
 # Ensure we use a builder that can leverage it (the default on linux will not)

--- a/hack/release/build/cross.sh
+++ b/hack/release/build/cross.sh
@@ -46,6 +46,7 @@ export GOOS=darwin GOARCH=arm64
 export GOOS=linux GOARCH=amd64
 export GOOS=linux GOARCH=arm64
 export GOOS=linux GOARCH=ppc64le
+export GOOS=linux GOARCH=s390x
 EOF
 )
 

--- a/images/Makefile.common.in
+++ b/images/Makefile.common.in
@@ -13,7 +13,7 @@ IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # build with buildx
-PLATFORMS?=linux/amd64,linux/arm64
+PLATFORMS?=linux/amd64,linux/arm64,linux/s390x
 OUTPUT=
 PROGRESS=auto
 build: ensure-buildx


### PR DESCRIPTION
Updated QEMU image to `tonistiigi/binfmt:qemu-v6.1.0` and added cross build support for s390x kind binary and associated images.