### PR TITLE
Delete ioutil as it is Deprecated since Go 1.16

### DIFF
--- a/cmd/kind/app/main.go
+++ b/cmd/kind/app/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package app
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/spf13/pflag"
@@ -45,7 +45,7 @@ func Run(logger log.Logger, streams cmd.IOStreams, args []string) error {
 		// if we are in quiet mode, we want to suppress all status output
 		// only streams.Out should be written to (program output)
 		logger = log.NoopLogger{}
-		streams.ErrOut = ioutil.Discard
+		streams.ErrOut = io.Discard
 	}
 	// actually run the command
 	c := kind.NewCommand(logger, streams)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kind
 
-go 1.14
+go 1.16
 
 require (
 	github.com/BurntSushi/toml v1.0.0

--- a/pkg/build/nodeimage/imageimporter.go
+++ b/pkg/build/nodeimage/imageimporter.go
@@ -17,7 +17,7 @@ limitations under the License.
 package nodeimage
 
 import (
-	"io/ioutil"
+	"io"
 
 	"sigs.k8s.io/kind/pkg/exec"
 )
@@ -49,7 +49,7 @@ func (c *containerdImporter) End() error {
 func (c *containerdImporter) Pull(image, platform string) error {
 	return c.containerCmder.Command(
 		"ctr", "--namespace=k8s.io", "content", "fetch", "--platform="+platform, image,
-	).SetStdout(ioutil.Discard).SetStderr(ioutil.Discard).Run()
+	).SetStdout(io.Discard).SetStderr(io.Discard).Run()
 }
 
 func (c *containerdImporter) LoadCommand() exec.Cmd {

--- a/pkg/build/nodeimage/internal/container/docker/archive.go
+++ b/pkg/build/nodeimage/internal/container/docker/archive.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -58,7 +57,7 @@ func GetArchiveTags(path string) ([]string, error) {
 		}
 	}
 	// read and parse the tags
-	b, err := ioutil.ReadAll(tr)
+	b, err := io.ReadAll(tr)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +106,7 @@ func EditArchive(reader io.Reader, writer io.Writer, editRepositories func(strin
 		} else if err != nil {
 			return err
 		}
-		b, err := ioutil.ReadAll(tarReader)
+		b, err := io.ReadAll(tarReader)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/internal/kubeconfig/internal/kubeconfig/merge_test.go
+++ b/pkg/cluster/internal/kubeconfig/internal/kubeconfig/merge_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package kubeconfig
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -234,7 +234,7 @@ func TestWriteMerged(t *testing.T) {
 
 func testWriteMergedNormal(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir("", "kind-testwritemerged")
+	dir, err := os.MkdirTemp("", "kind-testwritemerged")
 	if err != nil {
 		t.Fatalf("Failed to create tempdir: %d", err)
 	}
@@ -262,7 +262,7 @@ users:
     client-key-data: yep
 `
 	existingConfigPath := filepath.Join(dir, "existing-kubeconfig")
-	if err := ioutil.WriteFile(existingConfigPath, []byte(existingConfig), os.ModePerm); err != nil {
+	if err := os.WriteFile(existingConfigPath, []byte(existingConfig), os.ModePerm); err != nil {
 		t.Fatalf("Failed to create existing kubeconfig: %d", err)
 	}
 
@@ -313,7 +313,7 @@ users:
 	if err != nil {
 		t.Fatalf("Failed to open merged kubeconfig: %v", err)
 	}
-	contents, err := ioutil.ReadAll(f)
+	contents, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("Failed to read merged kubeconfig: %v", err)
 	}
@@ -354,7 +354,7 @@ users:
 
 func testWriteMergedBogusConfig(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir("", "kind-testwritemerged")
+	dir, err := os.MkdirTemp("", "kind-testwritemerged")
 	if err != nil {
 		t.Fatalf("Failed to create tempdir: %d", err)
 	}
@@ -366,7 +366,7 @@ func testWriteMergedBogusConfig(t *testing.T) {
 
 func testWriteMergedNoExistingFile(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir("", "kind-testwritemerged")
+	dir, err := os.MkdirTemp("", "kind-testwritemerged")
 	if err != nil {
 		t.Fatalf("Failed to create tempdir: %d", err)
 	}
@@ -419,7 +419,7 @@ func testWriteMergedNoExistingFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to open merged kubeconfig: %v", err)
 	}
-	contents, err := ioutil.ReadAll(f)
+	contents, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("Failed to read merged kubeconfig: %v", err)
 	}

--- a/pkg/cluster/internal/kubeconfig/internal/kubeconfig/read.go
+++ b/pkg/cluster/internal/kubeconfig/internal/kubeconfig/read.go
@@ -17,7 +17,7 @@ limitations under the License.
 package kubeconfig
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 
 	yaml "gopkg.in/yaml.v3"
@@ -70,7 +70,7 @@ func read(configPath string) (*Config, error) {
 
 	// otherwise read in and deserialize
 	cfg := &Config{}
-	rawExisting, err := ioutil.ReadAll(f)
+	rawExisting, err := io.ReadAll(f)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/pkg/cluster/internal/kubeconfig/internal/kubeconfig/remove_test.go
+++ b/pkg/cluster/internal/kubeconfig/internal/kubeconfig/remove_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package kubeconfig
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -150,7 +150,7 @@ func TestRemoveKIND(t *testing.T) {
 
 func testRemoveKINDTrivial(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir("", "kind-testremovekind")
+	dir, err := os.MkdirTemp("", "kind-testremovekind")
 	if err != nil {
 		t.Fatalf("Failed to create tempdir: %d", err)
 	}
@@ -178,7 +178,7 @@ users:
     client-key-data: yep
 `
 	existingConfigPath := filepath.Join(dir, "existing-kubeconfig")
-	if err := ioutil.WriteFile(existingConfigPath, []byte(existingConfig), os.ModePerm); err != nil {
+	if err := os.WriteFile(existingConfigPath, []byte(existingConfig), os.ModePerm); err != nil {
 		t.Fatalf("Failed to create existing kubeconfig: %d", err)
 	}
 
@@ -192,7 +192,7 @@ users:
 	if err != nil {
 		t.Fatalf("Failed to open merged kubeconfig: %v", err)
 	}
-	contents, err := ioutil.ReadAll(f)
+	contents, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("Failed to read merged kubeconfig: %v", err)
 	}
@@ -206,7 +206,7 @@ preferences: {}
 func testRemoveKINDKeepOther(t *testing.T) {
 	// tests removing a kind cluster but keeping another cluster
 	t.Parallel()
-	dir, err := ioutil.TempDir("", "kind-testremovekind")
+	dir, err := os.MkdirTemp("", "kind-testremovekind")
 	if err != nil {
 		t.Fatalf("Failed to create tempdir: %d", err)
 	}
@@ -246,7 +246,7 @@ users:
     client-key-data: yep
 `
 	existingConfigPath := filepath.Join(dir, "existing-kubeconfig")
-	if err := ioutil.WriteFile(existingConfigPath, []byte(existingConfig), os.ModePerm); err != nil {
+	if err := os.WriteFile(existingConfigPath, []byte(existingConfig), os.ModePerm); err != nil {
 		t.Fatalf("Failed to create existing kubeconfig: %d", err)
 	}
 
@@ -260,7 +260,7 @@ users:
 	if err != nil {
 		t.Fatalf("Failed to open merged kubeconfig: %v", err)
 	}
-	contents, err := ioutil.ReadAll(f)
+	contents, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("Failed to read merged kubeconfig: %v", err)
 	}

--- a/pkg/cluster/internal/kubeconfig/internal/kubeconfig/write.go
+++ b/pkg/cluster/internal/kubeconfig/internal/kubeconfig/write.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubeconfig
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -38,7 +37,7 @@ func write(cfg *Config, configPath string) error {
 			return errors.Wrap(err, "failed to create directory for KUBECONFIG")
 		}
 	}
-	if err := ioutil.WriteFile(configPath, encoded, 0600); err != nil {
+	if err := os.WriteFile(configPath, encoded, 0600); err != nil {
 		return errors.Wrap(err, "failed to write KUBECONFIG")
 	}
 	return nil

--- a/pkg/cluster/internal/kubeconfig/internal/kubeconfig/write_test.go
+++ b/pkg/cluster/internal/kubeconfig/internal/kubeconfig/write_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package kubeconfig
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +32,7 @@ func TestWrite(t *testing.T) {
 
 func testWriteNoExistingFile(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir("", "kind-testwritemerged")
+	dir, err := os.MkdirTemp("", "kind-testwritemerged")
 	if err != nil {
 		t.Fatalf("Failed to create tempdir: %d", err)
 	}
@@ -85,7 +85,7 @@ func testWriteNoExistingFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to open merged kubeconfig: %v", err)
 	}
-	contents, err := ioutil.ReadAll(f)
+	contents, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("Failed to read merged kubeconfig: %v", err)
 	}

--- a/pkg/cluster/internal/logs/logs.go
+++ b/pkg/cluster/internal/logs/logs.go
@@ -20,7 +20,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -66,7 +65,7 @@ func untar(logger log.Logger, r io.Reader, dir string) (err error) {
 		case err == io.EOF:
 			// drain the reader, which may have trailing null bytes
 			// we don't want to leave the writer hanging
-			_, err := io.Copy(ioutil.Discard, r)
+			_, err := io.Copy(io.Discard, r)
 			return err
 		case err != nil:
 			return errors.Wrapf(err, "tar reading error: %v", err)

--- a/pkg/cluster/provider.go
+++ b/pkg/cluster/provider.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -235,7 +234,7 @@ func (p *Provider) CollectLogs(name, dir string) error {
 		return errors.Wrap(err, "failed to create logs directory")
 	}
 	// write kind version
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		filepath.Join(dir, "kind-version.txt"),
 		[]byte(version.DisplayVersion()),
 		0666, // match os.Create

--- a/pkg/cmd/kind/create/cluster/createcluster.go
+++ b/pkg/cmd/kind/create/cluster/createcluster.go
@@ -19,7 +19,6 @@ package cluster
 
 import (
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -132,7 +131,7 @@ func configOption(rawConfigFlag string, stdin io.Reader) (cluster.CreateOption, 
 		return cluster.CreateWithConfigFile(rawConfigFlag), nil
 	}
 	// otherwise read from stdin
-	raw, err := ioutil.ReadAll(stdin)
+	raw, err := io.ReadAll(stdin)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading config from stdin")
 	}

--- a/pkg/cmd/kind/root.go
+++ b/pkg/cmd/kind/root.go
@@ -19,7 +19,6 @@ package kind
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/spf13/cobra"
 
@@ -106,7 +105,7 @@ func runE(logger log.Logger, flags *flagpole, command *cobra.Command) error {
 	if flags.Quiet {
 		// NOTE: if we are coming from app.Run handling this flag is
 		// redundant, however it doesn't hurt, and this may be called directly.
-		maybeSetWriter(logger, ioutil.Discard)
+		maybeSetWriter(logger, io.Discard)
 	}
 	maybeSetVerbosity(logger, log.Level(flags.Verbosity))
 	// warn about deprecated flag if used

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -21,7 +21,6 @@ package fs
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -29,10 +28,10 @@ import (
 	"strings"
 )
 
-// TempDir is like ioutil.TempDir, but more docker friendly
+// TempDir is like os.MkdirTemp, but more docker friendly
 func TempDir(dir, prefix string) (name string, err error) {
 	// create a tempdir as normal
-	name, err = ioutil.TempDir(dir, prefix)
+	name, err = os.MkdirTemp(dir, prefix)
 	if err != nil {
 		return "", err
 	}
@@ -138,14 +137,18 @@ func copyDir(src, dst string, info os.FileInfo) error {
 		return err
 	}
 	// copy every source dir entry
-	entries, err := ioutil.ReadDir(src)
+	entries, err := os.ReadDir(src)
 	if err != nil {
 		return err
 	}
 	for _, entry := range entries {
 		entrySrc := filepath.Join(src, entry.Name())
 		entryDst := filepath.Join(dst, entry.Name())
-		if err := copy(entrySrc, entryDst, entry); err != nil {
+		fileInfo, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if err := copy(entrySrc, entryDst, fileInfo); err != nil {
 			return err
 		}
 	}

--- a/pkg/internal/apis/config/encoding/load.go
+++ b/pkg/internal/apis/config/encoding/load.go
@@ -18,7 +18,7 @@ package encoding
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 
 	yaml "gopkg.in/yaml.v3"
 
@@ -42,7 +42,7 @@ func Load(path string) (*config.Cluster, error) {
 	}
 
 	// read in file
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading file")
 	}

--- a/pkg/internal/env/term_test.go
+++ b/pkg/internal/env/term_test.go
@@ -19,7 +19,7 @@ package env
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"sigs.k8s.io/kind/pkg/internal/assert"
@@ -36,7 +36,7 @@ func TestIsTerminal(t *testing.T) {
 		t.Fatalf("IsTerminal should be false for bytes.Buffer")
 	}
 	// test a file
-	f, err := ioutil.TempFile("", "kind-isterminal")
+	f, err := os.CreateTemp("", "kind-isterminal")
 	if err != nil {
 		t.Fatalf("Failed to create tempfile %v", err)
 	}


### PR DESCRIPTION
Delete ioutil as it is Deprecated since Go 1.16
[ioutil info](https://cs.opensource.google/go/go/+/master:src/io/ioutil/ioutil.go).
```
// Deprecated: As of Go 1.16, the same functionality is now provided
// by package [io] or package [os], and those implementations
// should be preferred in new code.
// See the specific function documentation for details.
```

We can use os and io package for the same logic in the future.