### PR TITLE
move some flags into kubelet config

### DIFF
--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -219,7 +219,6 @@ localAPIEndpoint:
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
   kubeletExtraArgs:
-    fail-swap-on: "false"
     node-ip: "{{ .NodeAddress }}"
     provider-id: "kind://{{.NodeProvider}}/{{.ClusterName}}/{{.NodeName}}"
 ---
@@ -237,7 +236,6 @@ controlPlane:
 nodeRegistration:
   criSocket: "/run/containerd/containerd.sock"
   kubeletExtraArgs:
-    fail-swap-on: "false"
     node-ip: "{{ .NodeAddress }}"
     provider-id: "kind://{{.NodeProvider}}/{{.ClusterName}}/{{.NodeName}}"
 discovery:
@@ -252,6 +250,7 @@ metadata:
   name: config
 cgroupDriver: {{ .CgroupDriver }}
 cgroupRoot: /kubelet
+failSwapOn: false
 # configure ipv6 addresses in IPv6 mode
 {{ if .IPv6 -}}
 address: "::"
@@ -350,7 +349,6 @@ localAPIEndpoint:
 nodeRegistration:
   criSocket: "unix:///run/containerd/containerd.sock"
   kubeletExtraArgs:
-    fail-swap-on: "false"
     node-ip: "{{ .NodeAddress }}"
     provider-id: "kind://{{.NodeProvider}}/{{.ClusterName}}/{{.NodeName}}"
     node-labels: "{{ .NodeLabels }}"
@@ -369,7 +367,6 @@ controlPlane:
 nodeRegistration:
   criSocket: "unix:///run/containerd/containerd.sock"
   kubeletExtraArgs:
-    fail-swap-on: "false"
     node-ip: "{{ .NodeAddress }}"
     provider-id: "kind://{{.NodeProvider}}/{{.ClusterName}}/{{.NodeName}}"
     node-labels: "{{ .NodeLabels }}"
@@ -385,6 +382,7 @@ metadata:
   name: config
 cgroupDriver: {{ .CgroupDriver }}
 cgroupRoot: /kubelet
+failSwapOn: false
 # configure ipv6 addresses in IPv6 mode
 {{ if .IPv6 -}}
 address: "::"
@@ -488,7 +486,6 @@ localAPIEndpoint:
 nodeRegistration:
   criSocket: "unix:///run/containerd/containerd.sock"
   kubeletExtraArgs:
-    fail-swap-on: "false"
     node-ip: "{{ .NodeAddress }}"
     provider-id: "kind://{{.NodeProvider}}/{{.ClusterName}}/{{.NodeName}}"
     node-labels: "{{ .NodeLabels }}"
@@ -507,7 +504,6 @@ controlPlane:
 nodeRegistration:
   criSocket: "unix:///run/containerd/containerd.sock"
   kubeletExtraArgs:
-    fail-swap-on: "false"
     node-ip: "{{ .NodeAddress }}"
     provider-id: "kind://{{.NodeProvider}}/{{.ClusterName}}/{{.NodeName}}"
     node-labels: "{{ .NodeLabels }}"
@@ -523,6 +519,7 @@ metadata:
   name: config
 cgroupDriver: {{ .CgroupDriver }}
 cgroupRoot: /kubelet
+failSwapOn: false
 # configure ipv6 addresses in IPv6 mode
 {{ if .IPv6 -}}
 address: "::"

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -250,11 +250,8 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 metadata:
   name: config
-# explicitly set default cgroup driver
-# unblocks https://github.com/kubernetes/kubernetes/pull/99471
-# TODO: consider switching to systemd instead
-# tracked in: https://github.com/kubernetes-sigs/kind/issues/1726
 cgroupDriver: {{ .CgroupDriver }}
+cgroupRoot: /kubelet
 # configure ipv6 addresses in IPv6 mode
 {{ if .IPv6 -}}
 address: "::"
@@ -386,11 +383,8 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 metadata:
   name: config
-# explicitly set default cgroup driver
-# unblocks https://github.com/kubernetes/kubernetes/pull/99471
-# TODO: consider switching to systemd instead
-# tracked in: https://github.com/kubernetes-sigs/kind/issues/1726
 cgroupDriver: {{ .CgroupDriver }}
+cgroupRoot: /kubelet
 # configure ipv6 addresses in IPv6 mode
 {{ if .IPv6 -}}
 address: "::"
@@ -527,11 +521,8 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 metadata:
   name: config
-# explicitly set default cgroup driver
-# unblocks https://github.com/kubernetes/kubernetes/pull/99471
-# TODO: consider switching to systemd instead
-# tracked in: https://github.com/kubernetes-sigs/kind/issues/1726
 cgroupDriver: {{ .CgroupDriver }}
+cgroupRoot: /kubelet
 # configure ipv6 addresses in IPv6 mode
 {{ if .IPv6 -}}
 address: "::"


### PR DESCRIPTION
We can't move node-address, labels, and provider-id, which is just as well because those need to be per-node.

The others we can, and need to, we get warning logs about deprecated flags.

In some future kind release we can stop setting `--cgroup-root` in the base image.
I'm not sure if we want to do that now, because it will break users attempting to use newer images since existing kind releases are not setting it in the config.

This breaks using kind with old images that don't have `/kubelet` cgroup setup, but it's been a few releases since we started using this cgroup root.