### PR TITLE
Added platform flag to docker command in site Makefile

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -2,7 +2,7 @@
 DOCKER       = docker
 HUGO_VERSION = 0.60.0
 DOCKER_IMAGE = jojomi/hugo:$(HUGO_VERSION)
-DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(realpath $(CURDIR)/..):/src -p 1313:1313 --workdir /src/site --entrypoint=hugo $(DOCKER_IMAGE)
+DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(realpath $(CURDIR)/..):/src -p 1313:1313 --workdir /src/site --entrypoint=hugo --platform linux/amd64 $(DOCKER_IMAGE)
 
 serve:
 	$(DOCKER_RUN) server --bind="0.0.0.0" \


### PR DESCRIPTION
A minor fix. On M1 Mac, running `make build` gives the following warning -

`WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested`

Specifying platform explicitly resolves the same.