### PR TITLE
Remove obsolete step from metallb guide

### DIFF
--- a/site/content/docs/user/loadbalancer.md
+++ b/site/content/docs/user/loadbalancer.md
@@ -32,12 +32,6 @@ description: |-
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/master/manifests/namespace.yaml
 {{< /codeFromInline >}}
 
-### Create the memberlist secrets
-
-{{< codeFromInline lang="bash" >}}
-kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)" 
-{{< /codeFromInline >}}
-
 ### Apply metallb manifest
 
 {{< codeFromInline lang="bash" >}}


### PR DESCRIPTION
According to the [metallb 0.10.0 release notes](https://metallb.universe.tf/release-notes/#version-0-10-0), it is no longer necessary to manually create the secret `metallb-system/memberlist` if deploying from the manifests linked to in this guide. I was just able to deploy metallb into a kind cluster without creating the secret.