### PR TITLE
CI: bump up macos-10.15 to macos-12

### DIFF
--- a/.github/workflows/cgroup2.yaml
+++ b/.github/workflows/cgroup2.yaml
@@ -12,7 +12,7 @@ jobs:
   docker:
     name: Cgroup v2
     # nested virtualization is only available on macOS hosts
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
GHA will stop supporting macos-10.15 on Aug 30, 2022
- https://github.com/actions/virtual-environments/issues/5583