### PR TITLE
Fix multi-node cluster not working after restarting docker

### DIFF
--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -378,6 +378,22 @@ select_iptables() {
   update-alternatives --set ip6tables "/usr/sbin/ip6tables-${mode}" > /dev/null
 }
 
+fix_certificate() {
+  local apiserver_crt_file="/etc/kubernetes/pki/apiserver.crt"
+  local apiserver_key_file="/etc/kubernetes/pki/apiserver.key"
+
+  # Skip if this Node doesn't run kube-apiserver
+  if [[ ! -f ${apiserver_crt_file} ]] || [[ ! -f ${apiserver_key_file} ]]; then
+    return
+  fi
+
+  # Deletes the certificate for kube-apiserver and generates a new one.
+  # This is necessary because the old one doesn't match the current IP.
+  echo 'INFO: clearing and regenerating the certificate for serving the Kubernetes API' >&2
+  rm -f ${apiserver_crt_file} ${apiserver_key_file}
+  kubeadm init phase certs apiserver --config /kind/kubeadm.conf
+}
+
 enable_network_magic(){
   # well-known docker embedded DNS is at 127.0.0.11:53
   local docker_embedded_dns_ip='127.0.0.11'
@@ -416,10 +432,17 @@ enable_network_magic(){
         echo "ERROR: Have an old IPv4 address but no current IPv4 address (!)" >&2
         exit 1
       fi
-      # kubernetes manifests are only present on control-plane nodes
-      sed -i "s#${old_ipv4}#${curr_ipv4}#" /etc/kubernetes/manifests/*.yaml || true
-      # this is no longer required with autodiscovery
-      sed -i "s#${old_ipv4}#${curr_ipv4}#" /var/lib/kubelet/kubeadm-flags.env || true
+      if [[ "${old_ipv4}" != "${curr_ipv4}" ]]; then
+        # kubernetes manifests are only present on control-plane nodes
+        sed -i "s#${old_ipv4}#${curr_ipv4}#" /etc/kubernetes/manifests/*.yaml || true
+        sed -i "s#${old_ipv4}#${curr_ipv4}#" /etc/kubernetes/controller-manager.conf || true
+        sed -i "s#${old_ipv4}#${curr_ipv4}#" /etc/kubernetes/scheduler.conf || true
+        sed -i "s#${old_ipv4}#${curr_ipv4}#" /kind/kubeadm.conf || true
+        # this is no longer required with autodiscovery
+        sed -i "s#${old_ipv4}#${curr_ipv4}#" /var/lib/kubelet/kubeadm-flags.env || true
+        # certificate must match the new IP
+        fix_certificate || true
+      fi
   fi
   if [[ -n $curr_ipv4 ]]; then
     echo -n "${curr_ipv4}" >/kind/old-ipv4
@@ -435,10 +458,17 @@ enable_network_magic(){
       if [[ -z $curr_ipv6 ]]; then
         echo "ERROR: Have an old IPv6 address but no current IPv6 address (!)" >&2
       fi
-      # kubernetes manifests are only present on control-plane nodes
-      sed -i "s#${old_ipv6}#${curr_ipv6}#" /etc/kubernetes/manifests/*.yaml || true
-      # this is no longer required with autodiscovery
-      sed -i "s#${old_ipv6}#${curr_ipv6}#" /var/lib/kubelet/kubeadm-flags.env || true
+      if [[ "${old_ipv6}" != "${curr_ipv6}" ]]; then
+        # kubernetes manifests are only present on control-plane nodes
+        sed -i "s#${old_ipv6}#${curr_ipv6}#" /etc/kubernetes/manifests/*.yaml || true
+        sed -i "s#${old_ipv6}#${curr_ipv6}#" /etc/kubernetes/controller-manager.conf || true
+        sed -i "s#${old_ipv6}#${curr_ipv6}#" /etc/kubernetes/scheduler.conf || true
+        sed -i "s#${old_ipv6}#${curr_ipv6}#" /kind/kubeadm.conf || true
+        # this is no longer required with autodiscovery
+        sed -i "s#${old_ipv6}#${curr_ipv6}#" /var/lib/kubelet/kubeadm-flags.env || true
+        # certificate must match the new IP
+        fix_certificate || true
+      fi
   fi
   if [[ -n $curr_ipv6 ]]; then
     echo -n "${curr_ipv6}" >/kind/old-ipv6

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -29,7 +29,12 @@ fi
 
 grep_allow_nomatch() {
   # grep exits 0 on match, 1 on no match, 2 on error
-  grep "$@" || [[ $? == 1 ]]
+  grep "$@"|| [[ $? == 1 ]]
+}
+
+# regex_escape_ip converts IP address string $1 to a regex-escaped literal
+regex_escape_ip(){
+  sed -e 's#\.#\\.#g' -e 's#\[#\\[#g' -e 's#\]#\\]#g' <<<"$1"
 }
 
 validate_userns() {
@@ -434,12 +439,13 @@ enable_network_magic(){
       fi
       if [[ "${old_ipv4}" != "${curr_ipv4}" ]]; then
         # kubernetes manifests are only present on control-plane nodes
-        sed -i "s#${old_ipv4}#${curr_ipv4}#" /etc/kubernetes/manifests/*.yaml || true
-        sed -i "s#${old_ipv4}#${curr_ipv4}#" /etc/kubernetes/controller-manager.conf || true
-        sed -i "s#${old_ipv4}#${curr_ipv4}#" /etc/kubernetes/scheduler.conf || true
-        sed -i "s#${old_ipv4}#${curr_ipv4}#" /kind/kubeadm.conf || true
+        sed_ipv4_command="s#$(regex_escape_ip "${old_ipv4}")#${curr_ipv4}#g"
+        sed -i "${sed_ipv4_command}" /etc/kubernetes/manifests/*.yaml || true
+        sed -i "${sed_ipv4_command}" /etc/kubernetes/controller-manager.conf || true
+        sed -i "${sed_ipv4_command}" /etc/kubernetes/scheduler.conf || true
+        sed -i "${sed_ipv4_command}" /kind/kubeadm.conf || true
         # this is no longer required with autodiscovery
-        sed -i "s#${old_ipv4}#${curr_ipv4}#" /var/lib/kubelet/kubeadm-flags.env || true
+        sed -i "${sed_ipv4_command}" /var/lib/kubelet/kubeadm-flags.env || true
         # certificate must match the new IP
         fix_certificate || true
       fi
@@ -459,13 +465,14 @@ enable_network_magic(){
         echo "ERROR: Have an old IPv6 address but no current IPv6 address (!)" >&2
       fi
       if [[ "${old_ipv6}" != "${curr_ipv6}" ]]; then
+        sed_ipv6_command="s#$(regex_escape_ip "${old_ipv6}")#${curr_ipv6}#g"
         # kubernetes manifests are only present on control-plane nodes
-        sed -i "s#${old_ipv6}#${curr_ipv6}#" /etc/kubernetes/manifests/*.yaml || true
-        sed -i "s#${old_ipv6}#${curr_ipv6}#" /etc/kubernetes/controller-manager.conf || true
-        sed -i "s#${old_ipv6}#${curr_ipv6}#" /etc/kubernetes/scheduler.conf || true
-        sed -i "s#${old_ipv6}#${curr_ipv6}#" /kind/kubeadm.conf || true
+        sed -i "${sed_ipv6_command}" /etc/kubernetes/manifests/*.yaml || true
+        sed -i "${sed_ipv6_command}" /etc/kubernetes/controller-manager.conf || true
+        sed -i "${sed_ipv6_command}" /etc/kubernetes/scheduler.conf || true
+        sed -i "${sed_ipv6_command}" /kind/kubeadm.conf || true
         # this is no longer required with autodiscovery
-        sed -i "s#${old_ipv6}#${curr_ipv6}#" /var/lib/kubelet/kubeadm-flags.env || true
+        sed -i "${sed_ipv6_command}" /var/lib/kubelet/kubeadm-flags.env || true
         # certificate must match the new IP
         fix_certificate || true
       fi

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -29,7 +29,7 @@ fi
 
 grep_allow_nomatch() {
   # grep exits 0 on match, 1 on no match, 2 on error
-  grep "$@"|| [[ $? == 1 ]]
+  grep "$@" || [[ $? == 1 ]]
 }
 
 # regex_escape_ip converts IP address string $1 to a regex-escaped literal
@@ -426,6 +426,17 @@ enable_network_magic(){
   cp /etc/resolv.conf /etc/resolv.conf.original
   sed -e "s/${docker_embedded_dns_ip}/${docker_host_ip}/g" /etc/resolv.conf.original >/etc/resolv.conf
 
+  local files_to_update=(
+    /etc/kubernetes/manifests/etcd.yaml
+    /etc/kubernetes/manifests/kube-apiserver.yaml
+    /etc/kubernetes/manifests/kube-controller-manager.yaml
+    /etc/kubernetes/manifests/kube-scheduler.yaml
+    /etc/kubernetes/controller-manager.conf
+    /etc/kubernetes/scheduler.conf
+    /kind/kubeadm.conf
+    /var/lib/kubelet/kubeadm-flags.env
+  )
+  local should_fix_certificate=false
   # fixup IPs in manifests ...
   curr_ipv4="$( (head -n1 <(getent ahostsv4 "$(hostname)") | cut -d' ' -f1) || true)"
   echo "INFO: Detected IPv4 address: ${curr_ipv4}" >&2
@@ -438,16 +449,14 @@ enable_network_magic(){
         exit 1
       fi
       if [[ "${old_ipv4}" != "${curr_ipv4}" ]]; then
-        # kubernetes manifests are only present on control-plane nodes
-        sed_ipv4_command="s#$(regex_escape_ip "${old_ipv4}")#${curr_ipv4}#g"
-        sed -i "${sed_ipv4_command}" /etc/kubernetes/manifests/*.yaml || true
-        sed -i "${sed_ipv4_command}" /etc/kubernetes/controller-manager.conf || true
-        sed -i "${sed_ipv4_command}" /etc/kubernetes/scheduler.conf || true
-        sed -i "${sed_ipv4_command}" /kind/kubeadm.conf || true
-        # this is no longer required with autodiscovery
-        sed -i "${sed_ipv4_command}" /var/lib/kubelet/kubeadm-flags.env || true
-        # certificate must match the new IP
-        fix_certificate || true
+        should_fix_certificate=true
+        sed_ipv4_command="s#\b$(regex_escape_ip "${old_ipv4}")\b#${curr_ipv4}#g"
+        for f in "${files_to_update[@]}"; do
+          # kubernetes manifests are only present on control-plane nodes
+          if [[ -f "$f" ]]; then
+            sed -i "${sed_ipv4_command}" "$f"
+          fi
+        done
       fi
   fi
   if [[ -n $curr_ipv4 ]]; then
@@ -465,20 +474,22 @@ enable_network_magic(){
         echo "ERROR: Have an old IPv6 address but no current IPv6 address (!)" >&2
       fi
       if [[ "${old_ipv6}" != "${curr_ipv6}" ]]; then
-        sed_ipv6_command="s#$(regex_escape_ip "${old_ipv6}")#${curr_ipv6}#g"
-        # kubernetes manifests are only present on control-plane nodes
-        sed -i "${sed_ipv6_command}" /etc/kubernetes/manifests/*.yaml || true
-        sed -i "${sed_ipv6_command}" /etc/kubernetes/controller-manager.conf || true
-        sed -i "${sed_ipv6_command}" /etc/kubernetes/scheduler.conf || true
-        sed -i "${sed_ipv6_command}" /kind/kubeadm.conf || true
-        # this is no longer required with autodiscovery
-        sed -i "${sed_ipv6_command}" /var/lib/kubelet/kubeadm-flags.env || true
-        # certificate must match the new IP
-        fix_certificate || true
+        should_fix_certificate=true
+        sed_ipv6_command="s#\b$(regex_escape_ip "${old_ipv6}")\b#${curr_ipv6}#g"
+        for f in "${files_to_update[@]}"; do
+          # kubernetes manifests are only present on control-plane nodes
+          if [[ -f "$f" ]]; then
+            sed -i "${sed_ipv6_command}" "$f"
+          fi
+        done
       fi
   fi
   if [[ -n $curr_ipv6 ]]; then
     echo -n "${curr_ipv6}" >/kind/old-ipv6
+  fi
+
+  if $should_fix_certificate; then
+    fix_certificate
   fi
 }
 

--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e"
+const Image = "kindest/node:v1.24.0@sha256:4bec67ade4adfd316ff95545a015d3071b3607c73ec167f21cba77c00a6e38c5"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,4 +20,4 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "docker.io/kindest/base:v20220518-0ffcf8d6"
+const DefaultBaseImage = "docker.io/kindest/base:v20220525-316e1160"


### PR DESCRIPTION
In a multi-node cluster with single controlplane node, if the
controlplane node's IP changes, kube-controller-manager and
kube-scheduler would fail to connect kube-apiserver.

This patch fixes it by replacing the server address in kubeconfig files
of kube-controller-manager and kube-scheduler with the new IP and
re-generate a certificate with the new IP for kube-apiserver.

Signed-off-by: Quan Tian <qtian@vmware.com>

Fixes #2759