### PR TITLE
docs: update kind example config to use v1beta3

### DIFF
--- a/site/content/docs/user/kind-example-config.yaml
+++ b/site/content/docs/user/kind-example-config.yaml
@@ -12,7 +12,7 @@ kubeadmConfigPatches:
 # patch it further using a JSON 6902 patch
 kubeadmConfigPatchesJSON6902:
 - group: kubeadm.k8s.io
-  version: v1beta2
+  version: v1beta3
   kind: ClusterConfiguration
   patch: |
     - op: add


### PR DESCRIPTION
From upgrading to a new version of kind I had to update my config to use v1beta3. I've updated the example config YAML to use this.

I also noticed quite a few places in code using v1beta2. Not sure if these need updating too? Although I wasn't comfortable doing that!