### PR TITLE
fix(cgroupsv2): skip procs from another namespace

### DIFF
--- a/images/base/files/usr/local/bin/create-kubelet-cgroup-v2
+++ b/images/base/files/usr/local/bin/create-kubelet-cgroup-v2
@@ -23,7 +23,7 @@ if [[ ! -f "/sys/fs/cgroup/cgroup.controllers" ]]; then
 fi
 
 # NOTE: we can't use `test -s` because cgroup.procs is not a regular file.
-if [[ -n "$(grep -v '^0$' /sys/fs/cgroup/cgroup.procs)" ]]; then
+if grep -qv '^0$' /sys/fs/cgroup/cgroup.procs ; then
 	echo 'ERROR: this script needs /sys/fs/cgroup/cgroup.procs to be empty (for writing the top-level cgroup.subtree_control)' >&2
 	# So, this script needs to be called after launching systemd.
 	# This script cannot be called from /usr/local/bin/entrypoint.

--- a/images/base/files/usr/local/bin/create-kubelet-cgroup-v2
+++ b/images/base/files/usr/local/bin/create-kubelet-cgroup-v2
@@ -23,7 +23,7 @@ if [[ ! -f "/sys/fs/cgroup/cgroup.controllers" ]]; then
 fi
 
 # NOTE: we can't use `test -s` because cgroup.procs is not a regular file.
-if [[ -n "$(cat /sys/fs/cgroup/cgroup.procs)" ]]; then
+if [[ -n "$(grep -v '^0$' /sys/fs/cgroup/cgroup.procs)" ]]; then
 	echo 'ERROR: this script needs /sys/fs/cgroup/cgroup.procs to be empty (for writing the top-level cgroup.subtree_control)' >&2
 	# So, this script needs to be called after launching systemd.
 	# This script cannot be called from /usr/local/bin/entrypoint.

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,4 +20,4 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "docker.io/kindest/base:v20211014-2d60a5ef"
+const DefaultBaseImage = "docker.io/kindest/base:v20211103-cae3ff30"


### PR DESCRIPTION
Previously, launching a kind container on a system with non-container processes in the root cgroup would fail: `/sys/fs/cgroup/cgroup.procs` would be full of pid `0`, and the `create-kubelet-cgroup-v2` script would see these and refuse to make progress.

On my system (Manjaro, details below) I have something like ~300 processes in my root cgroup:

<details>
<summary>process listing</summary>

```
$ </sys/fs/cgroup/cgroup.procs xargs -I{}  cat /proc/{}/comm | sort
acpi_thermal_pm
amd_iommu_v2
ata_sff
blkcg_punt_bio
card0-crtc0
card0-crtc1
card0-crtc2
card0-crtc3
card0-crtc4
card0-crtc5
charger_manager
comp_1.0.0
comp_1.0.1
comp_1.1.0
comp_1.1.1
comp_1.2.0
comp_1.2.1
comp_1.3.0
comp_1.3.1
cpuhp/0
cpuhp/1
cpuhp/10
cpuhp/11
cpuhp/12
cpuhp/13
cpuhp/14
cpuhp/15
cpuhp/2
cpuhp/3
cpuhp/4
cpuhp/5
cpuhp/6
cpuhp/7
cpuhp/8
cpuhp/9
cryptd
devfreq_wq
dmcrypt_write/2
edac-poller
ext4-rsv-conver
gfx_0.0.0
idle_inject/0
idle_inject/1
idle_inject/10
idle_inject/11
idle_inject/12
idle_inject/13
idle_inject/14
idle_inject/15
idle_inject/2
idle_inject/3
idle_inject/4
idle_inject/5
idle_inject/6
idle_inject/7
idle_inject/8
idle_inject/9
iprt-VBoxTscThr
iprt-VBoxWQueue
ipv6_addrconf
irq/26-AMD-Vi
irq/27-aerdrv
irq/28-aerdrv
irq/29-aerdrv
irq/31-aerdrv
irq/32-aerdrv
jbd2/dm-0-8
jpeg_dec
kauditd
kblockd
kcompactd0
kcryptd/253:0
kcryptd_io/253:
kdevtmpfs
kdmflush
khugepaged
khungtaskd
kintegrityd
ksmd
ksoftirqd/0
ksoftirqd/1
ksoftirqd/10
ksoftirqd/11
ksoftirqd/12
ksoftirqd/13
ksoftirqd/14
ksoftirqd/15
ksoftirqd/2
ksoftirqd/3
ksoftirqd/4
ksoftirqd/5
ksoftirqd/6
ksoftirqd/7
ksoftirqd/8
ksoftirqd/9
kstrp
kswapd0
kthreadd
kthrotld
kworker/0:0-events_long
kworker/0:0H-kblockd
kworker/0:2H-events_highpri
kworker/0:2-rcu_par_gp
kworker/10:0-events
kworker/10:0H-events_highpri
kworker/10:1H-kblockd
kworker/10:1-md
kworker/10:2-rcu_par_gp
kworker/10:3
kworker/1:0-events
kworker/1:0H-events_highpri
kworker/11:0-events
kworker/11:0H-events_highpri
kworker/11:1H-kblockd
kworker/11:1-rcu_par_gp
kworker/11:2-events
kworker/11:3
kworker/1:1H-kblockd
kworker/1:1-rcu_par_gp
kworker/12:0H-kblockd
kworker/12:0-rcu_par_gp
kworker/12:1H-kblockd
kworker/12:1-rcu_gp
kworker/12:2-events
kworker/1:2-events
kworker/13:0-events
kworker/13:0H-events_highpri
kworker/13:1H-kblockd
kworker/13:1-rcu_par_gp
kworker/13:2-rcu_par_gp
kworker/14:0H-kblockd
kworker/14:0-rcu_par_gp
kworker/14:1H-kblockd
kworker/14:1-rcu_par_gp
kworker/14:2-events
kworker/15:0-events
kworker/15:0H-kblockd
kworker/15:1H-kblockd
kworker/15:1-rcu_par_gp
kworker/15:2-rcu_gp
kworker/2:0-events
kworker/2:0H-events_highpri
kworker/2:1H-kblockd
kworker/2:1-rcu_par_gp
kworker/2:2-rcu_par_gp
kworker/3:0H-events_highpri
kworker/3:0-rcu_par_gp
kworker/3:1-cgroup_destroy
kworker/3:1H-kblockd
kworker/3:2-events
kworker/4:0-events
kworker/4:1H-kblockd
kworker/4:1-rcu_par_gp
kworker/4:2H-kblockd
kworker/4:2-rcu_gp
kworker/5:0H-kblockd
kworker/5:0-rcu_par_gp
kworker/5:1-events
kworker/5:1H-kblockd
kworker/5:2-rcu_par_gp
kworker/6:0-events
kworker/6:0H-kblockd
kworker/6:1H-kblockd
kworker/6:1-rcu_par_gp
kworker/6:2-rcu_par_gp
kworker/7:0H-kblockd
kworker/7:0-rcu_par_gp
kworker/7:1H-kblockd
kworker/7:1-rcu_gp
kworker/7:2-events
kworker/7:3-events
kworker/8:0-events
kworker/8:0H-events_highpri
kworker/8:1H-kblockd
kworker/8:1-rcu_par_gp
kworker/8:2-mm_percpu_wq
kworker/8:3
kworker/9:0
kworker/9:0H-events_highpri
kworker/9:1-events
kworker/9:1H-kblockd
kworker/9:2-rcu_par_gp
kworker/u64:0-kcryptd/253:0
kworker/u64:10-kcryptd/253:0
kworker/u64:11-kcryptd/253:0
kworker/u64:13-kcryptd/253:0
kworker/u64:14-kcryptd/253:0
kworker/u64:15-kcryptd/253:0
kworker/u64:1-kcryptd/253:0
kworker/u64:2-kcryptd/253:0
kworker/u64:3-kcryptd/253:0
kworker/u64:4-kcryptd/253:0
kworker/u64:5-kcryptd/253:0
kworker/u64:6-events_unbound
kworker/u64:7-kcryptd/253:0
kworker/u64:8-kcryptd/253:0
kworker/u64:9-kcryptd/253:0
kworker/u65:0
md
md126_raid1
migration/0
migration/1
migration/10
migration/11
migration/12
migration/13
migration/14
migration/15
migration/2
migration/3
migration/4
migration/5
migration/6
migration/7
migration/8
migration/9
mm_percpu_wq
netns
nvme-delete-wq
nvme-reset-wq
nvme-wq
oom_reaper
rcub/1
rcuc/0
rcuc/1
rcuc/10
rcuc/11
rcuc/12
rcuc/13
rcuc/14
rcuc/15
rcuc/2
rcuc/3
rcuc/4
rcuc/5
rcuc/6
rcuc/7
rcuc/8
rcuc/9
rcu_gp
rcu_par_gp
rcu_preempt
rcu_tasks_kthre
rcu_tasks_rude_
rcu_tasks_trace
scsi_eh_0
scsi_eh_1
scsi_eh_2
scsi_eh_3
scsi_eh_4
scsi_eh_5
scsi_eh_6
scsi_eh_7
scsi_eh_8
scsi_eh_9
scsi_tmf_0
scsi_tmf_1
scsi_tmf_2
scsi_tmf_3
scsi_tmf_4
scsi_tmf_5
scsi_tmf_6
scsi_tmf_7
scsi_tmf_8
scsi_tmf_9
sdma0
sdma1
tpm_dev_wq
ttm_swap
vcn_dec
vcn_enc0
vcn_enc1
watchdogd
writeback
zswap1
zswap1
zswap-shrink
```
</details>

They all appear to be kernel processes; I couldn't say why they're still in the root cgroup, but the systemd unit inside my `kind-control-plane` container tried to start the kubelet some ~1m times without success:

```
Oct 10 06:21:15 kind-control-plane systemd[1]: Starting kubelet: The Kubernetes Node Agent...
Oct 10 06:21:15 kind-control-plane sh[3064262]: ERROR: this script needs /sys/fs/cgroup/cgroup.procs to be empty (for writing the top-level cgroup.subtree_control)
Oct 10 06:21:15 kind-control-plane systemd[1]: kubelet.service: Control process exited, code=exited, status=1/FAILURE
Oct 10 06:21:15 kind-control-plane systemd[1]: kubelet.service: Failed with result 'exit-code'.
Oct 10 06:21:15 kind-control-plane systemd[1]: Failed to start kubelet: The Kubernetes Node Agent.
````

## Question

Is this an appropriate fix to the check? I don't have a strong sense what the check whether there are items in the root cgroup was guarding against, so I'm not 100% sure about it. I did find in [a comment](https://github.com/kubernetes-sigs/kind/blob/bb4197e83a5bfd71ca343ee80312fc3c83b80cc8/images/base/files/usr/local/bin/entrypoint#L99-L100) from an old commit that the kernel was refusing writes to the subtree control file when there were processes in the root cgroup. For what it's worth, I didn't see that with this change, and making it (via vi in the container) allowed my kubelet to start successfully.


## Environment

<details>
<summary>kind/kubernetes/docker</summary>

kind version:
```
kind v0.10.0 go1.16 linux/amd64
```
kubernetes:
```
Client Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.2", GitCommit:"8b5a19147530eaac9476b0ab82980b4088bbc1b2", GitTreeState:"archive", BuildDate:"2021-09-16T09:21:16Z", GoVersion:"go1.17.1", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
WARNING: version difference between client (1.22) and server (1.20) exceeds the supported minor version skew of +/-1
```
docker: 
```
Client:
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Build with BuildKit (Docker Inc., v0.6.1-docker)

Server:
 Containers: 34
  Running: 2
  Paused: 0
  Stopped: 32
 Images: 198
 Server Version: 20.10.8
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Native Overlay Diff: false
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runtime.v1.linux runc io.containerd.runc.v2
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 72cec4be58a9eb6b2910f5d10f1c01ca47d231c0.m
 runc version: v1.0.2-0-g52b36a2d
 init version: de40ad0
 Security Options:
  seccomp
   Profile: default
  cgroupns
 Kernel Version: 5.10.61-1-MANJARO
 Operating System: Manjaro Linux
 OSType: linux
 Architecture: x86_64
 CPUs: 16
 Total Memory: 62.81GiB
 Name: cerf
 ID: RLVC:47WW:U5MG:F3FI:IIKF:THAE:GK2Z:OVX5:SL6I:GOY7:R2QG:6D5D
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Registry: https://index.docker.io/v1/
 Labels:
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false
```
</details>

<details>
<summary>os/kernel/systemd</summary>

`/etc/os-release`:
```
NAME="Manjaro Linux"
ID=manjaro
ID_LIKE=arch
BUILD_ID=rolling
PRETTY_NAME="Manjaro Linux"
ANSI_COLOR="32;1;24;144;200"
HOME_URL="https://manjaro.org/"
DOCUMENTATION_URL="https://wiki.manjaro.org/"
SUPPORT_URL="https://manjaro.org/"
BUG_REPORT_URL="https://bugs.manjaro.org/"
LOGO=manjarolinux
```

`uname -a`:
```
Linux cerf 5.10.61-1-MANJARO #1 SMP PREEMPT Thu Aug 26 20:36:54 UTC 2021 x86_64 GNU/Linux
```
`/usr/lib/systemd/systemd --version`
```
systemd 249 (249.4-1-manjaro)
+PAM +AUDIT -SELINUX -APPARMOR -IMA +SMACK +SECCOMP +GCRYPT +GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 -PWQUALITY +P11KIT -QRENCODE +BZIP2 +LZ4 +XZ +ZLIB +ZSTD +XKBCOMMON +UTMP -SYSVINIT default-hierarchy=unified
```
</details>