### PR TITLE
Add KUBE_PROXY_DETECT_LOCAL_MODE option in e2e-k8s.sh

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -173,6 +173,9 @@ ${kubelet_extra_args}
   nodeRegistration:
     kubeletExtraArgs:
 ${kubelet_extra_args}
+  ---
+  kind: KubeProxyConfiguration
+  detectLocalMode: ${KUBE_PROXY_DETECT_LOCAL_MODE:-ClusterCIDR}
 EOF
   # NOTE: must match the number of workers above
   NUM_NODES=2


### PR DESCRIPTION
Allow running E2E tests with different configurations for kube-proxy "--detect-local-mode".

Currently, the two supported options are ClusterCIDR (default) and NodeCIDR. [PR 95400](https://github.com/kubernetes/kubernetes/pull/95400) is adding two additional options BridgeInterfaceName and InterfacePrefix, which we'd like to be able to validate end-to-end.

Related issue: https://github.com/kubernetes/kubernetes/issues/108525
