### PR TITLE
Update node Dockerfile to bring back flannel support

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -184,6 +184,7 @@ RUN echo "Installing CNI plugin binaries ..." \
          -o -iname ptp \
          -o -iname portmap \
          -o -iname loopback \
+         -o -iname bridge \
       \) \
       -delete
 


### PR DESCRIPTION
This change suppose to fix the following flannel error which prevents pods from starting

```
Warning  FailedCreatePodSandBox  18m                   kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "f38b0a31538c077ea17a0e388272d38a16661df3a8ea007eb4bdc9d0c93d5cb7": plugin type="flannel" failed (add): failed to delegate add: failed to find plugin "bridge" in path [/opt/cni/bin]
```

kind version

```terminal
$ kind version
kind v0.17.0 go1.19.2 windows/amd64
```

kindest/node version

```terminal
$ docker inspect d8644f660df0 -f "{{.Id}}"
sha256:d8644f660df0e5af6a7c882c98a253788da4b85aa33723136277c135fbe9188b
```

minimal configuration to reproduce the problem

```yaml
# config.yml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
networking:
  ipFamily: ipv4
  disableDefaultCNI: true
nodes:
  - role: control-plane
  - role: worker
  - role: worker
```

```terminal
$ kind create cluster --name kind --config config.yml
$ kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/v0.20.2/Documentation/kube-flannel.yml
```