### PR TITLE
Prefer to build Ginkgo V2

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -64,7 +64,7 @@ build() {
       GINKGO_SRC_DIR="vendor/github.com/onsi/ginkgo/ginkgo"
   fi
   # make sure we have e2e requirements
-  make all WHAT="cmd/kubectl test/e2e/e2e.test $GINKGO_SRC_DIR"
+  make all WHAT="cmd/kubectl test/e2e/e2e.test ${GINKGO_SRC_DIR}"
 }
 
 check_structured_log_support() {

--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -58,8 +58,13 @@ trap signal_handler INT TERM
 build() {
   # build the node image w/ kubernetes
   kind build node-image -v 1
+  # Ginkgo v1 is used by Kubernetes 1.24 and earlier, fallback if v2 is not available.
+  GINKGO_SRC_DIR="vendor/github.com/onsi/ginkgo/v2/ginkgo"
+  if [ ! -d "$GINKGO_SRC_DIR" ]; then
+      GINKGO_SRC_DIR="vendor/github.com/onsi/ginkgo/ginkgo"
+  fi
   # make sure we have e2e requirements
-  make all WHAT='cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo'
+  make all WHAT="cmd/kubectl test/e2e/e2e.test $GINKGO_SRC_DIR"
 }
 
 check_structured_log_support() {


### PR DESCRIPTION
Ginkgo V1 has been deprecated, for this issue like this https://github.com/onsi/ginkgo/issues/222 will be fixed in the v2 only.

>With the release of Ginkgo 2.0 the 1.x version is formally deprecated and no longer supported. All future development will occur on version 2.


The efforts to migrate the Ginkgo from v1 to v2 is being done here: https://github.com/kubernetes/kubernetes/pull/109111

But there are couple of required check e.g. `pull-kubernetes-e2e-kind` are building Ginkgo v1, pls see: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/109111/pull-kubernetes-e2e-kind/1514937224469155840/build-log.txt

Signed-off-by: Dave Chen <dave.chen@arm.com>