### PR TITLE
Fix start in container

### DIFF
--- a/pkg/cluster/internal/create/actions/kubeadminit/init.go
+++ b/pkg/cluster/internal/create/actions/kubeadminit/init.go
@@ -18,7 +18,6 @@ limitations under the License.
 package kubeadminit
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -112,14 +111,14 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 	// https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#master-isolation
 	if len(allNodes) == 1 {
 		var err error
-		for count := 10; count > 0; count -= 1 {
+		// retry and wait up to 1 minute for the server to be ready
+		endTime := time.Now().Add(1 * time.Minute)
+		for endTime.After(time.Now()) {
 			if err = node.Command(
 				"kubectl", "--kubeconfig=/etc/kubernetes/admin.conf",
 				"taint", "nodes", "--all", "node-role.kubernetes.io/master-",
 			).Run(); err == nil {
 				break
-			} else {
-				fmt.Println(count, err)
 			}
 			time.Sleep(1 * time.Second)
 		}

--- a/pkg/cluster/internal/create/actions/waitforready/waitforready.go
+++ b/pkg/cluster/internal/create/actions/waitforready/waitforready.go
@@ -97,7 +97,7 @@ func waitForReady(node nodes.Node, until time.Time) bool {
 		if err != nil {
 			return false
 		}
-		//fmt.Println(lines)
+		// If the server is not ready the answer is empty and this situation must be taken in account
 		if len(lines) == 0 {
 			return false
 		}

--- a/pkg/cluster/internal/create/actions/waitforready/waitforready.go
+++ b/pkg/cluster/internal/create/actions/waitforready/waitforready.go
@@ -97,6 +97,10 @@ func waitForReady(node nodes.Node, until time.Time) bool {
 		if err != nil {
 			return false
 		}
+		//fmt.Println(lines)
+		if len(lines) == 0 {
+			return false
+		}
 
 		// 'lines' will return the status of all nodes labeled as master. For
 		// example, if we have three control plane nodes, and all are ready,


### PR DESCRIPTION
If you try to run kind in a containerized environment (with docker access), like those generated by vs-code, it fails because of timing problems.

This patch fixes the problem.