### PR TITLE
Add node build steps to Building Images section

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -260,6 +260,16 @@ Currently, kind supports one default way to build a `node-image`
 if you have the [Kubernetes][kubernetes] source in your host machine
 (`$GOPATH/src/k8s.io/kubernetes`), by using `docker`.
 
+To create a cluster from Kubernetes source:
+
+- ensure that Kubernetes is cloned in `$(go env GOPATH)/src/k8s.io/kubernetes`
+- build a node image and create a cluster with:
+
+```console
+kind build node-image
+kind create cluster --image kindest/node:latest
+```
+
 > **NOTE**: Building Kubernetes node-images requires everything building upstream
 > Kubernetes requires, we wrap the upstream build. This includes Docker with buildx.
 > See: https://git.k8s.io/community/contributors/devel/development.md#building-kubernetes-with-docker


### PR DESCRIPTION
In our quick start guide we have a Building Images section that talks
about being able to build custom images. It describes some of the
pieces, but it doesn't actually have the steps to take to actually
create the image.

There are notes in the repo README.md file that include these steps.
This adds a small amount of duplication, but this adds those steps to
the Building Images section to make it easier for folks to find out what
steps to take to build their images.