### PR TITLE
misc: adding String() to KinD provider interface

### DIFF
--- a/pkg/cluster/internal/create/actions/config/config.go
+++ b/pkg/cluster/internal/create/actions/config/config.go
@@ -66,7 +66,7 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 	// create kubeadm init config
 	fns := []func() error{}
 
-	provider := fmt.Sprintf("%s", ctx.Provider)
+	provider := ctx.Provider.String()
 	configData := kubeadm.ConfigData{
 		NodeProvider:         provider,
 		ClusterName:          ctx.Config.Name,

--- a/pkg/cluster/internal/providers/provider.go
+++ b/pkg/cluster/internal/providers/provider.go
@@ -47,6 +47,8 @@ type Provider interface {
 	CollectLogs(dir string, nodes []nodes.Node) error
 	// Info returns the provider info
 	Info() (*ProviderInfo, error)
+	// String implements fmt.Stringer, it is used as the --provider-id flag in kubeadmin config
+	String() string
 }
 
 // ProviderInfo is the info of the provider


### PR DESCRIPTION
Providers should be required to implement the fmt.Stringer String() API since the provider string representation is used by the --provider-id in the kubeadmin config.

See: https://github.com/kubernetes-sigs/kind/blob/main/pkg/cluster/internal/create/actions/config/config.go#L71

Otherwise, new providers will see the kubeadm config generated with the full struct representation
of the provider which can be an invalid yaml

Signed-off-by: Yibo Zhuang <yibzhuang@gmail.com>