### PR TITLE
Local registry example uses port 5001 to be more mac friendly

### DIFF
--- a/site/content/docs/user/local-registry.md
+++ b/site/content/docs/user/local-registry.md
@@ -23,9 +23,9 @@ with it enabled.
 The registry can be used like this.
 
 1. First we'll pull an image `docker pull gcr.io/google-samples/hello-app:1.0`
-2. Then we'll tag the image to use the local registry `docker tag gcr.io/google-samples/hello-app:1.0 localhost:5000/hello-app:1.0`
-3. Then we'll push it to the registry `docker push localhost:5000/hello-app:1.0`
-4. And now we can use the image `kubectl create deployment hello-server --image=localhost:5000/hello-app:1.0`
+2. Then we'll tag the image to use the local registry `docker tag gcr.io/google-samples/hello-app:1.0 localhost:5001/hello-app:1.0`
+3. Then we'll push it to the registry `docker push localhost:5001/hello-app:1.0`
+4. And now we can use the image `kubectl create deployment hello-server --image=localhost:5001/hello-app:1.0`
 
-If you build your own image and tag it like `localhost:5000/image:foo` and then use
-it in kubernetes as `localhost:5000/image:foo`.
+If you build your own image and tag it like `localhost:5001/image:foo` and then use
+it in kubernetes as `localhost:5001/image:foo`.

--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -3,7 +3,7 @@ set -o errexit
 
 # create registry container unless it already exists
 reg_name='kind-registry'
-reg_port='5000'
+reg_port='5001'
 if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
   docker run \
     -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/kind/issues/1213#issuecomment-1003146939

> Consider using a different port than 5000 since its used by [Apple MacOS Monterrey](https://nono.ma/port-5000-used-by-control-center-in-macos#:~:text=As%20is%20port%203000%2C%20port,to%20serve%20local%20development%20servers.&text=The%20process%20running%20on%20this,Receiver%20to%20release%20port%205000%20.)

pair programmed with @BenTheElder and figured this out

/cc @BenTheElder 