### PR TITLE
increase machine size for auto-builds

### DIFF
--- a/images/base/cloudbuild.yaml
+++ b/images/base/cloudbuild.yaml
@@ -1,6 +1,7 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 options:
   substitution_option: ALLOW_LOOSE
+  machineType: N1_HIGHCPU_8
 steps:
 - name: gcr.io/k8s-testimages/krte:latest-master
   entrypoint: make

--- a/images/kindnetd/cloudbuild.yaml
+++ b/images/kindnetd/cloudbuild.yaml
@@ -1,6 +1,7 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 options:
   substitution_option: ALLOW_LOOSE
+  machineType: N1_HIGHCPU_8
 steps:
 - name: gcr.io/k8s-testimages/krte:latest-master
   entrypoint: make


### PR DESCRIPTION
one of these took almost an hour to build a small image for two architectures

https://github.com/kubernetes-sigs/kind/pull/3143#issuecomment-1489678463

see e.g. https://github.com/kubernetes/ingress-nginx/blob/c84ae78bdfabb1f93bf0e87cdff34c75c744b8df/images/nginx/cloudbuild.yaml#L5