### PR TITLE
exec: show command error output

### DIFF
--- a/pkg/exec/types.go
+++ b/pkg/exec/types.go
@@ -52,7 +52,7 @@ var _ error = &RunError{}
 
 func (e *RunError) Error() string {
 	// TODO(BenTheElder): implement formatter, and show output for %+v ?
-	return fmt.Sprintf("command \"%s\" failed with error: %v", e.PrettyCommand(), e.Inner)
+	return fmt.Sprintf("command \"%s\" failed with error: %v: %s", e.PrettyCommand(), e.Inner, e.Output)
 }
 
 // PrettyCommand pretty prints the command in a way that could be pasted


### PR DESCRIPTION
Without the output, often the error that would be printed would simply
not be actionable for the user.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Before:

```
ERROR: failed to delete cluster "kind": command "podman volume rm --force ''" failed with error: exit status 125
```

After:

```
ERROR: failed to delete cluster "kind": command "podman volume rm --force ''" failed with error: exit status 125: Error: name or ID cannot be empty
```