### PR TITLE
Ensures that images are pulled from the insecure registry with http

### DIFF
--- a/site/content/docs/user/local-registry.md
+++ b/site/content/docs/user/local-registry.md
@@ -25,7 +25,7 @@ The registry can be used like this.
 1. First we'll pull an image `docker pull gcr.io/google-samples/hello-app:1.0`
 2. Then we'll tag the image to use the local registry `docker tag gcr.io/google-samples/hello-app:1.0 localhost:5001/hello-app:1.0`
 3. Then we'll push it to the registry `docker push localhost:5001/hello-app:1.0`
-4. And now we can use the image `kubectl create deployment hello-server --image=localhost:5001/hello-app:1.0`
+4. And now we can use the image `kubectl create deployment hello-server --image=kind-registry:5000/hello-app:1.0`
 
 If you build your own image and tag it like `localhost:5001/image:foo` and then use
-it in kubernetes as `localhost:5001/image:foo`. And use it from inside of your cluster application as `kind-registry:5000`.
+it in kubernetes as `kind-registry:5000/image:foo`. And use it from inside of your cluster application as `kind-registry:5000`.

--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -16,7 +16,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."${reg_name}:5000"]
     endpoint = ["http://${reg_name}:5000"]
 EOF
 
@@ -36,6 +36,7 @@ metadata:
 data:
   localRegistryHosting.v1: |
     host: "localhost:${reg_port}"
+    hostFromClusterNetwork: "${reg_name}:5000"
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
 


### PR DESCRIPTION
Related to https://github.com/kubernetes-sigs/kind/issues/110

## Motivation

Inside k8s, the images are pulled from the insecure registry using HTTPS while they should be pulled with HTTP.

## Modifications:

* Modifies the registry mirrors' configuration to ensure that images pulled from `kind-registry` are pulled using HTTP 
* Defines the value of `hostFromClusterNetwork` of the `localRegistryHosting`
* Updates the documentation consequently