### PR TITLE
Fixes issue with overlapping ipv6 addresses when using Docker

### DIFF
--- a/pkg/cluster/internal/providers/docker/network.go
+++ b/pkg/cluster/internal/providers/docker/network.go
@@ -266,7 +266,7 @@ func isIPv6UnavailableError(err error) bool {
 
 func isPoolOverlapError(err error) bool {
 	rerr := exec.RunErrorForError(err)
-	return rerr != nil && strings.HasPrefix(string(rerr.Output), "Error response from daemon: Pool overlaps with other one on this address space")
+	return rerr != nil && strings.HasPrefix(string(rerr.Output), "Error response from daemon: Pool overlaps with other one on this address space") || strings.Contains(string(rerr.Output), "networks have overlapping")
 }
 
 func isNetworkAlreadyExistsError(err error) bool {


### PR DESCRIPTION
This commit just adds a condition to let kind know to pick another ipv6
address in case docker reports that's ovelapping with any of the system
interfaces

Fixes #2496
