### PR TITLE
add zfsutils-linux to base Dockerfile

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -115,7 +115,7 @@ RUN echo "Installing Packages ..." \
       conntrack iptables iproute2 ethtool socat util-linux mount ebtables kmod \
       libseccomp2 pigz \
       bash ca-certificates curl rsync \
-      nfs-common fuse-overlayfs open-iscsi \
+      nfs-common fuse-overlayfs open-iscsi zfsutils-linux \
       jq \
     && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-tmpfiles-setup.service" -delete \
     && rm -f /lib/systemd/system/multi-user.target.wants/* \


### PR DESCRIPTION
possibly a fix for #2163 so that the `snapshotter = "native"` config workaround is not needed.