### PR TITLE
consider prereleases on comparisons

### DIFF
--- a/pkg/cluster/internal/create/actions/kubeadminit/init.go
+++ b/pkg/cluster/internal/create/actions/kubeadminit/init.go
@@ -122,7 +122,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			return errors.Wrap(err, "could not parse Kubernetes version")
 		}
 		taints := []string{"node-role.kubernetes.io/control-plane-", "node-role.kubernetes.io/master-"}
-		if kubeVersion.LessThan(version.MustParseSemantic("v1.24.0")) {
+		if kubeVersion.LessThan(version.MustParseSemantic("v1.24.0-0")) {
 			taints = []string{"node-role.kubernetes.io/master-"}
 		}
 		taintArgs := []string{"--kubeconfig=/etc/kubernetes/admin.conf", "taint", "nodes", "--all"}

--- a/pkg/internal/version/version_test.go
+++ b/pkg/internal/version/version_test.go
@@ -346,3 +346,72 @@ func TestComponents(t *testing.T) {
 		}
 	}
 }
+
+func TestVersion_LessThan_AtLeast(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		lessThan string
+		want     bool
+	}{
+		{
+			name:     "same version",
+			version:  "1.21.1",
+			lessThan: "1.21.1",
+			want:     false,
+		},
+		{
+			name:     "one patch less",
+			version:  "1.21.1",
+			lessThan: "1.21.2",
+			want:     true,
+		},
+		{
+			name:     "one patch greater",
+			version:  "1.21.3",
+			lessThan: "1.21.2",
+			want:     false,
+		},
+		{
+			name:     "one patch less but one minor more",
+			version:  "1.22.1",
+			lessThan: "1.21.2",
+			want:     false,
+		},
+		{
+			name:     "one patch greater but one minor less",
+			version:  "1.20.3",
+			lessThan: "1.21.2",
+			want:     true,
+		},
+		{
+			name:     "same version against prerelease",
+			version:  "v1.24.0",
+			lessThan: "v1.24.0-beta.0.115+65178fec72df62",
+			want:     false,
+		},
+		{
+			name:     "prerelease against same version",
+			version:  "v1.24.0-beta.0.115+65178fec72df62",
+			lessThan: "v1.24.0",
+			want:     true,
+		},
+		{
+			name:     "prerelease against same version considering prereleases",
+			version:  "v1.24.0-beta.0.115+65178fec72df62",
+			lessThan: "v1.24.0-0",
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := MustParseSemantic(tt.version)
+			if got := v.LessThan(MustParseSemantic(tt.lessThan)); got != tt.want {
+				t.Errorf("Version.LessThan() = %v, want %v", got, tt.want)
+			}
+			if got := v.AtLeast(MustParseSemantic(tt.lessThan)); got == tt.want {
+				t.Errorf("Version.AtLeast() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
subtle bug, but it seems that the comparison functions are correct

http://masterminds.github.io/sprig/semver.html#:~:text=A%20pre%2Drelease%20version%20indicates,comparator%20will%20skip%20prerelease%20versions.

it should append the `-0` to the version to consider prereleases on comparison