### PR TITLE
Add automated builds configs for most images

### DIFF
--- a/images/Makefile.common.in
+++ b/images/Makefile.common.in
@@ -17,7 +17,7 @@
 # get image name from directory we're building
 IMAGE_NAME=$(notdir $(CURDIR))
 # docker image registry, default to upstream
-REGISTRY?=kindest
+REGISTRY?=gcr.io/k8s-staging-kind
 # tag based on date-sha
 TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git describe --always --dirty)")
 # the full image tag

--- a/images/base/cloudbuild.yaml
+++ b/images/base/cloudbuild.yaml
@@ -1,0 +1,7 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+- name: gcr.io/k8s-testimages/krte:latest-master
+  env:
+  entrypoint: make -C images/base push

--- a/images/haproxy/cloudbuild.yaml
+++ b/images/haproxy/cloudbuild.yaml
@@ -1,0 +1,7 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+- name: gcr.io/k8s-testimages/krte:latest-master
+  env:
+  entrypoint: make -C images/haproxy push

--- a/images/kindnetd/cloudbuild.yaml
+++ b/images/kindnetd/cloudbuild.yaml
@@ -1,0 +1,7 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+- name: gcr.io/k8s-testimages/krte:latest-master
+  env:
+  entrypoint: make -C images/kindnetd push

--- a/images/local-path-helper/cloudbuild.yaml
+++ b/images/local-path-helper/cloudbuild.yaml
@@ -1,0 +1,7 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+- name: gcr.io/k8s-testimages/krte:latest-master
+  env:
+  entrypoint: make -C images/local-path-helper push

--- a/images/local-path-provisioner/cloudbuild.yaml
+++ b/images/local-path-provisioner/cloudbuild.yaml
@@ -1,0 +1,7 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+- name: gcr.io/k8s-testimages/krte:latest-master
+  env:
+  entrypoint: make -C images/local-path-provisioner push


### PR DESCRIPTION
Not the node image, which is a whole other can of worms (mutable tags, usually pushed primarily on releases, need to build for ?? k8s versions, etc).

But these other "internal" images that we use to implement kind are already using a date-sha tagging scheme and are used 1:1 with kind releases.

For a while it's been nice to simply push new images and test them at the same time along with source changes, but after this we'll move to:
1. merge PR with source changes to images
2. submit PR updating image references to image(s) auto-pushed following 1)

We may also require:
3. File github.com/kubernetes/k8s.io image promotion PR prior to 2), however I think instead we should do 2) , vet changes, then consider 3) ahead of releases or shortly after 2) and follow up with switching references from the staging GCR to registry.k8s.io. One of those variants unblocks velocity a little and avoids promoting unvetted images to the production registry.

Doing this will also require github.com/kubernetes/test-infra changes to add post-submit jobs that trigger on these directories and run he cloudbuilds. Ref https://github.com/kubernetes/test-infra/pull/22986

This is a step towards https://github.com/kubernetes-sigs/kind/issues/1895