### PR TITLE
Enhance "kind delete cluster(s)" command

### DIFF
--- a/pkg/cluster/internal/delete/delete.go
+++ b/pkg/cluster/internal/delete/delete.go
@@ -32,6 +32,9 @@ func Cluster(logger log.Logger, p providers.Provider, name, explicitKubeconfigPa
 	if err != nil {
 		return errors.Wrap(err, "error listing nodes")
 	}
+	if len(n) == 0 {
+		return errors.Errorf("cluster \"%s\" doesn't exist", name)
+	}
 
 	kerr := kubeconfig.Remove(name, explicitKubeconfigPath)
 	if kerr != nil {


### PR DESCRIPTION
### Why?

`kind delete cluster(s)` command doesn't report any error if the cluster(s) to be deleted doesn't exist. The output can be misleading.

### What?

Check if the cluster(s) to be deleted exist or not. If it doesn't exist, report an error `cluster xxx doesn't exist"

### Example 
Current version: 
```
$ kind delete clusters non-existing-cluster
Deleted clusters: ["non-existing-cluster"]
```

New version: 
```
$ kind delete clusters non-existing-cluster
failed to delete cluster "non-existing-cluster": cluster "non-existing-cluster" doesn't exist
Deleted clusters: []
```
