### PR TITLE
update pause to use v3.7

### DIFF
--- a/images/base/files/etc/containerd/config.toml
+++ b/images/base/files/etc/containerd/config.toml
@@ -34,7 +34,7 @@ version = 2
 
 [plugins."io.containerd.grpc.v1.cri"]
   # use fixed sandbox image
-  sandbox_image = "k8s.gcr.io/pause:3.7"
+  sandbox_image = "registry.k8s.io/pause:3.7"
   # allow hugepages controller to be missing
   # see https://github.com/containerd/cri/pull/1501
   tolerate_missing_hugepages_controller = true

--- a/images/base/files/etc/containerd/config.toml
+++ b/images/base/files/etc/containerd/config.toml
@@ -34,7 +34,7 @@ version = 2
 
 [plugins."io.containerd.grpc.v1.cri"]
   # use fixed sandbox image
-  sandbox_image = "k8s.gcr.io/pause:3.6"
+  sandbox_image = "k8s.gcr.io/pause:3.7"
   # allow hugepages controller to be missing
   # see https://github.com/containerd/cri/pull/1501
   tolerate_missing_hugepages_controller = true

--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -15,7 +15,7 @@
 # This image is a haproxy image + minimal config so the container will not exit
 # while we rewrite the config at runtime and signal haproxy to reload.
 
-ARG BASE="k8s.gcr.io/build-image/debian-base:bullseye-v1.3.0"
+ARG BASE="registry.k8s.io/build-image/debian-base:bullseye-v1.3.0"
 FROM ${BASE} as build
 
 # NOTE: copyrights.tar.gz is a quirk of Kubernetes's debian-base image

--- a/images/kindnetd/Dockerfile
+++ b/images/kindnetd/Dockerfile
@@ -24,6 +24,6 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o ./kindnetd ./cmd/kindnetd
 
 # build real kindnetd image
-FROM k8s.gcr.io/build-image/debian-iptables:bullseye-v1.4.0
+FROM registry.k8s.io/build-image/debian-iptables:bullseye-v1.4.0
 COPY --from=0 --chown=root:root ./go/src/kindnetd /bin/kindnetd
 CMD ["/bin/kindnetd"]

--- a/images/local-path-helper/Dockerfile
+++ b/images/local-path-helper/Dockerfile
@@ -15,7 +15,7 @@
 # This image is contains the binaries needed for the local-path-provisioner
 # helper pod. Currently that means: sh, rm, mkdir
 
-ARG BASE="k8s.gcr.io/build-image/debian-base:bullseye-v1.3.0"
+ARG BASE="registry.k8s.io/build-image/debian-base:bullseye-v1.3.0"
 FROM ${BASE} as build
 
 # NOTE: copyrights.tar.gz is a quirk of Kubernetes's debian-base image

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,4 +20,4 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "docker.io/kindest/base:v20220525-316e1160"
+const DefaultBaseImage = "docker.io/kindest/base:v20220623-6fae6573"

--- a/pkg/cluster/nodeutils/util_test.go
+++ b/pkg/cluster/nodeutils/util_test.go
@@ -77,7 +77,7 @@ func TestParseSnapshotter(t *testing.T) {
 		max_container_log_line_size = 16384
 		netns_mounts_under_state_dir = false
 		restrict_oom_score_adj = false
-		sandbox_image = "k8s.gcr.io/pause:3.6"
+		sandbox_image = "k8s.gcr.io/pause:3.7"
 		selinux_category_range = 1024
 		stats_collect_period = 10
 		stream_idle_timeout = "4h0m0s"

--- a/pkg/cluster/nodeutils/util_test.go
+++ b/pkg/cluster/nodeutils/util_test.go
@@ -77,7 +77,7 @@ func TestParseSnapshotter(t *testing.T) {
 		max_container_log_line_size = 16384
 		netns_mounts_under_state_dir = false
 		restrict_oom_score_adj = false
-		sandbox_image = "k8s.gcr.io/pause:3.7"
+		sandbox_image = "registry.k8s.io/pause:3.7"
 		selinux_category_range = 1024
 		stats_collect_period = 10
 		stream_idle_timeout = "4h0m0s"


### PR DESCRIPTION
BTW, should I change to use `registry.k8s.io/pause:3.7`  instead of `k8s.gcr.io/pause:3.7`?

-  https://github.com/kubernetes-sigs/kind/pull/2688
- Kubernetes migrated to registry.k8s.io since https://github.com/kubernetes/kubernetes/pull/109938.
- similarly: https://github.com/containerd/containerd/pull/7038