### PR TITLE
mark release v0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ kind bootstraps each "node" with [kubeadm][kubeadm]. For more details see [the d
 
 For a complete [install guide] see [the documentation here][install guide].
 
-You can install kind with `GO111MODULE="on" go get sigs.k8s.io/kind@v0.13.0`.
+You can install kind with `GO111MODULE="on" go get sigs.k8s.io/kind@v0.14.0`.
 
 **NOTE**: please use the latest go to do this. KIND is developed with the latest stable go, see [`.go-version`](./.go-version) for the exact version we're using.
 
@@ -47,7 +47,7 @@ into your `$PATH`:
 On Linux:
 
 ```console
-curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.13.0/kind-$(uname)-amd64"
+curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.14.0/kind-$(uname)-amd64"
 chmod +x ./kind
 mv ./kind /some-dir-in-your-PATH/kind
 ```
@@ -68,9 +68,9 @@ On macOS via Bash:
 
 ```console
 # for Intel Macs
-[ $(uname -m) = x86_64 ]&& curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.13.0/kind-darwin-amd64
+[ $(uname -m) = x86_64 ]&& curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.14.0/kind-darwin-amd64
 # for M1 / ARM Macs
-[ $(uname -m) = arm64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.13.0/kind-darwin-arm64
+[ $(uname -m) = arm64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.14.0/kind-darwin-arm64
 chmod +x ./kind
 mv ./kind /some-dir-in-your-PATH/kind
 ```
@@ -78,7 +78,7 @@ mv ./kind /some-dir-in-your-PATH/kind
 On Windows:
 
 ```powershell
-curl.exe -Lo kind-windows-amd64.exe https://kind.sigs.k8s.io/dl/v0.13.0/kind-windows-amd64
+curl.exe -Lo kind-windows-amd64.exe https://kind.sigs.k8s.io/dl/v0.14.0/kind-windows-amd64
 Move-Item .\kind-windows-amd64.exe c:\some-dir-in-your-PATH\kind.exe
 
 # OR via Chocolatey (https://chocolatey.org/packages/kind)

--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -54,7 +54,7 @@ const VersionCore = "0.14.0"
 
 // VersionPreRelease is the pre-release portion of the kind CLI version per
 // Semantic Versioning 2.0.0
-const VersionPreRelease = "alpha"
+const VersionPreRelease = ""
 
 // GitCommit is the commit used to build the kind binary, if available.
 // It is injected at build time.

--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -50,11 +50,11 @@ func DisplayVersion() string {
 }
 
 // VersionCore is the core portion of the kind CLI version per Semantic Versioning 2.0.0
-const VersionCore = "0.14.0"
+const VersionCore = "0.15.0"
 
 // VersionPreRelease is the pre-release portion of the kind CLI version per
 // Semantic Versioning 2.0.0
-const VersionPreRelease = ""
+const VersionPreRelease = "alpha"
 
 // GitCommit is the commit used to build the kind binary, if available.
 // It is injected at build time.

--- a/site/config.toml
+++ b/site/config.toml
@@ -67,7 +67,7 @@ baseName = "_redirects"
 home = ["HTML", "REDIRECTS"]
 
 [params]
-stable = "v0.13.0"
+stable = "v0.14.0"
 
 # privacy settings
 [privacy]


### PR DESCRIPTION
/hold

I'm still pushing the images. I have release notes written, binaries uploaded, just waiting to update the image list with the digests.

Will unhold and merge, then push the tag once that's done.