### PR TITLE
containerd: Enable enable_unprivileged_ports and enable_unprivileged_icmp by default

### DIFF
--- a/images/base/files/etc/containerd/config.toml
+++ b/images/base/files/etc/containerd/config.toml
@@ -40,6 +40,10 @@ version = 2
   tolerate_missing_hugepages_controller = true
   # restrict_oom_score_adj needs to be true when running inside UserNS (rootless)
   restrict_oom_score_adj = false
+  # allow listen ports < 1024 for non-root
+  enable_unprivileged_ports = true
+  # allow icmp without capabilities
+  enable_unprivileged_icmp = true
 
 # Enable registry.k8s.io as the primary mirror for k8s.gcr.io
 # See: https://github.com/kubernetes/k8s.io/issues/3411


### PR DESCRIPTION
#### Proposed Changes ####
Make using hardened containers a bit easier by:
* Allowing non-root containers to listen ports < 1024
* Allowing ICMP on containers without any capabilities

#### Types of Changes ####
Containerd configuration change. Those settings was added on containerd 1.6.x version.

#### Verification ####
Deploy following test service:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: test
  name: test
spec:
  selector:
    matchLabels:
      app: test
  template:
    metadata:
      labels:
        app: test
    spec:
      containers:
      - name: test
        image: nginx
        ports:
        - containerPort: 80
          protocol: TCP
        volumeMounts:
        - name: nginx-tmp
          mountPath: /var/cache/nginx/
        securityContext:
          capabilities:
            drop:
            - ALL
      securityContext:
        runAsNonRoot: true
        runAsUser: 1001
      volumes:
      - name: nginx-tmp
        emptyDir: {}
```
Check that NGINX is running and listening port 80

On theory also ping with command like:
```bash
kubectl exec -it test-... -- ping 1.1.1.1
```
should works but at least on my env it does not.

However at least sysctl setting `net.ipv4.ping_group_range` got value value `0   2147483647` as expected. It might be configuration issue on my env or to be related the fact that kind run inside of docker.

Change can be tested without building kind with configuration like this:
```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
name: test
containerdConfigPatches:
- |-
  [plugins."io.containerd.grpc.v1.cri"]
    enable_unprivileged_ports = true
    enable_unprivileged_icmp = true
```
