### PR TITLE
increase node ready check timeout to 600 seconds

### DIFF
--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -401,7 +401,7 @@ func createContainerWithWaitUntilSystemdReachesMultiUserSystem(name string, args
 		return err
 	}
 
-	logCtx, logCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	logCtx, logCancel := context.WithTimeout(context.Background(), 600*time.Second)
 	logCmd := exec.CommandContext(logCtx, "docker", "logs", "-f", name)
 	defer logCancel()
 	return common.WaitUntilLogRegexpMatches(logCtx, logCmd, common.NodeReachedCgroupsReadyRegexp())


### PR DESCRIPTION
Hi,

When trying to run ```kind create cluster``` on Windows with WSL2 based Docker, it will timeout earlier before the node is ready.

This MR will increase the node ready timeout to 600 seconds, so that ```kind``` could wait enough time for the docker container to print the logs.
