### PR TITLE
Distinguish usage of local registry for cluster and in-cluster app.

### DIFF
--- a/site/content/docs/user/local-registry.md
+++ b/site/content/docs/user/local-registry.md
@@ -28,4 +28,4 @@ The registry can be used like this.
 4. And now we can use the image `kubectl create deployment hello-server --image=localhost:5001/hello-app:1.0`
 
 If you build your own image and tag it like `localhost:5001/image:foo` and then use
-it in kubernetes as `localhost:5001/image:foo`. And use it from inside of your cluster application as `${reg_name}:5000`.
+it in kubernetes as `localhost:5001/image:foo`. And use it from inside of your cluster application as `kind-registry:5000`.

--- a/site/content/docs/user/local-registry.md
+++ b/site/content/docs/user/local-registry.md
@@ -28,4 +28,4 @@ The registry can be used like this.
 4. And now we can use the image `kubectl create deployment hello-server --image=localhost:5001/hello-app:1.0`
 
 If you build your own image and tag it like `localhost:5001/image:foo` and then use
-it in kubernetes as `localhost:5001/image:foo`.
+it in kubernetes as `localhost:5001/image:foo`. And use it from inside of your cluster application as `${reg_name}:5000`.


### PR DESCRIPTION
Distinguish usage of local registry for cluster and in-cluster app.

Derived from Issue https://github.com/kubernetes-sigs/kind/issues/2604 , where this local registry is being used for both k8s cluster launch and also in-cluster app push/pull images.