### PR TITLE
Fix load docker-image re-tagging with prefix

### DIFF
--- a/pkg/cmd/kind/load/docker-image/docker-image.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image.go
@@ -136,7 +136,7 @@ func runE(logger log.Logger, flags *flagpole, args []string) error {
 		imageID := imageIDs[i]
 		processed := false
 		for _, node := range candidateNodes {
-			exists, reTagRequired := checkIfImageReTagRequired(node, imageID, imageName, nodeutils.ImageTags)
+			exists, reTagRequired, imageName := checkIfImageReTagRequired(node, imageID, imageName, nodeutils.ImageTags)
 			if exists && !reTagRequired {
 				continue
 			}
@@ -241,15 +241,15 @@ func removeDuplicates(slice []string) []string {
 }
 
 // checkIfImageExists makes sure we only perform the reverse lookup of the ImageID to tag map
-func checkIfImageReTagRequired(node nodes.Node, imageID, imageName string, tagFetcher imageTagFetcher) (exists, reTagRequired bool) {
+func checkIfImageReTagRequired(node nodes.Node, imageID, imageName string, tagFetcher imageTagFetcher) (exists, reTagRequired bool, sanitizedImage string) {
 	tags, err := tagFetcher(node, imageID)
 	if len(tags) == 0 || err != nil {
 		exists = false
 		return
 	}
 	exists = true
-	imageName = sanitizeImage(imageName)
-	if ok := tags[imageName]; ok {
+	sanitizedImage = sanitizeImage(imageName)
+	if ok := tags[sanitizedImage]; ok {
 		reTagRequired = false
 		return
 	}

--- a/pkg/cmd/kind/load/docker-image/docker-image_test.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image_test.go
@@ -112,9 +112,10 @@ func Test_checkIfImageReTagRequired(t *testing.T) {
 			tags map[string]bool
 			err  error
 		}
-		imageID      string
-		imageName    string
-		returnValues []bool
+		imageID        string
+		imageName      string
+		returnValues   []bool
+		sanitizedImage string
 	}{
 		{
 			name: "image is already present",
@@ -128,9 +129,10 @@ func Test_checkIfImageReTagRequired(t *testing.T) {
 				},
 				nil,
 			},
-			imageID:      "sha256:fd3fd9ab134a864eeb7b2c073c0d90192546f597c60416b81fc4166cca47f29a",
-			imageName:    "k8s.io/image1:tag1",
-			returnValues: []bool{true, false},
+			imageID:        "sha256:fd3fd9ab134a864eeb7b2c073c0d90192546f597c60416b81fc4166cca47f29a",
+			imageName:      "k8s.io/image1:tag1",
+			returnValues:   []bool{true, false},
+			sanitizedImage: "k8s.io/image1:tag1",
 		},
 		{
 			name: "re-tag is required",
@@ -144,9 +146,26 @@ func Test_checkIfImageReTagRequired(t *testing.T) {
 				},
 				nil,
 			},
-			imageID:      "sha256:fd3fd9ab134a864eeb7b2c073c0d90192546f597c60416b81fc4166cca47f29a",
-			imageName:    "k8s.io/image1:tag2",
-			returnValues: []bool{true, true},
+			imageID:        "sha256:fd3fd9ab134a864eeb7b2c073c0d90192546f597c60416b81fc4166cca47f29a",
+			imageName:      "k8s.io/image1:tag2",
+			returnValues:   []bool{true, true},
+			sanitizedImage: "k8s.io/image1:tag2",
+		},
+		{
+			name: "re-tag is required with docker.io prefix",
+			imageTags: struct {
+				tags map[string]bool
+				err  error
+			}{
+				map[string]bool{
+					"docker.io/foo/image1:tag1": true,
+				},
+				nil,
+			},
+			imageID:        "sha256:fd3fd9ab134a864eeb7b2c073c0d90192546f597c60416b81fc4166cca47f29a",
+			imageName:      "foo/image1:tag2",
+			returnValues:   []bool{true, true},
+			sanitizedImage: "docker.io/foo/image1:tag2",
 		},
 		{
 			name: "image tag fetch failed",
@@ -157,9 +176,10 @@ func Test_checkIfImageReTagRequired(t *testing.T) {
 				map[string]bool{},
 				errors.New("some runtime error"),
 			},
-			imageID:      "sha256:fd3fd9ab134a864eeb7b2c073c0d90192546f597c60416b81fc4166cca47f29a",
-			imageName:    "k8s.io/image1:tag2",
-			returnValues: []bool{false, false},
+			imageID:        "sha256:fd3fd9ab134a864eeb7b2c073c0d90192546f597c60416b81fc4166cca47f29a",
+			imageName:      "k8s.io/image1:tag2",
+			returnValues:   []bool{false, false},
+			sanitizedImage: "",
 		},
 	}
 
@@ -169,11 +189,11 @@ func Test_checkIfImageReTagRequired(t *testing.T) {
 			// checkIfImageReTagRequired doesn't use the `nodes.Node` type for anything. So
 			// passing a nil value here should be fine as the other two functions that use the
 			// nodes.Node has been stubbed out already
-			exists, reTagRequired := checkIfImageReTagRequired(nil, tc.imageID, tc.imageName, func(n nodes.Node, s string) (map[string]bool, error) {
+			exists, reTagRequired, sanitizedImage := checkIfImageReTagRequired(nil, tc.imageID, tc.imageName, func(n nodes.Node, s string) (map[string]bool, error) {
 				return tc.imageTags.tags, tc.imageTags.err
 			})
-			if exists != tc.returnValues[0] || reTagRequired != tc.returnValues[1] {
-				t.Errorf("checkIfImageReTagRequired failed. Expected: %v, got: [%v, %v]", tc.returnValues, exists, reTagRequired)
+			if exists != tc.returnValues[0] || reTagRequired != tc.returnValues[1] || sanitizedImage != tc.sanitizedImage {
+				t.Errorf("checkIfImageReTagRequired failed. Expected: [%v,%v,%v], got: [%v, %v, %v]", tc.returnValues[0], tc.returnValues[1], tc.sanitizedImage, exists, reTagRequired, sanitizedImage)
 			}
 		})
 	}


### PR DESCRIPTION
When loading a docker image that has already been loaded with a new tag, its name is not sanitized on import, leading to an inconsistent tag present in the kind container.

Reproducer with latest kind release (v0.16.0)

```
$ docker pull maven:3-jdk-11
$ docker tag maven:3-jdk-11 maven:test
```
Import the first tag
```
$ kind --name $cluster load docker-image maven:3-jdk-11
Image: "maven:3-jdk-11" with ID "sha256:a016b74d0cb2fdf1adcc87a85d6eb6fc4c299bf550def4d2b752b10f6f1cdbf1" not yet present on node "$cluster-control-plane", loading...
```
Then import the second tag
```
$ kind --name $cluster load docker-image maven:test
Image with ID: sha256:a016b74d0cb2fdf1adcc87a85d6eb6fc4c299bf550def4d2b752b10f6f1cdbf1 already present on the node $cluster-control-plane but is missing the tag maven:test. re-tagging...
```

Inspecting content of the internal registry shows that the new image hasn't been prefixed with `docker.io/library` as it was done for the first load.

```
$ docker exec $cluster-control-plane ctr -n k8s.io images list | grep maven
docker.io/library/maven:3-jdk-11                                                                                           application/vnd.docker.distribution.manifest.v2+json      sha256:89b095d4e90aaf193a782e16b53d0ba268ef75752a943b17aa346b632894c8fc 636.0 MiB linux/arm64                                                                  io.cri-containerd.image=managed
maven:test                                                                                                                 application/vnd.docker.distribution.manifest.v2+json      sha256:89b095d4e90aaf193a782e16b53d0ba268ef75752a943b17aa346b632894c8fc 636.0 MiB linux/arm64                                                                  io.cri-containerd.image=managed
```