### PR TITLE
mark /vagrant safe

### DIFF
--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -39,6 +39,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-kind", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
     set -eux -o pipefail
+    git config --global --add safe.directory /vagrant
     make -C /vagrant install INSTALL_DIR=/usr/local/bin
     SHELL
   end


### PR DESCRIPTION
https://github.blog/2022-04-12-git-security-vulnerability-announced/

All cgroupv2 CI is broken currently. Found in https://github.com/kubernetes-sigs/kind/pull/2737