### PR TITLE
Support getting all kind nodes with -A flag

### DIFF
--- a/pkg/cmd/kind/get/nodes/nodes.go
+++ b/pkg/cmd/kind/get/nodes/nodes.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cluster"
+	"sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/cmd"
 	"sigs.k8s.io/kind/pkg/log"
 
@@ -31,7 +32,8 @@ import (
 )
 
 type flagpole struct {
-	Name string
+	Name        string
+	AllClusters bool
 }
 
 // NewCommand returns a new cobra.Command for getting the list of nodes for a given cluster
@@ -53,6 +55,13 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		cluster.DefaultName,
 		"the cluster context name",
 	)
+	cmd.Flags().BoolVarP(
+		&flags.AllClusters,
+		"all-clusters",
+		"A",
+		false,
+		"If present, list all the available nodes across all cluster contexts. Current context is ignored even if specified with --name.",
+	)
 	return cmd
 }
 
@@ -62,15 +71,37 @@ func runE(logger log.Logger, streams cmd.IOStreams, flags *flagpole) error {
 		cluster.ProviderWithLogger(logger),
 		runtime.GetDefault(logger),
 	)
-	n, err := provider.ListNodes(flags.Name)
-	if err != nil {
-		return err
+
+	var nodes []nodes.Node
+	var err error
+	if flags.AllClusters {
+		clusters, err := provider.List()
+		if err != nil {
+			return err
+		}
+		for _, clusterName := range clusters {
+			clusterNodes, err := provider.ListNodes(clusterName)
+			if err != nil {
+				return err
+			}
+			nodes = append(nodes, clusterNodes...)
+		}
+		if len(nodes) == 0 {
+			logger.V(0).Infof("No kind nodes for any cluster.")
+			return nil
+		}
+	} else {
+		nodes, err = provider.ListNodes(flags.Name)
+		if err != nil {
+			return err
+		}
+		if len(nodes) == 0 {
+			logger.V(0).Infof("No kind nodes found for cluster %q.", flags.Name)
+			return nil
+		}
 	}
-	if len(n) == 0 {
-		logger.V(0).Infof("No kind nodes found for cluster %q.", flags.Name)
-		return nil
-	}
-	for _, node := range n {
+
+	for _, node := range nodes {
 		fmt.Fprintln(streams.Out, node.String())
 	}
 	return nil


### PR DESCRIPTION
Usage example

```bash
➜  kind git:(get-all-nodes) ./bin/kind get nodes
No kind nodes found for cluster "kind".
➜  kind git:(get-all-nodes) ./bin/kind get nodes --help
Lists existing kind nodes by their name

Usage:
  kind get nodes [flags]

Flags:
  -A, --all-clusters     -A, --all-clusters   If present, list all the available nodes across all cluster contexts. Current context is ignored even if specified with --name.
  -h, --help           help for nodes
      --name string    the cluster context name (default "kind")

Global Flags:
      --loglevel string   DEPRECATED: see -v instead
  -q, --quiet             silence all stderr output
  -v, --verbosity int32   info log verbosity, higher value produces more output
➜  kind git:(get-all-nodes) ./bin/kind get nodes -A    
road-to-secure-kubernetes-worker
road-to-secure-kubernetes-control-plane
road-to-secure-kubernetes-worker2
```