### PR TITLE
clarify the impact of Delegate=true when using rootless

### DIFF
--- a/site/content/docs/user/rootless.md
+++ b/site/content/docs/user/rootless.md
@@ -22,18 +22,26 @@ running `sudo update-grub`.
 Also, depending on the host configuration, the following steps might be needed:
 
 - Create `/etc/systemd/system/user@.service.d/delegate.conf` with the following content, and then run `sudo systemctl daemon-reload`:
-```ini
-[Service]
-Delegate=yes
-```
+
+  ```ini
+  [Service]
+  Delegate=yes
+  ```
+
+  (This is not enabled by default because ["the runtime impact of
+  [delegating the "cpu" controller] is still too
+  high"](https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/ZMKLS7SHMRJLJ57NZCYPBAQ3UOYULV65/).
+  Beware that changing this configuration may affect system
+  performance.)
 
 - Create `/etc/modules-load.d/iptables.conf` with the following content:
-```
-ip6_tables
-ip6table_nat
-ip_tables
-iptable_nat
-```
+
+  ```
+  ip6_tables
+  ip6table_nat
+  ip_tables
+  iptable_nat
+  ```
 
 ## Restrictions
 


### PR DESCRIPTION
The docs tell you to enable a mysterious systemd option when using rootless, but don't tell you why. I was assuming it was a security thing but it turns out it's actually just performance-related.

(The reindentation of the code blocks is because I couldn't figure out how to make the new paragraph be aligned under the previous bullet point without also making the code block be aligned under the bullet point.)

Fixes #2800 

/cc @aojea @AkihiroSuda 