### PR TITLE
Add single letter flag for names

### DIFF
--- a/pkg/cmd/kind/build/nodeimage/nodeimage.go
+++ b/pkg/cmd/kind/build/nodeimage/nodeimage.go
@@ -57,26 +57,32 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(
-		&flags.BuildType, "type",
-		"docker", "build type, default is docker",
+		&flags.BuildType,
+		"type",
+		"docker",
+		"build type, default is docker",
 	)
 	cmd.Flags().StringVar(
-		&flags.Image, "image",
+		&flags.Image,
+		"image",
 		nodeimage.DefaultImage,
 		"name:tag of the resulting image to be built",
 	)
 	cmd.Flags().StringVar(
-		&flags.KubeRoot, "kube-root",
+		&flags.KubeRoot,
+		"kube-root",
 		"",
 		"DEPRECATED: please switch to just the argument. Path to the Kubernetes source directory (if empty, the path is autodetected)",
 	)
 	cmd.Flags().StringVar(
-		&flags.BaseImage, "base-image",
+		&flags.BaseImage,
+		"base-image",
 		nodeimage.DefaultBaseImage,
 		"name:tag of the base image to use for the build",
 	)
 	cmd.Flags().StringVar(
-		&flags.Arch, "arch",
+		&flags.Arch,
+		"arch",
 		"",
 		"architecture to build for, defaults to the host architecture",
 	)

--- a/pkg/cmd/kind/create/cluster/createcluster.go
+++ b/pkg/cmd/kind/create/cluster/createcluster.go
@@ -55,12 +55,43 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, streams, flags)
 		},
 	}
-	cmd.Flags().StringVar(&flags.Name, "name", "", "cluster name, overrides KIND_CLUSTER_NAME, config (default kind)")
-	cmd.Flags().StringVar(&flags.Config, "config", "", "path to a kind config file")
-	cmd.Flags().StringVar(&flags.ImageName, "image", "", "node docker image to use for booting the cluster")
-	cmd.Flags().BoolVar(&flags.Retain, "retain", false, "retain nodes for debugging when cluster creation fails")
-	cmd.Flags().DurationVar(&flags.Wait, "wait", time.Duration(0), "wait for control plane node to be ready (default 0s)")
-	cmd.Flags().StringVar(&flags.Kubeconfig, "kubeconfig", "", "sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config")
+	cmd.Flags().StringVarP(
+		&flags.Name,
+		"name",
+		"n",
+		"",
+		"cluster name, overrides KIND_CLUSTER_NAME, config (default kind)",
+	)
+	cmd.Flags().StringVar(
+		&flags.Config,
+		"config",
+		"",
+		"path to a kind config file",
+	)
+	cmd.Flags().StringVar(
+		&flags.ImageName,
+		"image",
+		"",
+		"node docker image to use for booting the cluster",
+	)
+	cmd.Flags().BoolVar(
+		&flags.Retain,
+		"retain",
+		false,
+		"retain nodes for debugging when cluster creation fails",
+	)
+	cmd.Flags().DurationVar(
+		&flags.Wait,
+		"wait",
+		time.Duration(0),
+		"wait for control plane node to be ready (default 0s)",
+	)
+	cmd.Flags().StringVar(
+		&flags.Kubeconfig,
+		"kubeconfig",
+		"",
+		"sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config",
+	)
 	return cmd
 }
 

--- a/pkg/cmd/kind/delete/cluster/deletecluster.go
+++ b/pkg/cmd/kind/delete/cluster/deletecluster.go
@@ -34,7 +34,7 @@ type flagpole struct {
 	Kubeconfig string
 }
 
-// NewCommand returns a new cobra.Command for cluster creation
+// NewCommand returns a new cobra.Command for cluster deletion
 func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	flags := &flagpole{}
 	cmd := &cobra.Command{
@@ -48,8 +48,19 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return deleteCluster(logger, flags)
 		},
 	}
-	cmd.Flags().StringVar(&flags.Name, "name", cluster.DefaultName, "the cluster name")
-	cmd.Flags().StringVar(&flags.Kubeconfig, "kubeconfig", "", "sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config")
+	cmd.Flags().StringVarP(
+		&flags.Name,
+		"name",
+		"n",
+		cluster.DefaultName,
+		"the cluster name",
+	)
+	cmd.Flags().StringVar(
+		&flags.Kubeconfig,
+		"kubeconfig",
+		"",
+		"sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config",
+	)
 	return cmd
 }
 

--- a/pkg/cmd/kind/delete/clusters/deleteclusters.go
+++ b/pkg/cmd/kind/delete/clusters/deleteclusters.go
@@ -33,7 +33,7 @@ type flagpole struct {
 	All        bool
 }
 
-// NewCommand returns a new cobra.Command for cluster creation
+// NewCommand returns a new cobra.Command for cluster deletion
 func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	flags := &flagpole{}
 	cmd := &cobra.Command{
@@ -50,8 +50,19 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return deleteClusters(logger, flags, args)
 		},
 	}
-	cmd.Flags().StringVar(&flags.Kubeconfig, "kubeconfig", "", "sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config")
-	cmd.Flags().BoolVar(&flags.All, "all", false, "delete all clusters")
+	cmd.Flags().StringVar(
+		&flags.Kubeconfig,
+		"kubeconfig",
+		"",
+		"sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config",
+	)
+	cmd.Flags().BoolVarP(
+		&flags.All,
+		"all",
+		"A",
+		false,
+		"delete all clusters",
+	)
 	return cmd
 }
 

--- a/pkg/cmd/kind/delete/delete.go
+++ b/pkg/cmd/kind/delete/delete.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/kind/pkg/log"
 )
 
-// NewCommand returns a new cobra.Command for cluster creation
+// NewCommand returns a new cobra.Command for cluster deletion
 func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Args: cobra.NoArgs,

--- a/pkg/cmd/kind/export/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kind/export/kubeconfig/kubeconfig.go
@@ -47,9 +47,10 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, flags)
 		},
 	}
-	cmd.Flags().StringVar(
+	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
+		"n",
 		cluster.DefaultName,
 		"the cluster context name",
 	)

--- a/pkg/cmd/kind/export/logs/logs.go
+++ b/pkg/cmd/kind/export/logs/logs.go
@@ -49,7 +49,13 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, streams, flags, args)
 		},
 	}
-	cmd.Flags().StringVar(&flags.Name, "name", cluster.DefaultName, "the cluster context name")
+	cmd.Flags().StringVarP(
+		&flags.Name,
+		"name",
+		"n",
+		cluster.DefaultName,
+		"the cluster context name",
+	)
 	return cmd
 }
 

--- a/pkg/cmd/kind/get/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kind/get/kubeconfig/kubeconfig.go
@@ -48,9 +48,10 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, streams, flags)
 		},
 	}
-	cmd.Flags().StringVar(
+	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
+		"n",
 		cluster.DefaultName,
 		"the cluster context name",
 	)

--- a/pkg/cmd/kind/get/nodes/nodes.go
+++ b/pkg/cmd/kind/get/nodes/nodes.go
@@ -49,9 +49,10 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, streams, flags)
 		},
 	}
-	cmd.Flags().StringVar(
+	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
+		"n",
 		cluster.DefaultName,
 		"the cluster context name",
 	)

--- a/pkg/cmd/kind/load/docker-image/docker-image.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image.go
@@ -60,9 +60,10 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, flags, args)
 		},
 	}
-	cmd.Flags().StringVar(
+	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
+		"n",
 		cluster.DefaultName,
 		"the cluster context name",
 	)

--- a/pkg/cmd/kind/load/image-archive/image-archive.go
+++ b/pkg/cmd/kind/load/image-archive/image-archive.go
@@ -57,9 +57,10 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, flags, args)
 		},
 	}
-	cmd.Flags().StringVar(
+	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
+		"n",
 		cluster.DefaultName,
 		"the cluster context name",
 	)


### PR DESCRIPTION
Adds short letter flags for names (`-n`) and all (`-A`) and follow the same pattern for flag declaration (one argument per line).

It solves: https://github.com/kubernetes-sigs/kind/issues/2592