### PR TITLE
allow no matches when grepping for unsupported_cgroups

### DIFF
--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -27,6 +27,11 @@ if grep -Eqv "0[[:space:]]+0[[:space:]]+4294967295" /proc/self/uid_map; then
   echo 'INFO: running in a user namespace (experimental)'
 fi
 
+grep_allow_nomatch() {
+  # grep exits 0 on match, 1 on no match, 2 on error
+  grep "$@" || [[ $? == 1 ]]
+}
+
 validate_userns() {
   if [[ -z "${userns}" ]]; then
     return
@@ -240,7 +245,7 @@ fix_cgroup() {
   #
   # See https://github.com/kubernetes/kubernetes/issues/109182
   local unsupported_cgroups
-  unsupported_cgroups=$(findmnt -lun -o source,target -t cgroup | grep -v "${current_cgroup}" | awk '{print $2}')
+  unsupported_cgroups=$(findmnt -lun -o source,target -t cgroup | grep_allow_nomatch -v "${current_cgroup}" | awk '{print $2}')
   if [ -n "$unsupported_cgroups" ]; then
     local mnt
     echo "$unsupported_cgroups" |

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.23.5@sha256:1a72748086bc24ed6163de1d1e33cc0e2eb5a1eb5ebffdb15b53c3bcd5376a6f"
+const Image = "kindest/node:v1.23.6@sha256:b2921a38c34ac032ba2e53d734cdb33ef1e185b4a01c625d73a9f94f8e2d88e2"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,4 +20,4 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "docker.io/kindest/base:v20220413-d2354dce"
+const DefaultBaseImage = "docker.io/kindest/base:v20220509-75bb7585"


### PR DESCRIPTION
see: https://github.com/kubernetes-sigs/kind/pull/2737#issuecomment-1121690676

https://linuxcommand.org/lc3_man_pages/grep1.html#:~:text=is%20not%20set.-,EXIT%20STATUS,-Normally%20the%20exit