### PR TITLE
Fix KubeletConfiguration template for k8s < 1.15

### DIFF
--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -266,7 +266,7 @@ evictionHard:
   imagefs.available: "0%"
 {{if .FeatureGates}}featureGates:
 {{ range $key := .SortedFeatureGateKeys }}
-  "{{ $key }}": {{$.FeatureGates $key }}
+  "{{ $key }}": {{index $.FeatureGates $key }}
 {{end}}{{end}}
 {{if ne .KubeProxyMode "None"}}
 ---


### PR DESCRIPTION
Fix the KubeletConfiguration template for < 1.15 w.r.t feature gates - otherwise the cluster construction fails with:
```
Creating cluster "dev.test" ...
 ✓ Ensuring node image (knode:v1.14) 🖼 
 ✓ Preparing nodes 📦  
 ✗ Writing configuration 📜 
ERROR: failed to create cluster: failed to generate kubeadm config content: error executing config template: template: kubeadm-config:105:19: executing "kubeadm-config" at <$.FeatureGates>: FeatureGates has arguments but cannot be invoked as function
make: *** [cluster] Error 1
```