### PR TITLE
fix dual-stack order detection

### DIFF
--- a/pkg/cluster/internal/create/actions/config/config.go
+++ b/pkg/cluster/internal/create/actions/config/config.go
@@ -196,7 +196,11 @@ func getKubeadmConfig(cfg *config.Cluster, data kubeadm.ConfigData, node nodes.N
 			// order matters since the nodeAddress will be used later to configure the apiserver advertise address
 			// Ref: #2484
 			primaryServiceSubnet := strings.Split(cfg.Networking.ServiceSubnet, ",")[0]
-			if net.ParseIP(primaryServiceSubnet).To4() != nil {
+			ip, _, err := net.ParseCIDR(primaryServiceSubnet)
+			if err != nil {
+				return "", fmt.Errorf("failed to parse primary Service Subnet %s (%s): %w", primaryServiceSubnet, cfg.Networking.ServiceSubnet, err)
+			}
+			if ip.To4() != nil {
 				data.NodeAddress = fmt.Sprintf("%s,%s", nodeAddress, nodeAddressIPv6)
 			} else {
 				data.NodeAddress = fmt.Sprintf("%s,%s", nodeAddressIPv6, nodeAddress)


### PR DESCRIPTION
the logic was parsing a CIDR as an IP, hence always detecting the
order as IPv6 - IPv4.

https://go.dev/play/p/50xM3zCrWDe

Fixes: https://github.com/kubernetes/kubernetes/issues/106709