### PR TITLE
docs: revert description

### DIFF
--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -140,7 +140,7 @@ networking:
 {{< /codeFromInline >}}
 
 ##### Dual Stack clusters
-You can run dual stack clusters using `kind` 0.12+, on kubernetes versions 1.20+.
+You can run dual stack clusters using `kind` 0.11+, on kubernetes versions 1.20+.
 
 {{< codeFromInline lang="yaml" >}}
 kind: Cluster


### PR DESCRIPTION
Due to my mistake, update the document to an incorrect description. So revert to old description.

Refer to this comment: https://github.com/kubernetes-sigs/kind/pull/2676#discussion_r828216982