### PR TITLE
Added CPU pinning to Docker container

### DIFF
--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -118,6 +118,10 @@ type Node struct {
 	// binded to a host Port
 	ExtraPortMappings []PortMapping `yaml:"extraPortMappings,omitempty"`
 
+	// Limit the specific CPUs or cores a container can use.
+	// A comma-separated list or hyphen-separated range of CPUs a container can use, if you have more than one CPU.
+	CPUSet string `yaml:"cpuSet,omitempty"`
+
 	// KubeadmConfigPatches are applied to the generated kubeadm config as
 	// merge patches. The `kind` field must match the target object, and
 	// if `apiVersion` is specified it will only be applied to matching objects.

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -204,6 +204,7 @@ func commonArgs(cluster string, cfg *config.Cluster, networkName string, nodeNam
 
 func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, name string, args []string) ([]string, error) {
 	args = append([]string{
+		"--cpuset-cpus", node.CPUSet,
 		"--hostname", name, // make hostname match container name
 		// label the node with the role ID
 		"--label", fmt.Sprintf("%s=%s", nodeRoleLabelKey, node.Role),

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -166,6 +166,7 @@ func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, n
 	}
 
 	args = append([]string{
+		"--cpuset-cpus", node.CPUSet,
 		"--hostname", name, // make hostname match container name
 		// label the node with the role ID
 		"--label", fmt.Sprintf("%s=%s", nodeRoleLabelKey, node.Role),

--- a/pkg/internal/apis/config/convert_v1alpha4.go
+++ b/pkg/internal/apis/config/convert_v1alpha4.go
@@ -53,6 +53,7 @@ func convertv1alpha4Node(in *v1alpha4.Node, out *Node) {
 
 	out.Labels = in.Labels
 	out.KubeadmConfigPatches = in.KubeadmConfigPatches
+	out.CPUSet = in.CPUSet
 	out.ExtraMounts = make([]Mount, len(in.ExtraMounts))
 	out.ExtraPortMappings = make([]PortMapping, len(in.ExtraPortMappings))
 	out.KubeadmConfigPatchesJSON6902 = make([]PatchJSON6902, len(in.KubeadmConfigPatchesJSON6902))

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -104,6 +104,10 @@ type Node struct {
 	// This should be an inline yaml blob-string
 	KubeadmConfigPatches []string
 
+	// Limit the specific CPUs or cores a container can use.
+	// A comma-separated list or hyphen-separated range of CPUs a container can use, if you have more than one CPU.
+	CPUSet string
+
 	// KubeadmConfigPatchesJSON6902 are applied to the generated kubeadm config
 	// as patchesJson6902 to `kustomize build`
 	KubeadmConfigPatchesJSON6902 []PatchJSON6902


### PR DESCRIPTION
This PR is related to optimizing resource usage, it is useful especially for large clusters with many nodes on the same machine.
The purpose is simply to allow pinning kind nodes to cpus using docker feature by implementing a new field in node config.