### PR TITLE
docs: add example to specify kubernetes source location

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -260,6 +260,11 @@ Currently, kind supports one default way to build a `node-image`
 if you have the [Kubernetes][kubernetes] source in your host machine
 (`$GOPATH/src/k8s.io/kubernetes`), by using `docker`.
 
+You can also specify a different path to kubernetes source using 
+```
+kind build node-image /path/to/kubernetes/source
+```
+
 > **NOTE**: Building Kubernetes node-images requires everything building upstream
 > Kubernetes requires, we wrap the upstream build. This includes Docker with buildx.
 > See: https://git.k8s.io/community/contributors/devel/development.md#building-kubernetes-with-docker


### PR DESCRIPTION
Kind docs currently ask users to "[ensure that Kubernetes is cloned in `$(go env GOPATH)/src/k8s.io/kubernetes`](https://github.com/kubernetes-sigs/kind#installation-and-usage)". This got me confused and led me to believe that we can't have the source anywhere else, since we can't specify its location (which is not the case). This PR aims to fix the documentation by adding an example which uses a different Kubernetes source location.