### PR TITLE
ci: hack/release/get-contributors.sh: Fix incorrect token identification

### DIFF
--- a/hack/release/get-contributors.sh
+++ b/hack/release/get-contributors.sh
@@ -32,7 +32,7 @@ for contributor in "${contributors[@]}"; do
     # lookup the  commit info to get the login
     contributor_logins+=("$(curl \
         -sG \
-        ${GITHUB_OAUTH_TOKEN:+-H="Authorization: token ${GITHUB_OAUTH_TOKEN:?}"} \
+        ${GITHUB_OAUTH_TOKEN:+-H "Authorization: Bearer ${GITHUB_OAUTH_TOKEN:?}"} \
         --data-urlencode "q=${contributor}" \
         "https://api.github.com/repos/${ORG}/${REPO}/commits/${commit_for_contributor}" \
     | jq -r .author.login


### PR DESCRIPTION
Currently, TOKEN is set and not work