### PR TITLE
Add note to quick start about idempotent deletes

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -195,6 +195,10 @@ kind delete cluster
 If the flag `--name` is not specified, kind will use the default cluster
 context name `kind` and delete that cluster.
 
+> **Note**: By design, requesting to delete a cluster that does not exist
+> will not return an error. This is intentional and is a means to have an
+> idempotent way of cleaning up resources.
+
 ## Loading an Image Into Your Cluster
 
 Docker images can be loaded into your cluster nodes with:


### PR DESCRIPTION
While reviewing kind issues, I noticed there seems to be a regularly
recurring problem with users expecting `kind delete cluster foo` to
fail if there is not a cluster named `foo` present.

We intentionally do not fail in this case. The delete command is
idempotent, and should be able to be run repeatedly without erroring.
This is very useful in clean up scripts, and many users rely on this
behavior.

It also makes things somewhat declarative in that you are saying "I
don't want a cluster named foo", and `kind` helpfully confirms that
there is no cluster named "foo".

To try to avoid some of these repeated issues being filed, this adds a
note to the quick start docs in the "Deleting a Cluster" section to
point out that this is the expected behavior. This also helps new users
to know that they can depend on this behavior if they are scripting
things with kind.