### PR TITLE
Skip GitHub Actions on doc only changes

### DIFF
--- a/.github/workflows/cgroup2.yaml
+++ b/.github/workflows/cgroup2.yaml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'site/**'
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'site/**'
 
 jobs:
   docker:

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'site/**'
 
 jobs:
   podman:


### PR DESCRIPTION
We have a set of GitHub Action jobs that run to test cgroupv2, docker,
and podman functionality. They currently run on all PRs to main.

These are functional tests, so they are not necessary when making
documentation changes. This updates the job definitions to skip running
if the PR only contains doc changes. This is likely rare, but will save
some resources by not testing when there are no code changes.