### PR TITLE
Make changes in documentation 

### DIFF
--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -272,9 +272,14 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  image: kindest/node:v1.16.4@sha256:b91a2c2317a000f3a783489dfb755064177dbc3a0b2f4147d50f04825d016f55
 - role: worker
   image: kindest/node:v1.16.4@sha256:b91a2c2317a000f3a783489dfb755064177dbc3a0b2f4147d50f04825d016f55
 {{< /codeFromInline >}}
+
+[Reference](https://kind.sigs.k8s.io/docs/user/quick-start/#creating-a-cluster) 
+
+**Note**: Kubernetes versions are expressed as x.y.z, where x is the major version, y is the minor version, and z is the patch version, following [Semantic Versioning](https://semver.org/) terminology.For more information, see [Kubernetes Release Versioning.](https://github.com/kubernetes/sig-release/blob/master/release-engineering/versioning.md#kubernetes-release-versioning)
 
 ### Extra Mounts
 

--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -279,7 +279,7 @@ nodes:
 
 [Reference](https://kind.sigs.k8s.io/docs/user/quick-start/#creating-a-cluster) 
 
-**Note**: Kubernetes versions are expressed as x.y.z, where x is the major version, y is the minor version, and z is the patch version, following [Semantic Versioning](https://semver.org/) terminology.For more information, see [Kubernetes Release Versioning.](https://github.com/kubernetes/sig-release/blob/master/release-engineering/versioning.md#kubernetes-release-versioning)
+**Note**: Kubernetes versions are expressed as x.y.z, where x is the major version, y is the minor version, and z is the patch version, following [Semantic Versioning](https://semver.org/) terminology. For more information, see [Kubernetes Release Versioning.](https://github.com/kubernetes/sig-release/blob/master/release-engineering/versioning.md#kubernetes-release-versioning)
 
 ### Extra Mounts
 


### PR DESCRIPTION
Closes https://github.com/kubernetes-sigs/kind/issues/2792

This PR does the following changes :

- adds a note about the Kubernetes skew policy applying
- cross links to the main quick start docs about how to use node images
- rewrites the sample config to have a bogus image value so it isn't copy pasted with an image that isn't necessarily for the current kind release
