### PR TITLE
document unavailability of mount propogation

### DIFF
--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -289,6 +289,11 @@ included in the Preferences -> Resources -> File Sharing.
 
 For more information see the [Docker file sharing guide.](https://docs.docker.com/docker-for-mac/#file-sharing)
 
+**NOTE**: Mount propagation is not possible with Mac or Windows Docker Desktop,
+due to limitation of Docker Desktop implementation. 
+
+For more information, see this [issue thread](https://github.com/kubernetes-sigs/kind/issues/2576)
+
 ### Extra Port Mappings
 
 Extra port mappings can be used to port forward to the kind nodes. This is a 


### PR DESCRIPTION
Hi. I really did write small writeup concerning unavailability of mount propagation on Docker Desktop with a pointer to the issue thread(https://github.com/kubernetes-sigs/kind/issues/2576).

The thing I'm confused is, is the note below still relevant? As I read your explaniation on the issue thread, setting hostPath in Docker desktop configuration would not really help. Is there something I am missing? If that explaination is misleading, maybe I should delete that note as well? 

https://github.com/kubernetes-sigs/kind/blob/80836a7ecbadcc3864ae295ff8e1a06877e81674/site/content/docs/user/configuration.md?plain=1#L287-L290