### PR TITLE
image-archive: enable loading multiple image archives

### DIFF
--- a/pkg/cmd/kind/load/image-archive/image-archive.go
+++ b/pkg/cmd/kind/load/image-archive/image-archive.go
@@ -49,6 +49,11 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			}
 			return nil
 		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 1 {
+				logger.Warn("It is suggested that you save multiple images into a common archive and load that instead of loading multiple archives for better performance")
+			}
+		},
 		Use:   "image-archive <IMAGE.tar>",
 		Short: "Loads docker image from archive into nodes",
 		Long:  "Loads docker image from archive into all or specified nodes by name",
@@ -78,19 +83,28 @@ func runE(logger log.Logger, flags *flagpole, args []string) error {
 		runtime.GetDefault(logger),
 	)
 
-	// Check if file exists
-	imageTarPath := args[0]
-	if _, err := os.Stat(imageTarPath); err != nil {
-		return err
+	for _, imageTarPath := range args {
+		if _, err := os.Stat(imageTarPath); err != nil {
+			return err
+		}
 	}
 
+	for _, imageTarPath := range args {
+		if err := loadArchiveToNodes(logger, provider, flags.Name, flags.Nodes, imageTarPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func loadArchiveToNodes(logger log.Logger, provider *cluster.Provider, clusterName string, nodeNames []string, imageArchivePath string) error {
 	// Check if the cluster nodes exist
-	nodeList, err := provider.ListInternalNodes(flags.Name)
+	nodeList, err := provider.ListInternalNodes(clusterName)
 	if err != nil {
 		return err
 	}
 	if len(nodeList) == 0 {
-		return fmt.Errorf("no nodes found for cluster %q", flags.Name)
+		return fmt.Errorf("no nodes found for cluster %q", clusterName)
 	}
 
 	// map cluster nodes by their name
@@ -104,9 +118,9 @@ func runE(logger log.Logger, flags *flagpole, args []string) error {
 	// pick only the user selected nodes and ensure they exist
 	// the default is all nodes unless flags.Nodes is set
 	selectedNodes := nodeList
-	if len(flags.Nodes) > 0 {
+	if len(nodeNames) > 0 {
 		selectedNodes = []nodes.Node{}
-		for _, name := range flags.Nodes {
+		for _, name := range nodeNames {
 			node, ok := nodesByName[name]
 			if !ok {
 				return fmt.Errorf("unknown node: %s", name)
@@ -120,18 +134,19 @@ func runE(logger log.Logger, flags *flagpole, args []string) error {
 	for _, selectedNode := range selectedNodes {
 		selectedNode := selectedNode // capture loop variable
 		fns = append(fns, func() error {
-			return loadImage(imageTarPath, selectedNode)
+			return loadImage(logger, imageArchivePath, selectedNode)
 		})
 	}
 	return errors.UntilErrorConcurrent(fns)
 }
 
 // loads an image tarball onto a node
-func loadImage(imageTarName string, node nodes.Node) error {
+func loadImage(logger log.Logger, imageTarName string, node nodes.Node) error {
 	f, err := os.Open(imageTarName)
 	if err != nil {
 		return errors.Wrap(err, "failed to open image")
 	}
 	defer f.Close()
+	logger.V(2).Infof("Loading Docker Image from archive %s to node %s", imageTarName, node.String())
 	return nodeutils.LoadImageArchive(node, f)
 }


### PR DESCRIPTION
Current command implementation of the `kind load image-archive` expects that only one tar can be loaded at a time. Though the command handler checks to see a minimum of one file is passed as argument to the command while invocation, it doesn't enforce the maximum number of files that can be passed to the command. 

However, the implementation picks the `args[0]` and ignores the rest without any error or warning. This can lead to a bit of confusion. It is useful to be able to load multiple image archives in one go anyway.

This PR enables the ability to load images from more than one archive at one go while honouring the original behavior.

Closes #2881 

```bash
❯ docker exec -it test-control-plane bash
root@test-control-plane:/# crictl images | grep alpine
root@test-control-plane:/#
exit

❯ docker save alpine:3.12 > archive1.tar

❯ docker save alpine:3.13 > archive2.tar

❯ bin/kind load image-archive archive1.tar archive2.tar --name test

❯ docker exec -it test-control-plane bash
root@test-control-plane:/# crictl images | grep alpine
docker.io/library/alpine                   3.12                                      24c8ece58a1aa       5.87MB
docker.io/library/alpine                   3.13                                      6b5c5e00213a4       5.91MB
root@test-control-plane:/#
exit

❯ bin/kind -v=3 load image-archive archive1.tar archive2.tar --name test
DEBUG: image-archive/image-archive.go:142] Loading Docker Image from archive archive1.tar to node test-control-plane
DEBUG: image-archive/image-archive.go:142] Loading Docker Image from archive archive2.tar to node test-control-plane
```