### PR TITLE
Add `dnsSearch` cluster option

### DIFF
--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -417,7 +417,20 @@ enable_network_magic(){
 
   # now we can ensure that DNS is configured to use our IP
   cp /etc/resolv.conf /etc/resolv.conf.original
-  sed -e "s/${docker_embedded_dns_ip}/${docker_host_ip}/g" /etc/resolv.conf.original >/etc/resolv.conf
+  replaced="$(sed -e "s/${docker_embedded_dns_ip}/${docker_host_ip}/g" /etc/resolv.conf.original)"
+  if [[ "${KIND_DNS_SEARCH+x}" == "" ]]; then
+    # No DNS search set, just pass through as is
+    echo "$replaced" >/etc/resolv.conf
+  elif [[ -z "$KIND_DNS_SEARCH" ]]; then
+    # Empty search - remove all current search clauses
+    echo "$replaced" | grep -v "^search" >/etc/resolv.conf
+  else
+    # Search set - remove all current search clauses, and add the configured search
+    {
+      echo "search $KIND_DNS_SEARCH";
+      echo "$replaced" | grep -v "^search";
+    } >/etc/resolv.conf
+  fi
 
   local files_to_update=(
     /etc/kubernetes/manifests/etcd.yaml

--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -189,6 +189,8 @@ type Networking struct {
 	// KubeProxyMode defines if kube-proxy should operate in iptables or ipvs mode
 	// Defaults to 'iptables' mode
 	KubeProxyMode ProxyMode `yaml:"kubeProxyMode,omitempty" json:"kubeProxyMode,omitempty"`
+	// DNSSearch defines the DNS search domain to use for nodes. If not set, this will be inherited from the host.
+	DNSSearch *[]string `yaml:"dnsSearch,omitempty" json:"dnsSearch,omitempty"`
 }
 
 // ClusterIPFamily defines cluster network IP family

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -201,18 +201,7 @@ func commonArgs(cluster string, cfg *config.Cluster, networkName string, nodeNam
 	}
 
 	if cfg.Networking.DNSSearch != nil {
-		if len(*cfg.Networking.DNSSearch) == 0 {
-			return nil, errors.New("docker provider requires a non-empty dnsSearch")
-		}
-		for _, s := range *cfg.Networking.DNSSearch {
-			args = append(args, "--dns-search", s)
-		}
-		args = append(args, "--dns", "8.8.8.8")
-		args = append(args, "--dns", "8.8.4.4")
-		if config.ClusterHasIPv6(cfg) {
-			args = append(args, "--dns", "2001:4860:4860::8888")
-			args = append(args, "--dns", "2001:4860:4860::8844")
-		}
+		args = append(args, "-e", "KIND_DNS_SEARCH="+strings.Join(*cfg.Networking.DNSSearch, " "))
 	}
 
 	return args, nil

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -199,6 +199,22 @@ func commonArgs(cluster string, cfg *config.Cluster, networkName string, nodeNam
 	if mountFuse() {
 		args = append(args, "--device", "/dev/fuse")
 	}
+
+	if cfg.Networking.DNSSearch != nil {
+		if len(*cfg.Networking.DNSSearch) == 0 {
+			return nil, errors.New("docker provider requires a non-empty dnsSearch")
+		}
+		for _, s := range *cfg.Networking.DNSSearch {
+			args = append(args, "--dns-search", s)
+		}
+		args = append(args, "--dns", "8.8.8.8")
+		args = append(args, "--dns", "8.8.4.4")
+		if config.ClusterHasIPv6(cfg) {
+			args = append(args, "--dns", "2001:4860:4860::8888")
+			args = append(args, "--dns", "2001:4860:4860::8844")
+		}
+	}
+
 	return args, nil
 }
 

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -165,12 +165,7 @@ func commonArgs(cfg *config.Cluster, networkName string, nodeNames []string) ([]
 	}
 
 	if cfg.Networking.DNSSearch != nil {
-		if len(*cfg.Networking.DNSSearch) == 0 {
-			args = append(args, "--dns-search", "")
-		}
-		for _, s := range *cfg.Networking.DNSSearch {
-			args = append(args, "--dns-search", s)
-		}
+		args = append(args, "-e", "KIND_DNS_SEARCH="+strings.Join(*cfg.Networking.DNSSearch, " "))
 	}
 
 	return args, nil

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -164,6 +164,15 @@ func commonArgs(cfg *config.Cluster, networkName string, nodeNames []string) ([]
 		args = append(args, "--device", "/dev/fuse")
 	}
 
+	if cfg.Networking.DNSSearch != nil {
+		if len(*cfg.Networking.DNSSearch) == 0 {
+			args = append(args, "--dns-search", "")
+		}
+		for _, s := range *cfg.Networking.DNSSearch {
+			args = append(args, "--dns-search", s)
+		}
+	}
+
 	return args, nil
 }
 

--- a/pkg/internal/apis/config/convert_v1alpha4.go
+++ b/pkg/internal/apis/config/convert_v1alpha4.go
@@ -85,6 +85,7 @@ func convertv1alpha4Networking(in *v1alpha4.Networking, out *Networking) {
 	out.KubeProxyMode = ProxyMode(in.KubeProxyMode)
 	out.ServiceSubnet = in.ServiceSubnet
 	out.DisableDefaultCNI = in.DisableDefaultCNI
+	out.DNSSearch = in.DNSSearch
 }
 
 func convertv1alpha4Mount(in *v1alpha4.Mount, out *Mount) {

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -150,6 +150,8 @@ type Networking struct {
 	DisableDefaultCNI bool
 	// KubeProxyMode defines if kube-proxy should operate in iptables or ipvs mode
 	KubeProxyMode ProxyMode
+	// DNSSearch defines the DNS search domain to use for nodes. If not set, this will be inherited from the host.
+	DNSSearch *[]string
 }
 
 // ClusterIPFamily defines cluster network IP family


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kind/issues/3097

The implementation here may seem kind of complex - docker has a `--dns-search`, after all. But there are a few reasons we cannot use it directly

* We cannot set *no* search through this mechanism, so users need to set at least one value there.
* When any DNS options are set, docker skips its own (complex) logic to determine the correct DNS config. So simply setting --dns-search actually breaks all DNS in many cases. For example, a 127.0.0.1 resolver  on the host would be used directly when the flag is set (broken), but without the flag docker rewrites this to 8.8.8.8.

We could re-implement dockers logic and deny empty search list, but this seems like a much simpler option.