### PR TITLE
Add a flag to override server address in the generated config

### DIFF
--- a/pkg/cluster/createoption.go
+++ b/pkg/cluster/createoption.go
@@ -124,3 +124,11 @@ func CreateWithDisplaySalutation(displaySalutation bool) CreateOption {
 		return nil
 	})
 }
+
+// CreateWithApiServerAddress Sets server in kubeconfig to provided value
+func CreateWithApiServerAddress(apiServerAddress string) CreateOption {
+	return createOptionAdapter(func(o *internalcreate.ClusterOptions) error {
+		o.ApiServerAddressOverride = apiServerAddress
+		return nil
+	})
+}

--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -60,8 +60,9 @@ type ClusterOptions struct {
 	// see https://github.com/kubernetes-sigs/kind/issues/324
 	StopBeforeSettingUpKubernetes bool // if false kind should setup kubernetes after creating nodes
 	// Options to control output
-	DisplayUsage      bool
-	DisplaySalutation bool
+	DisplayUsage             bool
+	DisplaySalutation        bool
+	ApiServerAddressOverride string
 }
 
 // Cluster creates a cluster
@@ -231,6 +232,10 @@ func fixupOptions(opts *ClusterOptions) error {
 		for i := range opts.Config.Nodes {
 			opts.Config.Nodes[i].Image = opts.NodeImage
 		}
+	}
+
+	if opts.ApiServerAddressOverride != "" {
+		opts.Config.Networking.APIServerAddress = opts.ApiServerAddressOverride
 	}
 
 	// default config fields (important for usage as a library, where the config

--- a/pkg/cmd/kind/create/cluster/createcluster.go
+++ b/pkg/cmd/kind/create/cluster/createcluster.go
@@ -62,7 +62,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVar(&flags.Retain, "retain", false, "retain nodes for debugging when cluster creation fails")
 	cmd.Flags().DurationVar(&flags.Wait, "wait", time.Duration(0), "wait for control plane node to be ready (default 0s)")
 	cmd.Flags().StringVar(&flags.Kubeconfig, "kubeconfig", "", "sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config")
-	cmd.Flags().StringVar(&flags.Kubeconfig, "apiServerAddress", "", "apiServerAddress to write to kubeconfig")
+	cmd.Flags().StringVar(&flags.Kubeconfig, "address", "", "default cluster server address to write to kubeconfig instead of loopback address")
 	return cmd
 }
 

--- a/pkg/cmd/kind/create/cluster/createcluster.go
+++ b/pkg/cmd/kind/create/cluster/createcluster.go
@@ -34,12 +34,13 @@ import (
 )
 
 type flagpole struct {
-	Name       string
-	Config     string
-	ImageName  string
-	Retain     bool
-	Wait       time.Duration
-	Kubeconfig string
+	Name             string
+	Config           string
+	ImageName        string
+	Retain           bool
+	Wait             time.Duration
+	Kubeconfig       string
+	ApiServerAddress string
 }
 
 // NewCommand returns a new cobra.Command for cluster creation
@@ -61,6 +62,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVar(&flags.Retain, "retain", false, "retain nodes for debugging when cluster creation fails")
 	cmd.Flags().DurationVar(&flags.Wait, "wait", time.Duration(0), "wait for control plane node to be ready (default 0s)")
 	cmd.Flags().StringVar(&flags.Kubeconfig, "kubeconfig", "", "sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config")
+	cmd.Flags().StringVar(&flags.Kubeconfig, "apiServerAddress", "", "apiServerAddress to write to kubeconfig")
 	return cmd
 }
 
@@ -86,6 +88,7 @@ func runE(logger log.Logger, streams cmd.IOStreams, flags *flagpole) error {
 		cluster.CreateWithKubeconfigPath(flags.Kubeconfig),
 		cluster.CreateWithDisplayUsage(true),
 		cluster.CreateWithDisplaySalutation(true),
+		cluster.CreateWithApiServerAddress(flags.ApiServerAddress),
 	); err != nil {
 		return errors.Wrap(err, "failed to create cluster")
 	}


### PR DESCRIPTION
We are using Kind in one of our project integration tests suites, these tests run inside a docker container using github actions, when kind creates a cluster as part of the test run preparation it uses the default "127.0.0.1" for server address: https://github.com/kubernetes-sigs/kind/blob/main/pkg/internal/apis/config/default.go#L57

when the test runs a `kubectl` command it can't connect to the created cluster since `kubectl` is being ran from inside a container and `127.0.0.1` resolves to that container instead of the cluster on the host machine.

This change would allow us to set a different address when preparing for tests so it can execute `kubectl` commands and connect to the created cluster