### PR TITLE
kindnetd remove wrong routes

### DIFF
--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -20,7 +20,7 @@ package nodeimage
 The default CNI manifest and images are our own tiny kindnet
 */
 
-const kindnetdImage = "docker.io/kindest/kindnetd:v20220726-ed811e41"
+const kindnetdImage = "docker.io/kindest/kindnetd:v20220927-ce36d7c0"
 
 var defaultCNIImages = []string{kindnetdImage}
 


### PR DESCRIPTION
This adds logic to kindnetd to remove routes which do not match the expected gateway address for an (Pod)CIDR.

I'm currently working at
- https://github.com/kubernetes-sigs/cluster-api/issues/3728

Cluster API uses kindnetd as CNI for lots of e2e tests.

As of today, kindnetd only adds new routes and does never delete orphaned routes.

This could lead to the following situation in the workload Cluster created by Cluster API when kindnetd is used as CNI:
* a new Node joins the cluster which:
  * re-uses a PodCIDR of a deleted node
  * but has a different internal IP address compared to the deleted node
* All nodes which already had the route via the old node won't get the new route and pod to pod communication is broken

Broken pod to pod communication may include kube-apiserver to webhook communication, which is the case I detected during my tests.