### PR TITLE
docs(README): add github actions status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 # Please see [Our Documentation](https://kind.sigs.k8s.io/docs/user/quick-start/) for more in-depth installation etc.
 
-[![Cgroup v2](https://github.com/kubernetes-sigs/kind/actions/workflows/cgroup2.yaml/badge.svg)](https://github.com/kubernetes-sigs/kind/actions/workflows/cgroup2.yaml)
 [![Docker](https://github.com/kubernetes-sigs/kind/actions/workflows/docker.yaml/badge.svg)](https://github.com/kubernetes-sigs/kind/actions/workflows/docker.yaml)
-[![Podman](https://github.com/kubernetes-sigs/kind/actions/workflows/podman.yml/badge.svg)](https://github.com/kubernetes-sigs/kind/actions/workflows/podman.yml)
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 # Please see [Our Documentation](https://kind.sigs.k8s.io/docs/user/quick-start/) for more in-depth installation etc.
 
+[![Cgroup v2](https://github.com/kubernetes-sigs/kind/actions/workflows/cgroup2.yaml/badge.svg)](https://github.com/kubernetes-sigs/kind/actions/workflows/cgroup2.yaml)
+[![Docker](https://github.com/kubernetes-sigs/kind/actions/workflows/docker.yaml/badge.svg)](https://github.com/kubernetes-sigs/kind/actions/workflows/docker.yaml)
+[![Podman](https://github.com/kubernetes-sigs/kind/actions/workflows/podman.yml/badge.svg)](https://github.com/kubernetes-sigs/kind/actions/workflows/podman.yml)
+
+<br/>
+
 kind is a tool for running local Kubernetes clusters using Docker container "nodes".
 kind was primarily designed for testing Kubernetes itself, but may be used for local development or CI.
 


### PR DESCRIPTION
Added Github actions status badges to readme, as per documentation best practices.

You can take a look at my forked <a href ="https://github.com/R3DRUN3/kind#readme">repo</a> to inspect the appearance of my edit.