### PR TITLE
kindnet: add nodeSelector

### DIFF
--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -91,6 +91,8 @@ spec:
         k8s-app: kindnet
     spec:
       hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - operator: Exists
       serviceAccountName: kindnet


### PR DESCRIPTION
Currently, it is impossible to create a Node object and not have kindnet scheduled there. There is a blanket toleration for *any* taint, and no node selector.

This adds a nodeSelector for it, matching the one on kube-proxy. For most users this should have no impact, as kind nodes are linux.

however, for some cases where we are manually creating `Node`s like https://kwok.sigs.k8s.io/, it is useful to be able to prevent scheduling.