### PR TITLE
Add --all-platforms flag to LoadImageArchive so that images are not filtered out by ctr

### DIFF
--- a/pkg/cluster/nodeutils/util.go
+++ b/pkg/cluster/nodeutils/util.go
@@ -82,7 +82,7 @@ func LoadImageArchive(n nodes.Node, image io.Reader) error {
 	if err != nil {
 		return err
 	}
-	cmd := n.Command("ctr", "--namespace=k8s.io", "images", "import", "--digests", "--snapshotter="+snapshotter, "-").SetStdin(image)
+	cmd := n.Command("ctr", "--namespace=k8s.io", "images", "import", "--all-platforms", "--digests", "--snapshotter="+snapshotter, "-").SetStdin(image)
 	if err := cmd.Run(); err != nil {
 		return errors.Wrap(err, "failed to load image")
 	}


### PR DESCRIPTION
As discussed in the [slack thread](https://kubernetes.slack.com/archives/CEKK1KTN2/p1665033551816149l), this PR adds the `--all-platforms` flag to ctr. This makes it easier for folks to load images using local architectures that are different than the kind host architecture (ie, on M1 laptops)

To reproduce:

1) Pull a image that is not host native (amd64 in this case as I am on arm64):
```console
$ docker pull docker.io/bitnami/kubeapps-apis:2.4.6-debian-11-r18
2.4.6-debian-11-r18: Pulling from bitnami/kubeapps-apis
Digest: sha256:39ac7fbe10718857ce8d15a75760eb1fb081d04521308e1f7520aed19220ae74
Status: Image is up to date for bitnami/kubeapps-apis:2.4.6-debian-11-r18
docker.io/bitnami/kubeapps-apis:2.4.6-debian-11-r18

$ docker inspect docker.io/bitnami/kubeapps-apis:2.4.6-debian-11-r18 |grep 'Architecture'
      "Architecture": "amd64",
```

2) Before change (image cannot be loaded):
```console
$ kind load docker-image docker.io/bitnami/kubeapps-apis:2.4.6-debian-11-r18
Image: "" with ID "sha256:df590f58636e2ff336d3ac4b10be40e7b9c1dcdf85a1c253ffc17aaaca4ebda9" not yet present on node "kind-control-plane", loading...
ERROR: failed to load image: command "docker exec --privileged -i kind-control-plane ctr --namespace=k8s.io images import --digests --snapshotter=overlayfs -" failed with error: exit status 1
Command Output: ctr: image might be filtered out
```

3) After change (image is copied over):
```console
$ kind load docker-image docker.io/bitnami/kubeapps-apis:2.4.6-debian-11-r18
Image: "" with ID "sha256:df590f58636e2ff336d3ac4b10be40e7b9c1dcdf85a1c253ffc17aaaca4ebda9" not yet present on node "kind-control-plane", loading..

$ docker exec kind-control-plane ctr --namespace=k8s.io images ls |grep 'kubeapps'
docker.io/bitnami/kubeapps-apis:2.4.6-debian-11-r18                                       application/vnd.docker.distribution.manifest.v2+json      sha256:bbf6a77ef73ab2e98496fc1dc93722c3d9c4655ef60511d956d5963fda8f0ef5 344.2 MiB linux/amd64                                                                  io.cri-containerd.image=managed
```
