### PR TITLE
stage dpkg status, upgrade haproxy image to debian11

### DIFF
--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -45,7 +45,8 @@ RUN mkdir -p "${STAGE_DIR}" && \
     stage-binary-and-deps.sh haproxy "${STAGE_DIR}" && \
     stage-binary-and-deps.sh cp "${STAGE_DIR}" && \
     stage-binary-and-deps.sh mkdir "${STAGE_DIR}" && \
-    stage-binary-and-deps.sh kill "${STAGE_DIR}"
+    stage-binary-and-deps.sh kill "${STAGE_DIR}" && \
+    find "${STAGE_DIR}"
 
 ################################################################################
 

--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir -p "${STAGE_DIR}" && \
 # See: https://github.com/GoogleContainerTools/distroless/tree/main/base
 # See: https://github.com/GoogleContainerTools/distroless/tree/main/cc
 # This has /etc/passwd, tzdata, cacerts, glibc, libssl, openssl, and libgcc1
-FROM "gcr.io/distroless/cc-debian11"
+FROM "gcr.io/distroless/static-debian11"
 
 ARG STAGE_DIR="/opt/stage"
 

--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir -p "${STAGE_DIR}" && \
 # See: https://github.com/GoogleContainerTools/distroless/tree/main/base
 # See: https://github.com/GoogleContainerTools/distroless/tree/main/cc
 # This has /etc/passwd, tzdata, cacerts, glibc, libssl, openssl, and libgcc1
-FROM "gcr.io/distroless/cc"
+FROM "gcr.io/distroless/cc-debian11"
 
 ARG STAGE_DIR="/opt/stage"
 

--- a/images/haproxy/stage-binary-and-deps.sh
+++ b/images/haproxy/stage-binary-and-deps.sh
@@ -86,14 +86,6 @@ main(){
 
     # stage the dependencies of the binary
     while IFS= read -r c_dep; do
-        # skip libc, libgcc1 we already have this in the distroless images
-        # NOTE: debian10 -> libggc1, debian11 -> libgcc-s1
-        # https://github.com/GoogleContainerTools/distroless/blob/47cf1c0554fdfc71604af0b8f6e19072f62e4f93/cc/BUILD#L10-L14
-        pkg="$(file_to_package "${c_dep}")"
-        if [[ "${pkg}" == "libc6" || "${pkg}" == "libgcc1" || "${pkg}" == "libgcc-s1" ]]; then
-            continue
-        fi
-        # otherwise stage dependency
         stage_file "${c_dep}" "${STAGE_DIR}"
     done < <(binary_to_libraries "${binary_path}")
 }

--- a/images/haproxy/stage-binary-and-deps.sh
+++ b/images/haproxy/stage-binary-and-deps.sh
@@ -87,8 +87,10 @@ main(){
     # stage the dependencies of the binary
     while IFS= read -r c_dep; do
         # skip libc, libgcc1 we already have this in the distroless images
+        # NOTE: debian10 -> libggc1, debian11 -> libgcc-s1
+        # https://github.com/GoogleContainerTools/distroless/blob/47cf1c0554fdfc71604af0b8f6e19072f62e4f93/cc/BUILD#L10-L14
         pkg="$(file_to_package "${c_dep}")"
-        if [[ "${pkg}" == "libc6" || "${pkg}" == "libgcc1" ]]; then
+        if [[ "${pkg}" == "libc6" || "${pkg}" == "libgcc1" || "${pkg}" == "libgcc-s1" ]]; then
             continue
         fi
         # otherwise stage dependency

--- a/pkg/cluster/internal/loadbalancer/const.go
+++ b/pkg/cluster/internal/loadbalancer/const.go
@@ -17,7 +17,7 @@ limitations under the License.
 package loadbalancer
 
 // Image defines the loadbalancer image:tag
-const Image = "kindest/haproxy:v20210715-a6da3463"
+const Image = "kindest/haproxy:v20220207-ca68f7d4"
 
 // ConfigPath defines the path to the config file in the image
 const ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/issues/70249

- stage dpkg status so security scanners can detect package versions for the binaries / libraries we are copying
- debug stage paths during image build for easier iteration
- upgrade to debian 11
- switch to distroless-static and fully supply libraries ourselves to match the debian version across them

tested locally with:
```shell
$ cat ~/kind-ha.yaml 
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
- role: control-plane
- role: control-plane

$ kind --version
kind version 0.12.0-alpha+a6edb4aadc3627

$ kind create cluster --config=$HOME/kind-ha.yaml --retain
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.23.1) 🖼 
 ✓ Preparing nodes 📦 📦 📦  
 ✓ Configuring the external load balancer ⚖️ 
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
 ✓ Joining more control-plane nodes 🎮 
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/

$ docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED              STATUS              PORTS                       NAMES
930f727bc9ff   kindest/haproxy:v20220207-ca68f7d4   "haproxy -sf 7 -W -d…"   About a minute ago   Up About a minute   127.0.0.1:36141->6443/tcp   kind-external-load-balancer
```