### PR TITLE
rootless: set LocalStorageCapacityIsolation=false to avoid "could not find device..." error

### DIFF
--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -447,6 +447,10 @@ func Config(data ConfigData) (config string, err error) {
 			return "", errors.Errorf("version %q is not compatible with rootless provider (hint: kind v0.11.x may work with this version)", ver)
 		}
 		data.FeatureGates["KubeletInUserNamespace"] = true
+
+		// For avoiding err="failed to get rootfs info: failed to get device for dir \"/var/lib/kubelet\": could not find device with major: 0, minor: 41 in cached partitions map"
+		// https://github.com/kubernetes-sigs/kind/issues/2524
+		data.FeatureGates["LocalStorageCapacityIsolation"] = false
 	}
 
 	// assume the latest API version, then fallback if the k8s version is too low


### PR DESCRIPTION
For avoiding `err="failed to get rootfs info: failed to get device for dir \"/var/lib/kubelet\": could not find device with major: 0, minor: 41 in cached partitions map"`

Fix #2524

See https://github.com/kubernetes/kubernetes/blob/v1.22.2/pkg/kubelet/cm/container_manager_linux.go#L641-L649

---

Tested with Rootless Docker 20.10.10 on Fedora 35