### PR TITLE
added Kong ingress example

### DIFF
--- a/site/static/examples/ingress/kong/deployment.patch.json
+++ b/site/static/examples/ingress/kong/deployment.patch.json
@@ -1,0 +1,43 @@
+{
+  "spec": {
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "proxy",
+            "ports": [
+              {
+                "containerPort": 8000,
+                "hostPort": 80,
+                "name": "proxy",
+                "protocol": "TCP"
+              },
+              {
+                "containerPort": 8443,
+                "hostPort": 43,
+                "name": "proxy-ssl",
+                "protocol": "TCP"
+              }
+            ]
+          }
+        ],
+        "nodeSelector": {
+          "ingress-ready": "true"
+        },
+        "tolerations": [
+          {
+            "key": "node-role.kubernetes.io/control-plane",
+            "operator": "Equal",
+            "effect": "NoSchedule"
+          },
+          {
+            "key": "node-role.kubernetes.io/master",
+            "operator": "Equal",
+            "effect": "NoSchedule"
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/site/static/examples/ingress/kong/service.patch.json
+++ b/site/static/examples/ingress/kong/service.patch.json
@@ -1,0 +1,5 @@
+{
+  "spec": {
+    "type": "NodePort"
+  }
+}


### PR DESCRIPTION
Kind documentation included examples from a popular Kubernetes ingress controller.
This PR adds a doc/tutorial of how to enable Kong Ingress Controller with `kind`.