### PR TITLE
Add alias 'cluster' for clusters' and 'node' for 'nodes' in 'get' com…

### DIFF
--- a/pkg/cmd/kind/get/clusters/clusters.go
+++ b/pkg/cmd/kind/get/clusters/clusters.go
@@ -34,9 +34,10 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Args: cobra.NoArgs,
 		// TODO(bentheelder): more detailed usage
-		Use:   "clusters",
-		Short: "Lists existing kind clusters by their name",
-		Long:  "Lists existing kind clusters by their name",
+		Use:     "clusters",
+		Aliases: []string{"cluster"},
+		Short:   "Lists existing kind clusters by their name",
+		Long:    "Lists existing kind clusters by their name",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(logger, streams)
 		},

--- a/pkg/cmd/kind/get/nodes/nodes.go
+++ b/pkg/cmd/kind/get/nodes/nodes.go
@@ -40,10 +40,11 @@ type flagpole struct {
 func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	flags := &flagpole{}
 	cmd := &cobra.Command{
-		Args:  cobra.NoArgs,
-		Use:   "nodes",
-		Short: "Lists existing kind nodes by their name",
-		Long:  "Lists existing kind nodes by their name",
+		Args:    cobra.NoArgs,
+		Use:     "nodes",
+		Aliases: []string{"node"},
+		Short:   "Lists existing kind nodes by their name",
+		Long:    "Lists existing kind nodes by their name",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cli.OverrideDefaultName(cmd.Flags())
 			return runE(logger, streams, flags)


### PR DESCRIPTION
## What?
- Add alias `cluster` for `clusters` to support `kind get cluster(s)`.
- Add alias `node` for `nodes` to support `kind get node(s)`.

## Why?

**kubectl** allows `kubectl get cluster(s)/node(s)/pod(s)`. The PR makes **kind** command consistent with **kubectl**'s usage and improve user experience.

Issue: https://github.com/kubernetes-sigs/kind/issues/3031