### PR TITLE
feat(providers): add error when cluster does not exist

### DIFF
--- a/pkg/cluster/internal/providers/docker/provider.go
+++ b/pkg/cluster/internal/providers/docker/provider.go
@@ -108,6 +108,10 @@ func (p *provider) ListClusters() ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list clusters")
 	}
+	// provide feedback to the user about cluster inexistence
+	if len(lines) == 0 {
+		return nil, errors.Errorf("cluster does not exist")
+	}
 	return sets.NewString(lines...).List(), nil
 }
 
@@ -124,6 +128,10 @@ func (p *provider) ListNodes(cluster string) ([]nodes.Node, error) {
 	lines, err := exec.OutputLines(cmd)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list nodes")
+	}
+	// provide feedback to the user about cluster inexistence
+	if len(lines) == 0 {
+		return nil, errors.Errorf("cluster does not exist")
 	}
 	// convert names to node handles
 	ret := make([]nodes.Node, 0, len(lines))

--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -114,6 +114,10 @@ func (p *provider) ListClusters() ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list clusters")
 	}
+	// provide feedback to the user about cluster inexistence
+	if len(lines) == 0 {
+		return nil, errors.Errorf("cluster does not exist")
+	}
 	return sets.NewString(lines...).List(), nil
 }
 
@@ -130,6 +134,10 @@ func (p *provider) ListNodes(cluster string) ([]nodes.Node, error) {
 	lines, err := exec.OutputLines(cmd)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list nodes")
+	}
+	// provide feedback to the user about cluster inexistence
+	if len(lines) == 0 {
+		return nil, errors.Errorf("cluster does not exist")
 	}
 	// convert names to node handles
 	ret := make([]nodes.Node, 0, len(lines))


### PR DESCRIPTION
When deleting clusters with `kind`, it could be nice to have a feedback from the application if the cluster was not found.
Sometimes happen that clusters remain up and running because no feedback is provided and at a first glance seems that the command did its job.
Here's the current behavior of kind when the cluster does not exist:
```
$ kind delete cluster --name cluster_does_not_exist
Deleting cluster "cluster_does_not_exist" ...
```
Here's how the feedback is given to the user with my implementation:
```
kind delete cluster --name cluster_does_not_exist
Deleting cluster "cluster_does_not_exist" ...
ERROR: failed to delete cluster "cluster_does_not_exist": error listing nodes: cluster does not exist
```