### PR TITLE
upgrade local-path-provisioner

### DIFF
--- a/images/local-path-provisioner/Makefile
+++ b/images/local-path-provisioner/Makefile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-VERSION=v0.0.22
+VERSION=v0.0.23
 TAG=$(VERSION)-kind.0
 EXTRA_BUILD_OPT=--build-arg=VERSION=$(VERSION)
 include $(CURDIR)/../Makefile.common.in


### PR DESCRIPTION
Upgrades local path provisioner to [v0.0.23](https://github.com/rancher/local-path-provisioner/releases) which, besides other things, introduces the ability to enable shared filesystem support for multi node PVs.