### PR TITLE
enable progress notification from etcd for all k8s e2e tests

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -168,6 +168,10 @@ ${controllerManager_extra_args}
   scheduler:
     extraArgs:
 ${scheduler_extra_args}
+   etcd:
+     local:
+       extraArgs:
+         experimental-watch-progress-notify-interval: "5s"
   ---
   kind: InitConfiguration
   nodeRegistration:


### PR DESCRIPTION
the experimental-watch-progress-notify-interval flag specifies an interval
at which etcd sends data to the kube-api server.

It is used by the WatchBookmark feature which is GA since 1.17.
In addition to that, it will be used by a new WatchList feature which is Alpha since 1.25

Enables support for watch bookmark events.

xref: https://github.com/kubernetes/enhancements/issues/3157
xref: https://github.com/kubernetes/enhancements/pull/3142