### PR TITLE
entrypoint: improve `$userns` support (alternative to #2492)

### DIFF
--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -49,6 +49,46 @@ validate_userns() {
   fi
 }
 
+overlayfs_preferrable() {
+	if [[ -z "$userns" ]]; then
+		# If we are outside userns, we can always assume overlayfs is preferrable
+		return 0
+	fi
+
+	# Debian 10 and 11 supports overlayfs in userns with a "permit_mount_in_userns" kernel patch,
+	# but known to be unstable, so we avoid using it https://github.com/moby/moby/issues/42302
+	if [[ -e "/sys/module/overlay/parameters/permit_mounts_in_userns" ]]; then
+		echo "INFO: UserNS: kernel seems supporting overlayfs with permit_mounts_in_userns, but avoiding due to instability."
+		return 1
+	fi
+
+	# Check overlayfs availability, by attempting to mount it.
+	#
+	# Overlayfs inside userns is known to be available for the following environments:
+	# - Kernel >= 5.11 (but 5.11 and 5.12 have issues on SELinux hosts. Fixed in 5.13.)
+	# - Ubuntu kernel
+	# - Debian kernel (but avoided due to instability, see the /sys/module/overlay/... check above)
+	# - Sysbox
+	tmp=$(mktemp -d)
+	mkdir -p "${tmp}/l" "${tmp}/u" "${tmp}/w" "${tmp}/m"
+	if ! mount -t overlay -o lowerdir="${tmp}/l,upperdir=${tmp}/u,workdir=${tmp}/w" overlay "${tmp}/m"; then
+		echo "INFO: UserNS: kernel does not seem to support overlayfs."
+		rm -rf "${tmp}"
+		return 1
+	fi
+	umount "${tmp}/m"
+	rm -rf "${tmp}"
+
+	# Detect whether SELinux is Enforcing (or Permitted) by grepping /proc/self/attr/current .
+	# Note that we cannot use `getenforce` command here because /sys/fs/selinux is typically not mounted for containers.
+	if grep -q "_t:" "/proc/self/attr/current"; then
+		# When the kernel is before v5.13 and SELinux is enforced, fuse-overlayfs might be safer, so we print a warning (but not an error).
+		# https://github.com/torvalds/linux/commit/7fa2e79a6bb924fa4b2de5766dab31f0f47b5ab6
+		echo "WARN: UserNS: SELinux might be Enforcing. If you see an error related to overlayfs, try setting \`KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER=fuse-overlayfs\` ." >&2
+	fi
+	return 0
+}
+
 configure_containerd() {
   local snapshotter=${KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER:-}
   if [[ -n "$userns" ]]; then
@@ -57,8 +97,8 @@ configure_containerd() {
     # Adjust oomScoreAdj
     sed -i 's/restrict_oom_score_adj = false/restrict_oom_score_adj = true/' /etc/containerd/config.toml
 
-    # Use fuse-overlayfs by default: https://github.com/kubernetes-sigs/kind/issues/2275
-    if [[ -z "$snapshotter" ]]; then
+    # Use fuse-overlayfs if overlayfs is not preferrable: https://github.com/kubernetes-sigs/kind/issues/2275
+    if [[ -z "$snapshotter" ]] && ! overlayfs_preferrable; then
       snapshotter="fuse-overlayfs"
     fi
   else


### PR DESCRIPTION
Alternative to #2492 .


Tested on Ubuntu 21.04 and Debian 11 hosts, with Rootless Docker 20.10.9.

```
$ cat Dockerfile
# The node image must be v1.22.x or later for Rootless Docker/Podman drivers with the latest kind.
FROM kindest/node:v1.22.1
ADD https://raw.githubusercontent.com/AkihiroSuda/kind/robust-entrypoint-userns/images/base/files/usr/local/bin/entrypoint /usr/local/bin/entrypoint
RUN chmod +x /usr/local/bin/entrypoint

$ docker context use rootless
$ docker build -t tmp:v1.22.1
$ kind create cluster --image=tmp:v1.22.1
```

---
### Commit 1: `entrypoint: allow $userns without cgroup v2`

Fix #2490

---
### Commit 2: `entrypoint: try remounting /sys even when $userns is true`

Cherry-picked from PR #2492 (thanks @felipecrs)

---
### Commit 3: `entrypoint: fix KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER`

`KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER` was accidentally ignored when `$userns` is true

---
### Commit 4: `entrypoint: allow overlayfs in userns when preferrable`

Allow overlayfs in userns when `mount -t overlay ...` seems functional.
Previously `fuse-overlayfs` was always used.
    
`mount -t overlay` is known to work on the following environments:
- Kernel >= 5.11
- Ubuntu kernel
- Debian kernel with `modprobe overlay permit_mount_in_userns=1`
- Sysbox
   
However, Debian variant of overlayfs is avoided, as there is an issue on stability.
See moby/moby#42302.

