### PR TITLE
load: support loading images with different providers (`podman`)

### DIFF
--- a/pkg/cluster/internal/providers/docker/provider.go
+++ b/pkg/cluster/internal/providers/docker/provider.go
@@ -133,6 +133,28 @@ func (p *provider) ListNodes(cluster string) ([]nodes.Node, error) {
 	return ret, nil
 }
 
+// SaveImage saves images to dest, as in `docker save`
+func (p *provider) SaveImage(images []string, dest string) error {
+	commandArgs := append([]string{"save", "-o", dest}, images...)
+	return exec.Command("docker", commandArgs...).Run()
+}
+
+// ImageID return the Id of the container image
+func (p *provider) ImageID(containerNameOrID string) (string, error) {
+	cmd := exec.Command("docker", "image", "inspect",
+		"-f", "{{ .Id }}",
+		containerNameOrID, // ... against the container
+	)
+	lines, err := exec.OutputLines(cmd)
+	if err != nil {
+		return "", err
+	}
+	if len(lines) != 1 {
+		return "", errors.Errorf("Docker image ID should only be one line, got %d lines", len(lines))
+	}
+	return lines[0], nil
+}
+
 // DeleteNodes is part of the providers.Provider interface
 func (p *provider) DeleteNodes(n []nodes.Node) error {
 	if len(n) == 0 {

--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -139,6 +139,28 @@ func (p *provider) ListNodes(cluster string) ([]nodes.Node, error) {
 	return ret, nil
 }
 
+// SaveImage saves images to dest, as in `podman save`
+func (p *provider) SaveImage(images []string, dest string) error {
+	commandArgs := append([]string{"save", "-o", dest}, images...)
+	return exec.Command("podman", commandArgs...).Run()
+}
+
+// ImageID return the Id of the container image
+func (p *provider) ImageID(containerNameOrID string) (string, error) {
+	cmd := exec.Command("podman", "image", "inspect",
+		"-f", "{{ .Id }}",
+		containerNameOrID, // ... against the container
+	)
+	lines, err := exec.OutputLines(cmd)
+	if err != nil {
+		return "", err
+	}
+	if len(lines) != 1 {
+		return "", errors.Errorf("Podman image ID should only be one line, got %d lines", len(lines))
+	}
+	return lines[0], nil
+}
+
 // DeleteNodes is part of the providers.Provider interface
 func (p *provider) DeleteNodes(n []nodes.Node) error {
 	if len(n) == 0 {

--- a/pkg/cluster/internal/providers/provider.go
+++ b/pkg/cluster/internal/providers/provider.go
@@ -47,6 +47,10 @@ type Provider interface {
 	CollectLogs(dir string, nodes []nodes.Node) error
 	// Info returns the provider info
 	Info() (*ProviderInfo, error)
+	// SaveImage saves images to dest e.g `docker save` or `podman save`
+	SaveImage(images []string, dest string) error
+	// ImageID return the Id of the container image
+	ImageID(containerNameOrID string) (string, error)
 }
 
 // ProviderInfo is the info of the provider

--- a/pkg/cluster/provider.go
+++ b/pkg/cluster/provider.go
@@ -222,6 +222,16 @@ func (p *Provider) ListInternalNodes(name string) ([]nodes.Node, error) {
 	return nodeutils.InternalNodes(n)
 }
 
+// SaveImage saves images to dest, as in `podman save` or `docker save`
+func (p *Provider) SaveImage(images []string, dest string) error {
+	return p.provider.SaveImage(images, dest)
+}
+
+// ImageID return the Id of the container image
+func (p *Provider) ImageID(containerNameOrID string) (string, error) {
+	return p.provider.ImageID(containerNameOrID)
+}
+
 // CollectLogs will populate dir with cluster logs and other debug files
 func (p *Provider) CollectLogs(name, dir string) error {
 	// TODO: should use ListNodes and Collect should handle nodes differently

--- a/pkg/cmd/kind/load/docker-image/docker-image.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
 	"sigs.k8s.io/kind/pkg/cmd"
 	"sigs.k8s.io/kind/pkg/errors"
-	"sigs.k8s.io/kind/pkg/exec"
 	"sigs.k8s.io/kind/pkg/fs"
 	"sigs.k8s.io/kind/pkg/log"
 
@@ -85,7 +84,7 @@ func runE(logger log.Logger, flags *flagpole, args []string) error {
 	imageNames := removeDuplicates(args)
 	var imageIDs []string
 	for _, imageName := range imageNames {
-		imageID, err := imageID(imageName)
+		imageID, err := provider.ImageID(imageName)
 		if err != nil {
 			return fmt.Errorf("image: %q not present locally", imageName)
 		}
@@ -154,7 +153,7 @@ func runE(logger log.Logger, flags *flagpole, args []string) error {
 	defer os.RemoveAll(dir)
 	imagesTarPath := filepath.Join(dir, "images.tar")
 	// Save the images into a tar
-	err = save(imageNames, imagesTarPath)
+	err = provider.SaveImage(imageNames, imagesTarPath)
 	if err != nil {
 		return err
 	}
@@ -179,28 +178,6 @@ func loadImage(imageTarName string, node nodes.Node) error {
 	}
 	defer f.Close()
 	return nodeutils.LoadImageArchive(node, f)
-}
-
-// save saves images to dest, as in `docker save`
-func save(images []string, dest string) error {
-	commandArgs := append([]string{"save", "-o", dest}, images...)
-	return exec.Command("docker", commandArgs...).Run()
-}
-
-// imageID return the Id of the container image
-func imageID(containerNameOrID string) (string, error) {
-	cmd := exec.Command("docker", "image", "inspect",
-		"-f", "{{ .Id }}",
-		containerNameOrID, // ... against the container
-	)
-	lines, err := exec.OutputLines(cmd)
-	if err != nil {
-		return "", err
-	}
-	if len(lines) != 1 {
-		return "", errors.Errorf("Docker image ID should only be one line, got %d lines", len(lines))
-	}
-	return lines[0], nil
 }
 
 // removeDuplicates removes duplicates from a string slice


### PR DESCRIPTION
As of now `kind` hardcodes looking and loading images from `docker`
as a result `kind load docker-image <image>:<tag>` does not works well when
`Provider` is configured as `podman` instead of `docker`.

Following PR makes sure that `kind` supports loading images irrespective of
the providers configured and works for both `podman` and `docker`

Closes: https://github.com/kubernetes-sigs/kind/issues/2729