### PR TITLE
Update during image build to get security patches

### DIFF
--- a/images/base/files/usr/local/bin/clean-install
+++ b/images/base/files/usr/local/bin/clean-install
@@ -26,6 +26,7 @@ if [ $# = 0 ]; then
 fi
 
 apt-get update
+apt-get upgrade -y
 apt-get install -y --no-install-recommends "$@"
 apt-get clean -y
 rm -rf \


### PR DESCRIPTION
Pull in some security updates to the base image when building, as the Ubuntu base image is on a monthly-ish release cycle.  We're already updating listed packages with the `clean-install` script