### PR TITLE
Add field tags for JSON (un)marshalling

### DIFF
--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -18,33 +18,33 @@ package v1alpha4
 
 // Cluster contains kind cluster configuration
 type Cluster struct {
-	TypeMeta `yaml:",inline"`
+	TypeMeta `yaml:",inline" json:",inline"`
 
 	// The cluster name.
 	// Optional, this will be overridden by --name / KIND_CLUSTER_NAME
-	Name string `yaml:"name,omitempty"`
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 
 	// Nodes contains the list of nodes defined in the `kind` Cluster
 	// If unset this will default to a single control-plane node
 	// Note that if more than one control plane is specified, an external
 	// control plane load balancer will be provisioned implicitly
-	Nodes []Node `yaml:"nodes,omitempty"`
+	Nodes []Node `yaml:"nodes,omitempty" json:"nodes,omitempty"`
 
 	/* Advanced fields */
 
 	// Networking contains cluster wide network settings
-	Networking Networking `yaml:"networking,omitempty"`
+	Networking Networking `yaml:"networking,omitempty" json:"networking,omitempty"`
 
 	// FeatureGates contains a map of Kubernetes feature gates to whether they
 	// are enabled. The feature gates specified here are passed to all Kubernetes components as flags or in config.
 	//
 	// https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
-	FeatureGates map[string]bool `yaml:"featureGates,omitempty"`
+	FeatureGates map[string]bool `yaml:"featureGates,omitempty" json:"featureGates,omitempty"`
 
 	// RuntimeConfig Keys and values are translated into --runtime-config values for kube-apiserver, separated by commas.
 	//
 	// Use this to enable alpha APIs.
-	RuntimeConfig map[string]string `yaml:"runtimeConfig,omitempty"`
+	RuntimeConfig map[string]string `yaml:"runtimeConfig,omitempty" json:"runtimeConfig,omitempty"`
 
 	// KubeadmConfigPatches are applied to the generated kubeadm config as
 	// merge patches. The `kind` field must match the target object, and
@@ -55,7 +55,7 @@ type Cluster struct {
 	// https://tools.ietf.org/html/rfc7386
 	//
 	// The cluster-level patches are applied before the node-level patches.
-	KubeadmConfigPatches []string `yaml:"kubeadmConfigPatches,omitempty"`
+	KubeadmConfigPatches []string `yaml:"kubeadmConfigPatches,omitempty" json:"kubeadmConfigPatches,omitempty"`
 
 	// KubeadmConfigPatchesJSON6902 are applied to the generated kubeadm config
 	// as JSON 6902 patches. The `kind` field must match the target object, and
@@ -70,24 +70,24 @@ type Cluster struct {
 	// https://tools.ietf.org/html/rfc6902
 	//
 	// The cluster-level patches are applied before the node-level patches.
-	KubeadmConfigPatchesJSON6902 []PatchJSON6902 `yaml:"kubeadmConfigPatchesJSON6902,omitempty"`
+	KubeadmConfigPatchesJSON6902 []PatchJSON6902 `yaml:"kubeadmConfigPatchesJSON6902,omitempty" json:"kubeadmConfigPatchesJSON6902,omitempty"`
 
 	// ContainerdConfigPatches are applied to every node's containerd config
 	// in the order listed.
 	// These should be toml stringsto be applied as merge patches
-	ContainerdConfigPatches []string `yaml:"containerdConfigPatches,omitempty"`
+	ContainerdConfigPatches []string `yaml:"containerdConfigPatches,omitempty" json:"containerdConfigPatches,omitempty"`
 
 	// ContainerdConfigPatchesJSON6902 are applied to every node's containerd config
 	// in the order listed.
 	// These should be YAML or JSON formatting RFC 6902 JSON patches
-	ContainerdConfigPatchesJSON6902 []string `yaml:"containerdConfigPatchesJSON6902,omitempty"`
+	ContainerdConfigPatchesJSON6902 []string `yaml:"containerdConfigPatchesJSON6902,omitempty" json:"containerdConfigPatchesJSON6902,omitempty"`
 }
 
 // TypeMeta partially copies apimachinery/pkg/apis/meta/v1.TypeMeta
 // No need for a direct dependence; the fields are stable.
 type TypeMeta struct {
-	Kind       string `json:"kind,omitempty" yaml:"kind,omitempty"`
-	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Kind       string `yaml:"kind,omitempty" json:"kind,omitempty"`
+	APIVersion string `yaml:"apiVersion,omitempty" json:"apiVersion,omitempty"`
 }
 
 // Node contains settings for a node in the `kind` Cluster.
@@ -98,25 +98,25 @@ type Node struct {
 	// created by kind
 	//
 	// Defaults to "control-plane"
-	Role NodeRole `yaml:"role,omitempty"`
+	Role NodeRole `yaml:"role,omitempty" json:"role,omitempty"`
 
 	// Image is the node image to use when creating this node
 	// If unset a default image will be used, see defaults.Image
-	Image string `yaml:"image,omitempty"`
+	Image string `yaml:"image,omitempty" json:"image,omitempty"`
 
 	// Labels are the labels with which the respective node will be labeled
-	Labels map[string]string `yaml:"labels,omitempty"`
+	Labels map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
 
 	/* Advanced fields */
 
 	// TODO: cri-like types should be inline instead
 	// ExtraMounts describes additional mount points for the node container
 	// These may be used to bind a hostPath
-	ExtraMounts []Mount `yaml:"extraMounts,omitempty"`
+	ExtraMounts []Mount `yaml:"extraMounts,omitempty" json:"extraMounts,omitempty"`
 
 	// ExtraPortMappings describes additional port mappings for the node container
 	// binded to a host Port
-	ExtraPortMappings []PortMapping `yaml:"extraPortMappings,omitempty"`
+	ExtraPortMappings []PortMapping `yaml:"extraPortMappings,omitempty" json:"extraPortMappings,omitempty"`
 
 	// KubeadmConfigPatches are applied to the generated kubeadm config as
 	// merge patches. The `kind` field must match the target object, and
@@ -128,7 +128,7 @@ type Node struct {
 	//
 	// The node-level patches will be applied after the cluster-level patches
 	// have been applied. (See Cluster.KubeadmConfigPatches)
-	KubeadmConfigPatches []string `yaml:"kubeadmConfigPatches,omitempty"`
+	KubeadmConfigPatches []string `yaml:"kubeadmConfigPatches,omitempty" json:"kubeadmConfigPatches,omitempty"`
 
 	// KubeadmConfigPatchesJSON6902 are applied to the generated kubeadm config
 	// as JSON 6902 patches. The `kind` field must match the target object, and
@@ -144,7 +144,7 @@ type Node struct {
 	//
 	// The node-level patches will be applied after the cluster-level patches
 	// have been applied. (See Cluster.KubeadmConfigPatchesJSON6902)
-	KubeadmConfigPatchesJSON6902 []PatchJSON6902 `yaml:"kubeadmConfigPatchesJSON6902,omitempty"`
+	KubeadmConfigPatchesJSON6902 []PatchJSON6902 `yaml:"kubeadmConfigPatchesJSON6902,omitempty" json:"kubeadmConfigPatchesJSON6902,omitempty"`
 }
 
 // NodeRole defines possible role for nodes in a Kubernetes cluster managed by `kind`
@@ -163,7 +163,7 @@ const (
 // Networking contains cluster wide network settings
 type Networking struct {
 	// IPFamily is the network cluster model, currently it can be ipv4 or ipv6
-	IPFamily ClusterIPFamily `yaml:"ipFamily,omitempty"`
+	IPFamily ClusterIPFamily `yaml:"ipFamily,omitempty" json:"ipFamily,omitempty"`
 	// APIServerPort is the listen port on the host for the Kubernetes API Server
 	// Defaults to a random port on the host obtained by kind
 	//
@@ -171,24 +171,24 @@ type Networking struct {
 	// (docker, podman...) will be left to pick the port instead.
 	// This is potentially useful for remote hosts, BUT it means when the container
 	// is restarted it will be randomized. Leave this unset to allow kind to pick it.
-	APIServerPort int32 `yaml:"apiServerPort,omitempty"`
+	APIServerPort int32 `yaml:"apiServerPort,omitempty" json:"apiServerPort,omitempty"`
 	// APIServerAddress is the listen address on the host for the Kubernetes
 	// API Server. This should be an IP address.
 	//
 	// Defaults to 127.0.0.1
-	APIServerAddress string `yaml:"apiServerAddress,omitempty"`
+	APIServerAddress string `yaml:"apiServerAddress,omitempty" json:"apiServerAddress,omitempty"`
 	// PodSubnet is the CIDR used for pod IPs
 	// kind will select a default if unspecified
-	PodSubnet string `yaml:"podSubnet,omitempty"`
+	PodSubnet string `yaml:"podSubnet,omitempty" json:"podSubnet,omitempty"`
 	// ServiceSubnet is the CIDR used for services VIPs
 	// kind will select a default if unspecified for IPv6
-	ServiceSubnet string `yaml:"serviceSubnet,omitempty"`
+	ServiceSubnet string `yaml:"serviceSubnet,omitempty" json:"serviceSubnet,omitempty"`
 	// If DisableDefaultCNI is true, kind will not install the default CNI setup.
 	// Instead the user should install their own CNI after creating the cluster.
-	DisableDefaultCNI bool `yaml:"disableDefaultCNI,omitempty"`
+	DisableDefaultCNI bool `yaml:"disableDefaultCNI,omitempty" json:"disableDefaultCNI,omitempty"`
 	// KubeProxyMode defines if kube-proxy should operate in iptables or ipvs mode
 	// Defaults to 'iptables' mode
-	KubeProxyMode ProxyMode `yaml:"kubeProxyMode,omitempty"`
+	KubeProxyMode ProxyMode `yaml:"kubeProxyMode,omitempty" json:"kubeProxyMode,omitempty"`
 }
 
 // ClusterIPFamily defines cluster network IP family
@@ -217,11 +217,11 @@ const (
 // https://tools.ietf.org/html/rfc6902
 type PatchJSON6902 struct {
 	// these fields specify the patch target resource
-	Group   string `yaml:"group"`
-	Version string `yaml:"version"`
-	Kind    string `yaml:"kind"`
+	Group   string `yaml:"group" json:"group"`
+	Version string `yaml:"version" json:"version"`
+	Kind    string `yaml:"kind" json:"kind"`
 	// Patch should contain the contents of the json patch as a string
-	Patch string `yaml:"patch"`
+	Patch string `yaml:"patch" json:"patch"`
 }
 
 /*
@@ -244,17 +244,17 @@ https://github.com/kubernetes/kubernetes/blob/063e7ff358fdc8b0916e6f39beedc0d025
 // Propagation may be one of: None, HostToContainer, Bidirectional
 type Mount struct {
 	// Path of the mount within the container.
-	ContainerPath string `yaml:"containerPath,omitempty"`
+	ContainerPath string `yaml:"containerPath,omitempty" json:"containerPath,omitempty"`
 	// Path of the mount on the host. If the hostPath doesn't exist, then runtimes
 	// should report error. If the hostpath is a symbolic link, runtimes should
 	// follow the symlink and mount the real destination to container.
-	HostPath string `yaml:"hostPath,omitempty"`
+	HostPath string `yaml:"hostPath,omitempty" json:"hostPath,omitempty"`
 	// If set, the mount is read-only.
-	Readonly bool `yaml:"readOnly,omitempty"`
+	Readonly bool `yaml:"readOnly,omitempty" json:"readOnly,omitempty"`
 	// If set, the mount needs SELinux relabeling.
-	SelinuxRelabel bool `yaml:"selinuxRelabel,omitempty"`
+	SelinuxRelabel bool `yaml:"selinuxRelabel,omitempty" json:"selinuxRelabel,omitempty"`
 	// Requested propagation mode.
-	Propagation MountPropagation `yaml:"propagation,omitempty"`
+	Propagation MountPropagation `yaml:"propagation,omitempty" json:"propagation,omitempty"`
 }
 
 // PortMapping specifies a host port mapped into a container port.
@@ -265,7 +265,7 @@ type Mount struct {
 //  protocol: TCP
 type PortMapping struct {
 	// Port within the container.
-	ContainerPort int32 `yaml:"containerPort,omitempty"`
+	ContainerPort int32 `yaml:"containerPort,omitempty" json:"containerPort,omitempty"`
 	// Port on the host.
 	//
 	// If unset, a random port will be selected.
@@ -274,11 +274,11 @@ type PortMapping struct {
 	// (docker, podman...) will be left to pick the port instead.
 	// This is potentially useful for remote hosts, BUT it means when the container
 	// is restarted it will be randomized. Leave this unset to allow kind to pick it.
-	HostPort int32 `yaml:"hostPort,omitempty"`
+	HostPort int32 `yaml:"hostPort,omitempty" json:"hostPort,omitempty"`
 	// TODO: add protocol (tcp/udp) and port-ranges
-	ListenAddress string `yaml:"listenAddress,omitempty"`
+	ListenAddress string `yaml:"listenAddress,omitempty" json:"listenAddress,omitempty"`
 	// Protocol (TCP/UDP/SCTP)
-	Protocol PortMappingProtocol `yaml:"protocol,omitempty"`
+	Protocol PortMappingProtocol `yaml:"protocol,omitempty" json:"protocol,omitempty"`
 }
 
 // MountPropagation represents an "enum" for mount propagation options,


### PR DESCRIPTION
This makes the API types reusable across the k8s ecosystem. I've been working on cluster-api provider for kind and wanted to reuse as much configuration as possible in the CRD. if this pr is merged I could directly reference the kind upstream types, instead of introducing my own, converting them back and forth and making sure the contract is still the same.


Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>