### PR TITLE
e2e-k8s.sh: support alpha features

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -24,7 +24,14 @@ set -o errexit -o nounset -o xtrace
 # FOCUS: ginkgo focus regex
 # GA_ONLY: true  - limit to GA APIs/features as much as possible
 #          false - (default) APIs and features left at defaults
-# 
+# FEATURE_GATES:
+#          JSON or YAML encoding of a string/bool map: {"FeatureGateA": true, "FeatureGateB": false}
+#          Enables or disables feature gates in the entire cluster.
+#          Cannot be used when GA_ONLY=true.
+# RUNTIME_CONFIG:
+#          JSON or YAML encoding of a string/string (!) map: {"apia.example.com/v1alpha1": "true", "apib.example.com/v1beta1": "false"}
+#          Enables API groups in the apiserver via --runtime-config.
+#          Cannot be used when GA_ONLY=true.
 
 # cleanup logic for cleanup on exit
 CLEANED_UP=false
@@ -107,17 +114,25 @@ create_cluster() {
       \"logging-format\": \"${KUBELET_LOG_FORMAT}\""
   fi
 
-  # JSON map injected into featureGates config
-  feature_gates="{}"
-  # --runtime-config argument value passed to the API server
-  runtime_config="{}"
+  # JSON or YAML map injected into featureGates config
+  feature_gates="${FEATURE_GATES:-{\}}"
+  # --runtime-config argument value passed to the API server, again as a map
+  runtime_config="${RUNTIME_CONFIG:-{\}}"
 
   case "${GA_ONLY:-false}" in
   false)
-    feature_gates="{}"
-    runtime_config="{}"
+    :
     ;;
   true)
+    if [ "${feature_gates}" != "{}" ]; then
+      echo "GA_ONLY=true and FEATURE_GATES=${feature_gates} are mutually exclusive."
+      exit 1
+    fi
+    if [ "${runtime_config}" != "{}" ]; then
+      echo "GA_ONLY=true and RUNTIME_CONFIG=${runtime_config} are mutually exclusive."
+      exit 1
+    fi
+
     echo "Limiting to GA APIs and features for ${KUBE_VERSION}"
     feature_gates='{"AllAlpha":false,"AllBeta":false}'
     runtime_config='{"api/alpha":"false", "api/beta":"false"}'


### PR DESCRIPTION
FEATURE_GATES and RUNTIME_CONFIG can be set to populate the corresponding kind config and thus modify the cluster.