### PR TITLE
don't build kindnetd image in build job

### DIFF
--- a/hack/ci/build-all.sh
+++ b/hack/ci/build-all.sh
@@ -24,7 +24,3 @@ cd "${REPO_ROOT}"
 
 # build kind
 hack/release/build/cross.sh
-
-# build kindnetd
-cd "${REPO_ROOT}/images/kindnetd"
-make build


### PR DESCRIPTION
we have a post-submit build, if we need presubmit build we can add a dedicated job with appropriate resources

building this is slow and we rarely make changes, and we don't immediately pickup the results until kindnetd image reference is upgraded anyhow.