### PR TITLE
Fix multi-node cluster not working after restarting docker

### DIFF
--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -477,6 +477,8 @@ apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
 metadata:
   name: config
+patches:
+  directory: /kind/patches
 # we use a well know token for TLS bootstrap
 bootstrapTokens:
 - token: "{{ .Token }}"
@@ -498,6 +500,8 @@ apiVersion: kubeadm.k8s.io/v1beta3
 kind: JoinConfiguration
 metadata:
   name: config
+patches:
+  directory: /kind/patches
 {{ if .ControlPlane -}}
 controlPlane:
   localAPIEndpoint:


### PR DESCRIPTION
In a multi-node cluster with single controlplane node, if the
controlplane node's IP changes, kube-controller-manager and
kube-scheduler would fail to connect kube-apiserver. Updating the
server address to new IP doesn't work because the API server's
certificate isn't valid for it.

This patch uses "patches" option of kubeadm to replace the server
address in the kubeconfig files of kube-controller-manager and
kube-scheduler with loopback address, which is an alternative address
of the API server's certificate.

Signed-off-by: Quan Tian <qtian@vmware.com>

For #1685

Depends on https://github.com/kubernetes/kubernetes/pull/109886