### PR TITLE
Doc update for nginx ingress with kind: Update apiVersion from v1alpha4 to v1

### DIFF
--- a/site/content/docs/user/ingress.md
+++ b/site/content/docs/user/ingress.md
@@ -35,7 +35,7 @@ Create a kind cluster with `extraPortMappings` and `node-labels`.
 {{< codeFromInline lang="bash" >}}
 cat <<EOF | kind create cluster --config=-
 kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
+apiVersion: kind.x-k8s.io/v1
 nodes:
 - role: control-plane
   kubeadmConfigPatches:


### PR DESCRIPTION
Hi k8s kind team!

I'm unsure if there's a better more explicit version to use, but using `v1alpha4` seems to result in `create cluster: unknown apiVersion` on king version `0.17.0`. If we're not ready to update that from alpha to v1, I'm happy to update it to something else that works, but haven't had the change to test beta or higher alphas.

Thanks so much for you time and help in making kind awesome :)