### PR TITLE
Update deprecated github actions

### DIFF
--- a/.github/workflows/cgroup2.yaml
+++ b/.github/workflows/cgroup2.yaml
@@ -29,7 +29,7 @@ jobs:
       JOB_NAME: "cgroup2-${{ matrix.provider }}-${{ matrix.rootless }}"
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Boot Fedora
         run: |
@@ -53,7 +53,6 @@ jobs:
           "$HELPER" dockerd-rootless-setuptool.sh install
           # Modify the client config to use the rootless daemon by default
           "$HELPER" docker context use rootless
-
 
       - name: Set up Rootless Podman
         if: ${{ matrix.provider == 'podman' && matrix.rootless == 'rootless' }}
@@ -88,7 +87,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
           path: /tmp/kind/logs

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -26,7 +26,7 @@ jobs:
       IP_FAMILY: ${{ matrix.ipFamily }}
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install kind
         run: sudo make install INSTALL_DIR=/usr/local/bin
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
           path: /tmp/kind/logs

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -30,7 +30,7 @@ jobs:
       PODMAN_VERSION: "stable"
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
           path: /tmp/kind/logs


### PR DESCRIPTION
This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/) rather then node12. 

🚨 Node 12 has an end of life on April 30, 2022.

The GitHub Actions workflow gives the following deprecation warning while running the action and the warnings may break some pipelines: #3084 

> Docker (ipv6, singleNode) Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. 

>  Docker (ipv4, singleNode) Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. 

>  Docker (ipv6, multiNode) Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. 

>  Docker (ipv4, multiNode) Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

`actions/checkout@v2` and `actions/upload-artifact@v2` use Node.js 12 environments. We can update to the major action versions `actions/checkout@v3` and `actions/upload-artifact@v3` that use Node.js 16 environments.

Signed-off-by: Enes <ahmedenesturan@gmail.com>