### PR TITLE
don't use digests for preloaded images

### DIFF
--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -20,7 +20,7 @@ package nodeimage
 The default CNI manifest and images are our own tiny kindnet
 */
 
-const kindnetdImage = "docker.io/kindest/kindnetd:v20230330-48f316cd@sha256:c19d6362a6a928139820761475a38c24c0cf84d507b9ddf414a078cf627497af"
+const kindnetdImage = "docker.io/kindest/kindnetd:v20230330-48f316cd"
 
 var defaultCNIImages = []string{kindnetdImage}
 

--- a/pkg/build/nodeimage/const_storage.go
+++ b/pkg/build/nodeimage/const_storage.go
@@ -25,8 +25,8 @@ NOTE: we have customized it in the following ways:
 - install as the default storage class
 */
 
-const storageProvisionerImage = "docker.io/kindest/local-path-provisioner:v0.0.23-kind.0@sha256:f2d0a02831ff3a03cf51343226670d5060623b43a4cfc4808bd0875b2c4b9501"
-const storageHelperImage = "docker.io/kindest/local-path-helper:v20230330-48f316cd@sha256:135203f2441f916fb13dad1561d27f60a6f11f50ec288b01a7d2ee9947c36270"
+const storageProvisionerImage = "docker.io/kindest/local-path-provisioner:v0.0.23-kind.0"
+const storageHelperImage = "docker.io/kindest/local-path-helper:v20230330-48f316cd"
 
 // image we need to preload
 var defaultStorageImages = []string{storageProvisionerImage, storageHelperImage}


### PR DESCRIPTION
The architecture specific digest will be recorded and they will need live access to the remote registry.
The images won't need a full pull but will need access to resolve the multi-arch digest => specific digest.

In offline situations or when the host has access to the registry but the kind nodes do not (e.g. proxy) this is a problem.

For now we just won't digest pin the set of images that are pre-loaded into the nodes.

fixes https://github.com/kubernetes-sigs/kind/issues/3173