### PR TITLE
use precise versions for kubeadm label / taint changes

### DIFF
--- a/pkg/cluster/internal/create/actions/kubeadminit/init.go
+++ b/pkg/cluster/internal/create/actions/kubeadminit/init.go
@@ -122,10 +122,10 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			return errors.Wrap(err, "could not parse Kubernetes version")
 		}
 		var taints []string
-		if kubeVersion.LessThan(version.MustParseSemantic("v1.24.0-0")) {
+		if kubeVersion.LessThan(version.MustParseSemantic("v1.24.0-alpha.1.592+370031cadac624")) {
 			// for versions older than 1.24 prerelease remove only the old taint
 			taints = []string{"node-role.kubernetes.io/master-"}
-		} else if kubeVersion.LessThan(version.MustParseSemantic("v1.25.0-0")) {
+		} else if kubeVersion.LessThan(version.MustParseSemantic("v1.25.0-alpha.0.557+84c8afeba39ec9")) {
 			// for versions between 1.24 and 1.25 prerelease remove both the old and new taint
 			taints = []string{"node-role.kubernetes.io/control-plane-", "node-role.kubernetes.io/master-"}
 		} else {

--- a/pkg/cluster/internal/create/actions/waitforready/waitforready.go
+++ b/pkg/cluster/internal/create/actions/waitforready/waitforready.go
@@ -80,7 +80,7 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 		return errors.Wrap(err, "could not parse Kubernetes version")
 	}
 	selectorLabel := "node-role.kubernetes.io/control-plane"
-	if kubeVersion.LessThan(version.MustParseSemantic("v1.24.0")) {
+	if kubeVersion.LessThan(version.MustParseSemantic("v1.24.0-alpha.1.591+a3d5e5598290df")) {
 		selectorLabel = "node-role.kubernetes.io/master"
 	}
 


### PR DESCRIPTION
follow up to https://github.com/kubernetes-sigs/kind/pull/2777, https://github.com/kubernetes-sigs/kind/issues/1699#issuecomment-1048595301 

there are 3 versions here:
- when we removed the old label
- when we added the new taint
- when we removed the old taint

versions are from `hack/print-workspace-status.sh` when checked out to the commit in kubernetes, after fetching the latest upstream changes