### PR TITLE
doc: refactor copy to clipboard button

### DIFF
--- a/site/assets/css/inline.css
+++ b/site/assets/css/inline.css
@@ -286,8 +286,8 @@ table.includecode thead th {
 }
 
 table.includecode thead th button {
-  background: #326be5;
-  border: .25em solid white;
+  background: transparent;
+  border: 0;
   color: white;
   font-weight: bold;
   margin: .25em;

--- a/site/assets/css/inline.css
+++ b/site/assets/css/inline.css
@@ -288,7 +288,6 @@ table.includecode thead th {
 table.includecode thead th button {
   background: transparent;
   border: 0;
-  color: white;
   font-weight: bold;
   margin: .25em;
   cursor: pointer;

--- a/site/assets/css/inline.css
+++ b/site/assets/css/inline.css
@@ -261,37 +261,33 @@ table.includecode {
   max-width: 100%;
   width: 100%;
   table-layout: fixed;
-  background: #f3f4f4;
-  border: .15em solid black;
+  border: 1px solid rgba(0,0,0,.125);
   border-spacing: 0;
 }
 
-table.includecode thead {
-  background: #333;
-  color: white;
-}
-
-table.includecode thead th a {
-  color: white;
-}
-
 table.includecode thead th {
-  border-bottom: .1em solid black;
+  border-bottom: 1px solid rgba(0,0,0,.125);
   font-weight: normal;
-  font-size: .9em;
+  font-size: 85%;
 }
 
 table.includecode thead th {
   text-align: right;
 }
 
+table.includecode thead th a {
+  font-family: monospace;
+}
+
 table.includecode thead th button {
+  vertical-align: middle;
   background: transparent;
   border: 0;
-  font-weight: bold;
-  margin: .25em;
   cursor: pointer;
-  padding: .1em .5em;
+}
+
+table.includecode tbody {
+  background: #f3f4f4;
 }
 
 table.includecode pre {

--- a/site/layouts/shortcodes/codeFromFile.html
+++ b/site/layouts/shortcodes/codeFromFile.html
@@ -9,8 +9,12 @@
 <table class="includecode" id="code-{{ $virtualPath }}">
   <thead>
     <tr>
-      <th><a href="/{{ $virtualPath }}">{{ $virtualPath }}</a> <button
-          onclick='copyText("code-{{ $virtualPath }}-hidden-copy-text");'>COPY</button></th>
+      <th>
+        <a href="/{{ $virtualPath }}">{{ $virtualPath }}</a>
+        <button onclick='copyText("code-{{ $virtualPath }}-hidden-copy-text");' title="Copy to clipboard">
+          COPY
+        </button>
+      </th>
     </tr>
   </thead>
   <tbody>

--- a/site/layouts/shortcodes/codeFromFile.html
+++ b/site/layouts/shortcodes/codeFromFile.html
@@ -12,7 +12,7 @@
       <th>
         <a href="/{{ $virtualPath }}">{{ $virtualPath }}</a>
         <button onclick='copyText("code-{{ $virtualPath }}-hidden-copy-text");' title="Copy to clipboard">
-          COPY
+          📋
         </button>
       </th>
     </tr>

--- a/site/layouts/shortcodes/codeFromFile.html
+++ b/site/layouts/shortcodes/codeFromFile.html
@@ -12,7 +12,7 @@
       <th>
         <a href="/{{ $virtualPath }}">{{ $virtualPath }}</a>
         <button onclick='copyText("code-{{ $virtualPath }}-hidden-copy-text");' title="Copy to clipboard">
-          📋
+          <img src="{{ "copycode.svg" | relURL }}" alt="Copy">
         </button>
       </th>
     </tr>

--- a/site/layouts/shortcodes/codeFromInline.html
+++ b/site/layouts/shortcodes/codeFromInline.html
@@ -5,8 +5,11 @@
 <table class="includecode" id="inline-code-{{ $hash }}">
   <thead>
   <tr>
-    <th> <button
-        onclick='copyText("inline-code-{{ $hash }}-hidden-copy-text");'>COPY</button></th>
+    <th>
+      <button onclick='copyText("inline-code-{{ $hash }}-hidden-copy-text");' title="Copy to clipboard">
+        COPY
+      </button>
+    </th>
   </tr>
   </thead>
   <tbody>

--- a/site/layouts/shortcodes/codeFromInline.html
+++ b/site/layouts/shortcodes/codeFromInline.html
@@ -7,7 +7,7 @@
   <tr>
     <th>
       <button onclick='copyText("inline-code-{{ $hash }}-hidden-copy-text");' title="Copy to clipboard">
-        📋
+        <img src="{{ "copycode.svg" | relURL }}" alt="Copy">
       </button>
     </th>
   </tr>

--- a/site/layouts/shortcodes/codeFromInline.html
+++ b/site/layouts/shortcodes/codeFromInline.html
@@ -7,7 +7,7 @@
   <tr>
     <th>
       <button onclick='copyText("inline-code-{{ $hash }}-hidden-copy-text");' title="Copy to clipboard">
-        COPY
+        📋
       </button>
     </th>
   </tr>

--- a/site/static/copycode.svg
+++ b/site/static/copycode.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#184eb1">
+<path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+</svg>

--- a/site/static/copycode.svg
+++ b/site/static/copycode.svg
@@ -1,3 +1,10 @@
+<!--
+copycode.svg by The Kubernetes Authors is licensed under CC BY 4.0
+
+[copycode.svg]: https://github.com/kubernetes/website/blob/0088ea5da01fd82995122bcd2a4e26be8bbfe005/static/images/copycode.svg
+[The Kubernetes Authors]: https://github.com/kubernetes
+[CC BY 4.0]: https://github.com/kubernetes/website/blob/0088ea5da01fd82995122bcd2a4e26be8bbfe005/LICENSE
+-->
 <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#184eb1">
 <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
 </svg>

--- a/site/static/copycode.svg
+++ b/site/static/copycode.svg
@@ -1,10 +1,3 @@
-<!--
-copycode.svg by The Kubernetes Authors is licensed under CC BY 4.0
-
-[copycode.svg]: https://github.com/kubernetes/website/blob/0088ea5da01fd82995122bcd2a4e26be8bbfe005/static/images/copycode.svg
-[The Kubernetes Authors]: https://github.com/kubernetes
-[CC BY 4.0]: https://github.com/kubernetes/website/blob/0088ea5da01fd82995122bcd2a4e26be8bbfe005/LICENSE
--->
 <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#184eb1">
 <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
 </svg>


### PR DESCRIPTION
The background colour on the Copy to clipboard button is driving me nuts! :laughing: 

I constantly think I have marked the COPY buttons, but when I check, I haven't.

The background colour is so similar to the background colour for marked text, that I think it triggers my brain's habit and makes me believe they are marked:
![image](https://user-images.githubusercontent.com/13132188/186411412-e688c438-f7ca-4980-99da-19ad99d3376a.png)

I'm suggesting to change the background colour to something else than that important colour, and while I was at it I experimented with using emojis as well, the kind project seems fond of emojis :smile: 
![image](https://user-images.githubusercontent.com/13132188/186412207-c92eb83c-9c40-447e-bedf-1b5e55f7b9db.png)

What do you think?