### PR TITLE
kindnetd fix removal of wrong routes

### DIFF
--- a/images/kindnetd/cmd/kindnetd/routes.go
+++ b/images/kindnetd/cmd/kindnetd/routes.go
@@ -46,7 +46,7 @@ func syncRoute(nodeIP string, podCIDRs []string) error {
 		// Check if the wanted route exists and delete wrong routes
 		found := false
 		for _, route := range routes {
-			if routeToDst.Gw.Equal(ip) {
+			if route.Gw.Equal(ip) {
 				found = true
 				continue
 			}

--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -20,7 +20,7 @@ package nodeimage
 The default CNI manifest and images are our own tiny kindnet
 */
 
-const kindnetdImage = "docker.io/kindest/kindnetd:v20220927-ce36d7c0"
+const kindnetdImage = "docker.io/kindest/kindnetd:v20221004-44d545d1"
 
 var defaultCNIImages = []string{kindnetdImage}
 


### PR DESCRIPTION
Hi, I'm sorry to disturb again on this topic, but I introduced a small bug in #2941 .

This PR is supposed to fix that.

The current implementation does not compare the node IP with the existing route, but instead with the wanted route which always results in true and never in removal of an orphaned ip route.

cc @BenTheElder @aojea 