### PR TITLE
fix: Limit HAProxy maximum concurrent connections

### DIFF
--- a/images/haproxy/haproxy.cfg
+++ b/images/haproxy/haproxy.cfg
@@ -14,6 +14,10 @@
 
 # minimal config file to avoid haproxy exiting due to invalid / missing config
 # kind will rewrite this config at runtime
+global
+    # limit memory usage to approximately 18 MB
+    maxconn 100000
+
 frontend controlPlane
     bind 0.0.0.0:6443
     mode tcp

--- a/pkg/cluster/internal/loadbalancer/config.go
+++ b/pkg/cluster/internal/loadbalancer/config.go
@@ -36,6 +36,8 @@ global
   log /dev/log local0
   log /dev/log local1 notice
   daemon
+  # limit memory usage to approximately 18 MB
+  maxconn 100000
 
 resolvers docker
   nameserver dns 127.0.0.11:53


### PR DESCRIPTION
If the limit is not configured, HAProxy derives it from the file descriptor limit. The higher the limit, the more memory HAProxy allocates. That limit can be so high on modern Linux distros that HAproxy allocates all available memory.

I think this change is preferable to #3028. Please see my explanation in https://github.com/kubernetes-sigs/kind/issues/2954#issuecomment-1453826595. :pray: 

Why 100000 (10^5) connections? I _assume_  that most kind clusters do not see 100000 concurrent connections. But I must admit that I have no evidence.

Increasing the limit to 1000000 (10^6) causes memory usage* to go from 18MB to 128MB (for a reproducible demonstration, see https://gist.github.com/dlipovetsky/23443bef17371a56acd8cf0579e3f6b4, which I've also linked in my issue comment). If the extra connections go unused, I think 110MB is too much additional overhead.

* To be clear, memory usage means _resident_ memory usage. This is memory that is allocated and cannot be used by other processes.
 
Fixes: #2954