### PR TITLE
just export logs into artifacts directly

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -34,7 +34,7 @@ cleanup() {
   fi
   # KIND_CREATE_ATTEMPTED is true once we: kind create
   if [ "${KIND_CREATE_ATTEMPTED:-}" = true ]; then
-    kind "export" logs "${ARTIFACTS}/logs" || true
+    kind "export" logs "${ARTIFACTS}" || true
     kind delete cluster || true
   fi
   rm -f _output/bin/e2e.test || true


### PR DESCRIPTION
deeply nested paths are annoying when viewing CI results, I don't think this extra nesting adds anyhow.

GCE jobs dump their logs into ARTIFACTS directly