### PR TITLE
handle "master" label/taint changes for kubeadm 1.24

### DIFF
--- a/pkg/build/nodeimage/const_storage.go
+++ b/pkg/build/nodeimage/const_storage.go
@@ -88,7 +88,13 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      # TODO: Remove the "master" taint after kubeadm nodes no longer have it.
+      # This can be done once kind no longer supports kubeadm 1.24.
+      # https://github.com/kubernetes-sigs/kind/issues/1699
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Equal
+        effect: NoSchedule
       - key: node-role.kubernetes.io/master
         operator: Equal
         effect: NoSchedule

--- a/pkg/cluster/internal/create/actions/waitforready/waitforready.go
+++ b/pkg/cluster/internal/create/actions/waitforready/waitforready.go
@@ -25,7 +25,9 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
+	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/exec"
+	"sigs.k8s.io/kind/pkg/internal/version"
 )
 
 // Action implements an action for waiting for the cluster to be ready
@@ -66,7 +68,23 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 
 	// Wait for the nodes to reach Ready status.
 	startTime := time.Now()
-	isReady := waitForReady(node, startTime.Add(a.waitTime))
+
+	// TODO: Remove the below handling once kubeadm 1.23 is no longer supported.
+	// https://github.com/kubernetes-sigs/kind/issues/1699
+	rawVersion, err := nodeutils.KubeVersion(node)
+	if err != nil {
+		return errors.Wrap(err, "failed to get Kubernetes version from node")
+	}
+	kubeVersion, err := version.ParseSemantic(rawVersion)
+	if err != nil {
+		return errors.Wrap(err, "could not parse Kubernetes version")
+	}
+	selectorLabel := "node-role.kubernetes.io/control-plane"
+	if kubeVersion.LessThan(version.MustParseSemantic("v1.24.0")) {
+		selectorLabel = "node-role.kubernetes.io/master"
+	}
+
+	isReady := waitForReady(node, startTime.Add(a.waitTime), selectorLabel)
 	if !isReady {
 		ctx.Status.End(false)
 		ctx.Logger.V(0).Info(" • WARNING: Timed out waiting for Ready ⚠️")
@@ -81,14 +99,14 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 
 // WaitForReady uses kubectl inside the "node" container to check if the
 // control plane nodes are "Ready".
-func waitForReady(node nodes.Node, until time.Time) bool {
+func waitForReady(node nodes.Node, until time.Time, selectorLabel string) bool {
 	return tryUntil(until, func() bool {
 		cmd := node.Command(
 			"kubectl",
 			"--kubeconfig=/etc/kubernetes/admin.conf",
 			"get",
 			"nodes",
-			"--selector=node-role.kubernetes.io/master",
+			"--selector="+selectorLabel,
 			// When the node reaches status ready, the status field will be set
 			// to true.
 			"-o=jsonpath='{.items..status.conditions[-1:].status}'",

--- a/site/static/examples/ingress/contour/patch.json
+++ b/site/static/examples/ingress/contour/patch.json
@@ -6,11 +6,16 @@
           "ingress-ready": "true"
         },
         "tolerations": [
-        {
-          "key": "node-role.kubernetes.io/master",
-          "operator": "Equal",
-          "effect": "NoSchedule"
-        }
+          {
+            "key": "node-role.kubernetes.io/control-plane",
+            "operator": "Equal",
+            "effect": "NoSchedule"
+          },
+          {
+            "key": "node-role.kubernetes.io/master",
+            "operator": "Equal",
+            "effect": "NoSchedule"
+          }
         ]
       }
     }


### PR DESCRIPTION
As per the kubeadm KEP for "master" label/taint changes:
- kubeadm 1.24 nodes will only have the "control-plane" label.
- kubeadm 1.24 nodes will have both the "master"
and "control-plane" taints.
- kubeadm 1.25 nodes will have only the "control-plane" taint

Adapt kind to these changes and add TODOs with links
for the tracking issue in k-sigs/kind.

this is blocking https://github.com/kubernetes/kubernetes/pull/107533
tracking issue in kind repository https://github.com/kubernetes-sigs/kind/issues/1699
