### PR TITLE
Base image to ubuntu 22.04

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -19,7 +19,7 @@
 
 # start from ubuntu, this image is reasonably small as a starting point
 # for a kubernetes node image, it doesn't contain much we don't need
-ARG BASE_IMAGE=ubuntu:21.10
+ARG BASE_IMAGE=ubuntu:22.04
 FROM $BASE_IMAGE as build
 
 # `docker buildx` automatically sets this arg value

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -20,4 +20,4 @@ package nodeimage
 const DefaultImage = "kindest/node:latest"
 
 // DefaultBaseImage is the default base image used
-const DefaultBaseImage = "docker.io/kindest/base:v20220623-3a47e971"
+const DefaultBaseImage = "docker.io/kindest/base:v20220724-323cba64"


### PR DESCRIPTION
The current ubuntu version used by the base image (21.10) reached End of Life on July 14, 2022 ([announcement](https://lists.ubuntu.com/archives/ubuntu-announce/2022-May/000280.html))

Fixes: #2837