### PR TITLE
Adding support for 'kind provider' command

### DIFF
--- a/pkg/cluster/provider.go
+++ b/pkg/cluster/provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cluster
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -91,6 +92,24 @@ func NewProvider(options ...ProviderOption) *Provider {
 		providerOpt.apply(p)
 	}
 	return p
+}
+
+// SupportedProviders returns a list of all supported providers
+func SupportedProviders() []*Provider {
+	opts := []ProviderOption{
+		ProviderWithDocker(),
+		ProviderWithPodman(),
+	}
+
+	var providers []*Provider
+	for _, opt := range opts {
+		p := &Provider{
+			logger: log.NoopLogger{},
+		}
+		opt.apply(p)
+		providers = append(providers, p)
+	}
+	return providers
 }
 
 // NoNodeProviderDetectedError indicates that we could not autolocate an available
@@ -244,4 +263,9 @@ func (p *Provider) CollectLogs(name, dir string) error {
 	}
 	// collect and write cluster logs
 	return p.provider.CollectLogs(dir, n)
+}
+
+// Name returns the runtime name of the configured provider
+func (p *Provider) Name() string {
+	return fmt.Sprintf("%s", p.provider)
 }

--- a/pkg/cluster/provider_test.go
+++ b/pkg/cluster/provider_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import "testing"
+
+const supportProvidersCount = 2
+
+func TestSupportedProviders(t *testing.T) {
+	providers := SupportedProviders()
+	if len(providers) != supportProvidersCount {
+		t.Fatalf("expected supported providers count to be %d, but got: %d", supportProvidersCount, len(providers))
+	}
+}

--- a/pkg/cmd/kind/provider/provider.go
+++ b/pkg/cmd/kind/provider/provider.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package provider implements the `provider` command
+package provider
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kind/pkg/cluster"
+	"sigs.k8s.io/kind/pkg/cmd"
+	"sigs.k8s.io/kind/pkg/internal/runtime"
+	"sigs.k8s.io/kind/pkg/log"
+)
+
+// NewCommand returns a new cobra.Command for provider
+func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
+	var current bool
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "provider",
+		Short: "Display information around providers",
+		Long:  "Display information on supported providers, and currently active provider",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runE(logger, streams, current)
+		},
+	}
+	cmd.Flags().BoolVarP(
+		&current,
+		"current",
+		"c",
+		false,
+		"display the current active provider",
+	)
+	return cmd
+}
+
+func runE(_ log.Logger, streams cmd.IOStreams, current bool) error {
+	if current {
+		provider := cluster.NewProvider(
+			runtime.GetDefault(log.NoopLogger{}),
+		)
+		fmt.Fprintln(streams.Out, provider.Name())
+		return nil
+	}
+
+	providers := cluster.SupportedProviders()
+	for _, provider := range providers {
+		fmt.Fprintln(streams.Out, provider.Name())
+	}
+	return nil
+}

--- a/pkg/cmd/kind/root.go
+++ b/pkg/cmd/kind/root.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cmd/kind/export"
 	"sigs.k8s.io/kind/pkg/cmd/kind/get"
 	"sigs.k8s.io/kind/pkg/cmd/kind/load"
+	"sigs.k8s.io/kind/pkg/cmd/kind/provider"
 	"sigs.k8s.io/kind/pkg/cmd/kind/version"
 	"sigs.k8s.io/kind/pkg/log"
 )
@@ -85,8 +86,9 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd.AddCommand(delete.NewCommand(logger, streams))
 	cmd.AddCommand(export.NewCommand(logger, streams))
 	cmd.AddCommand(get.NewCommand(logger, streams))
-	cmd.AddCommand(version.NewCommand(logger, streams))
 	cmd.AddCommand(load.NewCommand(logger, streams))
+	cmd.AddCommand(provider.NewCommand(logger, streams))
+	cmd.AddCommand(version.NewCommand(logger, streams))
 	return cmd
 }
 


### PR DESCRIPTION
I'm very much open to UX feedback, as we can do something like `kind get provider`, but keeping it at `kind provider` for now as this seems to be somewhat separate from the other operations.

There are use cases where it would help to be able to list the supported providers as well as display the currently configured runtime provider.

This change adds a `kind provider` command which
will display all supported providers. The `--current` flag can be provided to show the currently configured provider which honors the KIND_EXPERIMENTAL_PROVIDER env if set.

Addresses: #3056 

Signed-off-by: Yibo Zhuang <yibzhuang@gmail.com>