### PR TITLE
doc: fix wrong implementation of creation of kong-ingress

### DIFF
--- a/site/content/docs/user/ingress.md
+++ b/site/content/docs/user/ingress.md
@@ -98,7 +98,7 @@ Apply kind specific patches to forward the `hostPorts` to the ingress controller
 Apply it by running:
 
 {{< codeFromInline lang="bash" >}}
-kubectl patch deployment -n kong ingress-kong -p '{{< minify file="static/examples/ingress/kong/deployment.patch.json" >}}'
+kubectl patch deployment -n kong proxy-kong -p '{{< minify file="static/examples/ingress/kong/deployment.patch.json" >}}'
 {{< /codeFromInline >}}
 
 Apply kind specific patch to change service type to `NodePort`:

--- a/site/static/examples/ingress/kong/deployment.patch.json
+++ b/site/static/examples/ingress/kong/deployment.patch.json
@@ -1,5 +1,6 @@
 {
   "spec": {
+    "replicas": 1,
     "template": {
       "spec": {
         "containers": [


### PR DESCRIPTION
1. The container proxy is in the deployment proxy-kong.
3. Set the value of replicas in deployment proxy-kong to 1 to ensure the hostPort can be allocated.