### PR TITLE
refactor: remove deprecated flag --address from scheduler config

### DIFF
--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -326,7 +326,6 @@ scheduler:
 {{ end }}
     # configure ipv6 default addresses for IPv6 clusters
     {{ if .IPv6 -}}
-    address: "::"
     bind-address: "::1"
     {{- end }}
 networking:


### PR DESCRIPTION
Signed-off-by: Jian Zeng <anonymousknight96@gmail.com>

The flag `--address` in `kube-scheduler` has been deprecated and will be removed.