### PR TITLE
Add ppc64le support

### DIFF
--- a/images/Makefile.common.in
+++ b/images/Makefile.common.in
@@ -13,8 +13,8 @@ IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # build with buildx
-PLATFORMS?=linux/amd64,linux/arm64,linux/s390x
-OUTPUT=
+PLATFORMS?=linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+OUTPUT?=
 PROGRESS=auto
 build: ensure-buildx
 	docker buildx build --platform=${PLATFORMS} $(OUTPUT) --progress=$(PROGRESS) -t ${IMAGE} --pull .


### PR DESCRIPTION
This PR addresses
- Add linux/ppc64le support
- Allow OUTPUT flag to override to use with build target e.g: `PLATFORMS=linux/ppc64le OUTPUT=--load make build`