### PR TITLE
images/haproxy: overwrite instead of concatenating dpkg status

### DIFF
--- a/images/haproxy/stage-binary-and-deps.sh
+++ b/images/haproxy/stage-binary-and-deps.sh
@@ -53,7 +53,7 @@ stage_file() {
     # stage the package status mimicking bazel
     # https://github.com/bazelbuild/rules_docker/commit/f5432b813e0a11491cf2bf83ff1a923706b36420
     # instead of parsing the control file, we can just get the actual package status with dpkg
-    dpkg -s "${package}" >> "${2}/var/lib/dpkg/status.d/${package}"
+    dpkg -s "${package}" > "${2}/var/lib/dpkg/status.d/${package}"
 }
 
 # binary_to_libraries identifies the library files needed by the binary $1 with ldd

--- a/pkg/cluster/internal/loadbalancer/const.go
+++ b/pkg/cluster/internal/loadbalancer/const.go
@@ -17,7 +17,7 @@ limitations under the License.
 package loadbalancer
 
 // Image defines the loadbalancer image:tag
-const Image = "kindest/haproxy:v20220607-9a4d8d2a"
+const Image = "kindest/haproxy:v20221220-7705dd1a"
 
 // ConfigPath defines the path to the config file in the image
 const ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"


### PR DESCRIPTION
see: https://github.com/kubernetes/release/pull/2831