### PR TITLE
Local registry: only attach network if missing

### DIFF
--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -23,7 +23,9 @@ EOF
 
 # connect the registry to the cluster network
 # (the network may already be connected)
-docker network connect "kind" "${reg_name}" || true
+if [ "$(docker inspect --format='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
+    docker network connect "kind" "${reg_name}" || true
+fi
 
 # Document the local registry
 # https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry


### PR DESCRIPTION
The example script for creating a kind cluster with a local registry
will connect the container to the "kind" network. The first time the
local registry is created, this is fine and is what is needed. On
subsequent runs to create new clusters, if the local registry container
has already been set up, the command to attach to the "kind" network
will emit an error message to the create output that can be confusing.

This updates the example script to do a basic check of the registry
containers network configuration. If the kind network appears to be
already connected, then the script will not attempt to connect it again.

Fixed: #2600 