### PR TITLE
update local-path-provisioner

### DIFF
--- a/hack/make-rules/verify/shellcheck.sh
+++ b/hack/make-rules/verify/shellcheck.sh
@@ -34,7 +34,7 @@ SHELLCHECK_IMAGE='koalaman/shellcheck:v0.7.1'
 all_shell_scripts=()
 while IFS=$'\n' read -r script;
   do git check-ignore -q "$script" || all_shell_scripts+=("$script");
-done < <(grep -irl '#!.*sh' . | grep -Ev '^(\./\.git/)|(\./vendor/)|(\./bin/)')
+done < <(grep -irl '#!.*sh' . | grep -Ev '(^\./\.git/)|(^\./vendor/)|(^\./bin/)|(\.go$)')
 
 # common arguments we'll pass to shellcheck
 SHELLCHECK_OPTIONS=(

--- a/images/Makefile.common.in
+++ b/images/Makefile.common.in
@@ -1,3 +1,17 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # shared makefile for all images
 
 # get image name from directory we're building

--- a/images/Makefile.common.in
+++ b/images/Makefile.common.in
@@ -16,8 +16,9 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 PLATFORMS?=linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
 OUTPUT?=
 PROGRESS=auto
+EXTRA_BUILD_OPT?=
 build: ensure-buildx
-	docker buildx build --platform=${PLATFORMS} $(OUTPUT) --progress=$(PROGRESS) -t ${IMAGE} --pull .
+	docker buildx build --platform=${PLATFORMS} $(OUTPUT) --progress=$(PROGRESS) -t ${IMAGE} --pull $(EXTRA_BUILD_OPT) .
 
 # push the cross built image
 push: OUTPUT=--push

--- a/images/base/Makefile
+++ b/images/base/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include $(CURDIR)/../Makefile.common.in
 
 update-shasums:

--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -48,10 +48,8 @@ RUN mkdir -p "${STAGE_DIR}" && \
 
 ################################################################################
 
-# haproxy is a c++ binary, so we will use the c++ distroless image
 # See: https://github.com/GoogleContainerTools/distroless/tree/main/base
-# See: https://github.com/GoogleContainerTools/distroless/tree/main/cc
-# This has /etc/passwd, tzdata, cacerts, glibc, libssl, openssl, and libgcc1
+# This has /etc/passwd, tzdata, cacerts
 FROM "gcr.io/distroless/static-debian11"
 
 ARG STAGE_DIR="/opt/stage"

--- a/images/haproxy/README.md
+++ b/images/haproxy/README.md
@@ -9,6 +9,6 @@ hot reload it at runtime with the actual desired config.
 
 ## Building
 
-You can `docker build -t kindest/haproxy .` in this directory to build a test image.
+You can `make quick` in this directory to build a test image.
 
-To push an actual image use `./push-cross.sh`.
+To push an actual image use `make push`.

--- a/images/haproxy/stage-binary-and-deps.sh
+++ b/images/haproxy/stage-binary-and-deps.sh
@@ -30,7 +30,7 @@ file_to_package() {
     # `dpkg-query --search $file-pattern` outputs lines with the format: "$package: $file-path"
     # where $file-path belongs to $package
     # https://manpages.debian.org/jessie/dpkg/dpkg-query.1.en.html
-    dpkg-query --search "${1}" | cut -d':' -f1
+    dpkg-query --search "$(realpath "${1}")" | cut -d':' -f1
 }
 
 # package_to_copyright gives the path to the copyright file for the package $1

--- a/images/local-path-helper/Dockerfile
+++ b/images/local-path-helper/Dockerfile
@@ -1,0 +1,47 @@
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This image is a haproxy image + minimal config so the container will not exit
+# while we rewrite the config at runtime and signal haproxy to reload.
+
+ARG BASE="k8s.gcr.io/build-image/debian-base:bullseye-v1.2.0"
+FROM ${BASE} as build
+
+# NOTE: copyrights.tar.gz is a quirk of Kubernetes's debian-base image
+# We extract these here so we can grab the relevant files are easily
+# staged for copying into our final image.
+RUN [ ! -f /usr/share/copyrights.tar.gz ] || tar -C / -xzvf /usr/share/copyrights.tar.gz
+
+# we need bash for stage-binary-and-deps.sh
+RUN apt update && apt install -y --no-install-recommends bash
+# replace sh with bash
+RUN ln -sf /bin/bash /bin/sh
+
+# copy in script for staging distro provided binary to distroless
+COPY --chmod=0755 stage-binary-and-deps.sh /usr/local/bin/
+
+# local-path-provisioner needs these things for the helper pod
+# TODO: we could probably coerce local-path-provisioner to use a small binary
+# for these instead
+ARG STAGE_DIR="/opt/stage"
+RUN mkdir -p "${STAGE_DIR}" && \
+    stage-binary-and-deps.sh sh "${STAGE_DIR}" && \
+    stage-binary-and-deps.sh rm "${STAGE_DIR}" && \
+    stage-binary-and-deps.sh mkdir "${STAGE_DIR}" && \
+    find "${STAGE_DIR}"
+
+# copy staged binary + deps + copyright into distroless
+FROM "gcr.io/distroless/static-debian11"
+ARG STAGE_DIR="/opt/stage"
+COPY --from=build "${STAGE_DIR}/" /

--- a/images/local-path-helper/Dockerfile
+++ b/images/local-path-helper/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This image is a haproxy image + minimal config so the container will not exit
-# while we rewrite the config at runtime and signal haproxy to reload.
+# This image is contains the binaries needed for the local-path-provisioner
+# helper pod. Currently that means: sh, rm, mkdir
 
 ARG BASE="k8s.gcr.io/build-image/debian-base:bullseye-v1.2.0"
 FROM ${BASE} as build

--- a/images/local-path-helper/Makefile
+++ b/images/local-path-helper/Makefile
@@ -1,0 +1,15 @@
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include $(CURDIR)/../Makefile.common.in

--- a/images/local-path-helper/README.md
+++ b/images/local-path-helper/README.md
@@ -1,0 +1,9 @@
+# local-path-helper
+
+This image is the image used for the https://github.com/rancher/local-path-provisioner helper pod.
+
+## Building
+
+You can `make quick` in this directory to build a test image.
+
+To push an actual image use `make push`.

--- a/images/local-path-helper/stage-binary-and-deps.sh
+++ b/images/local-path-helper/stage-binary-and-deps.sh
@@ -30,7 +30,7 @@ file_to_package() {
     # `dpkg-query --search $file-pattern` outputs lines with the format: "$package: $file-path"
     # where $file-path belongs to $package
     # https://manpages.debian.org/jessie/dpkg/dpkg-query.1.en.html
-    dpkg-query --search "${1}" | cut -d':' -f1
+    dpkg-query --search "$(realpath "${1}")" | cut -d':' -f1
 }
 
 # package_to_copyright gives the path to the copyright file for the package $1

--- a/images/local-path-helper/stage-binary-and-deps.sh
+++ b/images/local-path-helper/stage-binary-and-deps.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# USAGE: stage-binary-and-deps.sh haproxy /opt/stage
+#
+# Stages $1 and it's dependencies + their copyright files to $2
+#
+# This is intended to be used in a multi-stage docker build with a distroless/base
+# or distroless/cc image.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# file_to_package identifies the debian package that provided the file $1
+file_to_package() {
+    # `dpkg-query --search $file-pattern` outputs lines with the format: "$package: $file-path"
+    # where $file-path belongs to $package
+    # https://manpages.debian.org/jessie/dpkg/dpkg-query.1.en.html
+    dpkg-query --search "${1}" | cut -d':' -f1
+}
+
+# package_to_copyright gives the path to the copyright file for the package $1
+package_to_copyright() {
+    echo "/usr/share/doc/${1}/copyright"
+}
+
+# stage_file stages the filepath $1 to $2, following symlinks
+# and staging copyrights
+stage_file() {
+    cp -a --parents "${1}" "${2}"
+    # recursively follow symlinks
+    if [[ -L "${1}" ]]; then
+        stage_file "$(cd "$(dirname "${1}")"; realpath -s "$(readlink "${1}")")" "${2}"
+    fi
+    # get the package so we can stage package metadata as well
+    package="$(file_to_package "${1}")"
+    # stage the copyright for the file
+    cp -a --parents "$(package_to_copyright "${package}")" "${2}"
+    # stage the package status mimicking bazel
+    # https://github.com/bazelbuild/rules_docker/commit/f5432b813e0a11491cf2bf83ff1a923706b36420
+    # instead of parsing the control file, we can just get the actual package status with dpkg
+    dpkg -s "${package}" >> "${2}/var/lib/dpkg/status.d/${package}"
+}
+
+# binary_to_libraries identifies the library files needed by the binary $1 with ldd
+binary_to_libraries() {
+    # see: https://man7.org/linux/man-pages/man1/ldd.1.html
+    ldd "${1}" \
+    `# strip the leading '${name} => ' if any so only '/lib-foo.so (0xf00)' remains` \
+    | sed -E 's#.* => /#/#' \
+    `# we want only the path remaining, not the (0x${LOCATION})` \
+    | awk '{print $1}' \
+    `# linux-vdso.so.1 is a special virtual shared object from the kernel` \
+    `# see: http://man7.org/linux/man-pages/man7/vdso.7.html` \
+    | grep -v 'linux-vdso.so.1'
+}
+
+# main script logic
+main(){
+    local BINARY=$1
+    local STAGE_DIR="${2}/"
+
+    # locate the path to the binary
+    local binary_path
+    binary_path="$(which "${BINARY}")"
+
+    # ensure package metadata dir
+    mkdir -p "${STAGE_DIR}"/var/lib/dpkg/status.d/
+
+    # stage the binary itself
+    stage_file "${binary_path}" "${STAGE_DIR}"
+
+    # stage the dependencies of the binary
+    while IFS= read -r c_dep; do
+        stage_file "${c_dep}" "${STAGE_DIR}"
+    done < <(binary_to_libraries "${binary_path}")
+}
+
+main "$@"

--- a/images/local-path-provisioner/Dockerfile
+++ b/images/local-path-provisioner/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.18
+RUN git clone https://github.com/rancher/local-path-provisioner
+ARG VERSION
+RUN cd local-path-provisioner && \
+    git fetch && git checkout "${VERSION}" && \
+    scripts/build && \
+    mv bin/local-path-provisioner /usr/local/bin/local-path-provisioner
+
+FROM gcr.io/distroless/base-debian11
+COPY --from=0 /usr/local/bin/local-path-provisioner /usr/local/bin/local-path-provisioner
+ENTRYPOINT /usr/local/bin/local-path-provisioner

--- a/images/local-path-provisioner/Makefile
+++ b/images/local-path-provisioner/Makefile
@@ -1,0 +1,17 @@
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+VERSION=v0.0.22
+TAG=$(VERSION)-kind.0
+EXTRA_BUILD_OPT=--build-arg=VERSION=$(VERSION)
+include $(CURDIR)/../Makefile.common.in

--- a/images/local-path-provisioner/README.md
+++ b/images/local-path-provisioner/README.md
@@ -1,0 +1,13 @@
+# local-path-provisioner
+
+This image packages https://github.com/rancher/local-path-provisioner to meet
+our requirements.
+
+- Not based on alpine (see: https://github.com/kubernetes/kubernetes/issues/109406#issuecomment-1103479928)
+- Control over building with current patched go version
+
+## Building
+
+You can `make quick` in this directory to build a test image.
+
+To push an actual image use `make push`.


### PR DESCRIPTION
- build our own images (alpine is not approved in the Kubernetes project due to licensing ... https://github.com/kubernetes/kubernetes/issues/109406#issuecomment-1103479928)
- build a minimal helper image replacement for busybox/alpine
- update to v0.0.22
- fix some minor nits in images

TODO: push these images, and update the manifest for v0.0.22

fixes #2453 (latest disables leader election outright https://github.com/rancher/local-path-provisioner/pull/167)
fixes #2697 