### PR TITLE
Added multi-arch support for quay quick

### DIFF
--- a/images/Makefile.common.in
+++ b/images/Makefile.common.in
@@ -27,7 +27,7 @@ push: build
 # for sanity checking before doing a cross build push
 # cross builds cannot be imported locally at the moment
 # https://github.com/docker/buildx/issues/59
-quick: PLATFORMS=linux/amd64
+quick: PLATFORMS=linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
 quick: OUTPUT=--load
 quick: build
 


### PR DESCRIPTION
quick allows building image into the local docker