### PR TITLE
minor follow-up tweaks to kind-with-registry.sh

### DIFF
--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -4,8 +4,7 @@ set -o errexit
 # create registry container unless it already exists
 reg_name='kind-registry'
 reg_port='5000'
-running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
-if [ "${running}" != 'true' ]; then
+if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
   docker run \
     -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
     registry:2
@@ -21,10 +20,9 @@ containerdConfigPatches:
     endpoint = ["http://${reg_name}:5000"]
 EOF
 
-# connect the registry to the cluster network
-# (the network may already be connected)
-if [ "$(docker inspect --format='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
-    docker network connect "kind" "${reg_name}" || true
+# connect the registry to the cluster network if not already connected
+if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
+  docker network connect "kind" "${reg_name}"
 fi
 
 # Document the local registry


### PR DESCRIPTION
missed or punted in review:
- don't need `|| true` on `docker network connect` now
- 2 space indent for sample scripts (because space is tight in the docs)
- normalize `if` for registry running to match network check
- update comment on network connect