### PR TITLE
pkg/build: improve source finding message

### DIFF
--- a/pkg/build/nodeimage/internal/kube/source.go
+++ b/pkg/build/nodeimage/internal/kube/source.go
@@ -38,7 +38,7 @@ func FindSource() (root string, err error) {
 	if err == nil && maybeKubeDir(pkg.Dir) {
 		return pkg.Dir, nil
 	}
-	return "", errors.New("could not find kubernetes source")
+	return "", fmt.Errorf("could not find %s module source under GOPATH=%s: %w", ImportPath, build.Default.GOPATH, err)
 }
 
 // maybeKubeDir returns true if the dir looks plausibly like a kubernetes


### PR DESCRIPTION
Previously, users were not told where `kind` was looking for the
Kubernetes source, making the error message not actionable:

```
$ kind build node-image
ERROR: error building node image: error finding kuberoot: could not find kubernetes source
```

Now, we expose that information so the user can ensure we locate it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>