### PR TITLE
mark v0.13.0

### DIFF
--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -54,7 +54,7 @@ const VersionCore = "0.13.0"
 
 // VersionPreRelease is the pre-release portion of the kind CLI version per
 // Semantic Versioning 2.0.0
-const VersionPreRelease = "alpha"
+const VersionPreRelease = ""
 
 // GitCommit is the commit used to build the kind binary, if available.
 // It is injected at build time.

--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -50,11 +50,11 @@ func DisplayVersion() string {
 }
 
 // VersionCore is the core portion of the kind CLI version per Semantic Versioning 2.0.0
-const VersionCore = "0.13.0"
+const VersionCore = "0.14.0"
 
 // VersionPreRelease is the pre-release portion of the kind CLI version per
 // Semantic Versioning 2.0.0
-const VersionPreRelease = ""
+const VersionPreRelease = "alpha"
 
 // GitCommit is the commit used to build the kind binary, if available.
 // It is injected at build time.


### PR DESCRIPTION
we're cutting it now following #2737, discussed with @aojea 