### PR TITLE
Add repo LICENSE file to base image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -79,6 +79,9 @@ COPY --chmod=0644 files/etc/sysctl.d/* /etc/sysctl.d/
 COPY --chmod=0644 files/etc/systemd/system/* /etc/systemd/system/
 COPY --chmod=0644 files/etc/systemd/system/kubelet.service.d/* /etc/systemd/system/kubelet.service.d/
 
+# copy the repo LICENSE file
+ADD https://raw.githubusercontent.com/kubernetes-sigs/kind/main/LICENSE /
+
 # Install dependencies, first from apt, then from release tarballs.
 # NOTE: we use one RUN to minimize layers.
 #


### PR DESCRIPTION
I would like to add the base repo LICENSE file to the base image.

Because the docker build env does not include the parent dir where the LICENSE file is I am using ADD to fetch from the URL.

Resulting image:

```
$ docker run -it --entrypoint sh 27ee7c05fa24
# ls
LICENSE  bin  boot  dev  etc  home  lib  lib32	lib64  libx32  media  mnt  opt	proc  root  run  sbin  srv  sys  tmp  usr  var
# cat LICENSE	
                                 Apache License
                           Version 2.0, January 2004
                        http://www.apache.org/licenses/

   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION

   1. Definitions.

      "License" shall mean the terms and conditions for use, reproduction,
      and distribution as defined by Sections 1 through 9 of this document.
...
```