### PR TITLE
Fixed install command on index and readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 kind is a tool for running local Kubernetes clusters using Docker container "nodes".
 kind was primarily designed for testing Kubernetes itself, but may be used for local development or CI.
 
-If you have [go] ([1.11+][go-supported]) and [docker] installed `GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.1 && kind create cluster` is all you need!
+If you have [go] \([1.17+][go-supported]) and [docker] installed `go install sigs.k8s.io/kind@{{< stableVersion >}} && kind create cluster` is all you need!
+
+For older versions use `GO111MODULE="on" go get sigs.k8s.io/kind@{{< stableVersion >}}`.
 
 ![](site/static/images/kind-create-cluster.png)
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -6,7 +6,9 @@ title: kind
 [kind] is a tool for running local Kubernetes clusters using Docker container "nodes".  
 kind was primarily designed for testing Kubernetes itself, but may be used for local development or CI.
 
-If you have [go] \([1.11+][go-supported]) and [docker] installed `GO111MODULE="on" go get sigs.k8s.io/kind@{{< stableVersion >}} && kind create cluster` is all you need!
+If you have [go] \([1.17+][go-supported]) and [docker] installed `go install sigs.k8s.io/kind@{{< stableVersion >}} && kind create cluster` is all you need!
+
+For older versions use `GO111MODULE="on" go get sigs.k8s.io/kind@{{< stableVersion >}}`.
 
 <img src="images/kind-create-cluster.png" />
 


### PR DESCRIPTION
#2351 Missed a few places that the go get command should prolly be removed from. Rather then omit go get completely I've  just stolen the text from the quick-install and adapted what is already there.