### PR TITLE
support not setting GITHUB_OAUTH_TOKEN

### DIFF
--- a/hack/release/get-contributors.sh
+++ b/hack/release/get-contributors.sh
@@ -32,7 +32,7 @@ for contributor in "${contributors[@]}"; do
     # lookup the  commit info to get the login
     contributor_logins+=("$(curl \
         -sG \
-        -H "Authorization: token ${GITHUB_OAUTH_TOKEN:?}" \
+        ${GITHUB_OAUTH_TOKEN:+-H="Authorization: token ${GITHUB_OAUTH_TOKEN:?}"} \
         --data-urlencode "q=${contributor}" \
         "https://api.github.com/repos/${ORG}/${REPO}/commits/${commit_for_contributor}" \
     | jq -r .author.login


### PR DESCRIPTION
note: the unauthenticated rate limit is a low per-ip limit IIRC
but it may be OK for small releases