### PR TITLE
docs: fix usage.yaml in ingress user guide

### DIFF
--- a/site/content/docs/user/ingress.md
+++ b/site/content/docs/user/ingress.md
@@ -165,8 +165,8 @@ kubectl apply -f {{< absURL "examples/ingress/usage.yaml" >}}
 Now verify that the ingress works
 
 {{< codeFromInline lang="bash" >}}
-# should output "foo"
-curl localhost/foo
-# should output "bar"
-curl localhost/bar
+# should output "foo-app"
+curl localhost/foo/hostname
+# should output "bar-app"
+curl localhost/bar/hostname
 {{< /codeFromInline >}}

--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -6,10 +6,11 @@ metadata:
     app: foo
 spec:
   containers:
-  - name: foo-app
-    image: hashicorp/http-echo:0.2.3
-    args:
-    - "-text=foo"
+    - name: foo-app
+      image: mcr.microsoft.com/azuredocs/aks-helloworld:v2
+      env:
+        - name: TITLE
+          value: "Welcome to foo-app!"
 ---
 kind: Service
 apiVersion: v1
@@ -19,8 +20,8 @@ spec:
   selector:
     app: foo
   ports:
-  # Default port used by the image
-  - port: 5678
+    # Default port used by the image
+    - port: 80
 ---
 kind: Pod
 apiVersion: v1
@@ -30,10 +31,11 @@ metadata:
     app: bar
 spec:
   containers:
-  - name: bar-app
-    image: hashicorp/http-echo:0.2.3
-    args:
-    - "-text=bar"
+    - name: bar-app
+      image: mcr.microsoft.com/azuredocs/aks-helloworld:v2
+      env:
+        - name: TITLE
+          value: "Welcome to bar-app!"
 ---
 kind: Service
 apiVersion: v1
@@ -43,29 +45,31 @@ spec:
   selector:
     app: bar
   ports:
-  # Default port used by the image
-  - port: 5678
+    # Default port used by the image
+    - port: 80
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-  - http:
-      paths:
-      - pathType: Prefix
-        path: "/foo"
-        backend:
-          service:
-            name: foo-service
-            port:
-              number: 5678
-      - pathType: Prefix
-        path: "/bar"
-        backend:
-          service:
-            name: bar-service
-            port:
-              number: 5678
+    - http:
+        paths:
+          - pathType: Prefix
+            path: "/foo"
+            backend:
+              service:
+                name: foo-service
+                port:
+                  number: 80
+          - pathType: Prefix
+            path: "/bar"
+            backend:
+              service:
+                name: bar-service
+                port:
+                  number: 80
 ---

--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -6,11 +6,13 @@ metadata:
     app: foo
 spec:
   containers:
-    - name: foo-app
-      image: mcr.microsoft.com/azuredocs/aks-helloworld:v1
-      env:
-        - name: TITLE
-          value: "Welcome to foo-app!"
+  - command:
+    - /agnhost
+    - netexec
+    - --http-port
+    - "8080"
+    image: registry.k8s.io/e2e-test-images/agnhost:2.39
+    name: foo-app
 ---
 kind: Service
 apiVersion: v1
@@ -21,7 +23,7 @@ spec:
     app: foo
   ports:
     # Default port used by the image
-    - port: 80
+    - port: 8080
 ---
 kind: Pod
 apiVersion: v1
@@ -31,11 +33,13 @@ metadata:
     app: bar
 spec:
   containers:
-    - name: bar-app
-      image: mcr.microsoft.com/azuredocs/aks-helloworld:v1
-      env:
-        - name: TITLE
-          value: "Welcome to bar-app!"
+  - command:
+    - /agnhost
+    - netexec
+    - --http-port
+    - "8080"
+    image: registry.k8s.io/e2e-test-images/agnhost:2.39
+    name: bar-app
 ---
 kind: Service
 apiVersion: v1
@@ -46,30 +50,30 @@ spec:
     app: bar
   ports:
     # Default port used by the image
-    - port: 80
+    - port: 8080
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   rules:
-    - http:
-        paths:
-          - pathType: Prefix
-            path: "/foo"
-            backend:
-              service:
-                name: foo-service
-                port:
-                  number: 80
-          - pathType: Prefix
-            path: "/bar"
-            backend:
-              service:
-                name: bar-service
-                port:
-                  number: 80
+  - http:
+      paths:
+      - pathType: Prefix
+        path: /foo(/|$)(.*)
+        backend:
+          service:
+            name: foo-service
+            port:
+              number: 8080
+      - pathType: Prefix
+        path: /bar(/|$)(.*)
+        backend:
+          service:
+            name: bar-service
+            port:
+              number: 8080
 ---

--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: foo-app
-      image: mcr.microsoft.com/azuredocs/aks-helloworld:v2
+      image: mcr.microsoft.com/azuredocs/aks-helloworld:v1
       env:
         - name: TITLE
           value: "Welcome to foo-app!"
@@ -32,7 +32,7 @@ metadata:
 spec:
   containers:
     - name: bar-app
-      image: mcr.microsoft.com/azuredocs/aks-helloworld:v2
+      image: mcr.microsoft.com/azuredocs/aks-helloworld:v1
       env:
         - name: TITLE
           value: "Welcome to bar-app!"

--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -22,8 +22,8 @@ spec:
   selector:
     app: foo
   ports:
-    # Default port used by the image
-    - port: 8080
+  # Default port used by the image
+  - port: 8080
 ---
 kind: Pod
 apiVersion: v1
@@ -49,8 +49,8 @@ spec:
   selector:
     app: bar
   ports:
-    # Default port used by the image
-    - port: 8080
+  # Default port used by the image
+  - port: 8080
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
Changed container image in `usage.yaml` to get [ingress user guide](https://kind.sigs.k8s.io/docs/user/ingress/) working again. Old image `hashicorp/http-echo` seems to have problems, new image `azuredocs/aks-helloworld` works fine.

![image](https://user-images.githubusercontent.com/28647218/207697580-633ddd15-af3a-49c9-894b-3d4b04c8f19e.png)

![image](https://user-images.githubusercontent.com/28647218/207703339-cf3afa17-fe0a-4fbe-8b32-65b76bcdd226.png)

resolves #3024 