### PR TITLE
update local-path-provisioner to build latest version and use standar…

### DIFF
--- a/images/local-path-provisioner/Makefile
+++ b/images/local-path-provisioner/Makefile
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-VERSION=v0.0.23
-TAG=$(VERSION)-kind.0
+VERSION=v0.0.24
 EXTRA_BUILD_OPT=--build-arg=VERSION=$(VERSION)
 include $(CURDIR)/../Makefile.common.in


### PR DESCRIPTION
…d date-sha tags like the rest of the kind helper images

this will make the tag match with the local-path-provisioner when we e.g. bump the go version and ensures we don't keep building over the same tag