### PR TITLE
bump haproxy, kindnetd, local-path, base image

### DIFF
--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -20,7 +20,7 @@ package nodeimage
 The default CNI manifest and images are our own tiny kindnet
 */
 
-const kindnetdImage = "docker.io/kindest/kindnetd:v20230330-48f316cd"
+const kindnetdImage = "docker.io/kindest/kindnetd:v20230511-dc714da8"
 
 var defaultCNIImages = []string{kindnetdImage}
 

--- a/pkg/build/nodeimage/const_storage.go
+++ b/pkg/build/nodeimage/const_storage.go
@@ -25,8 +25,8 @@ NOTE: we have customized it in the following ways:
 - install as the default storage class
 */
 
-const storageProvisionerImage = "docker.io/kindest/local-path-provisioner:v0.0.23-kind.0"
-const storageHelperImage = "docker.io/kindest/local-path-helper:v20230330-48f316cd"
+const storageProvisionerImage = "docker.io/kindest/local-path-provisioner:v20230511-dc714da8"
+const storageHelperImage = "docker.io/kindest/local-path-helper:v20230510-486859a6"
 
 // image we need to preload
 var defaultStorageImages = []string{storageProvisionerImage, storageHelperImage}

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20230331-d9206d8a"
+const DefaultBaseImage = "docker.io/kindest/base:v20230512-4855a7f1"

--- a/pkg/cluster/internal/loadbalancer/const.go
+++ b/pkg/cluster/internal/loadbalancer/const.go
@@ -17,7 +17,7 @@ limitations under the License.
 package loadbalancer
 
 // Image defines the loadbalancer image:tag
-const Image = "docker.io/kindest/haproxy:v20230330-2f738c2@sha256:57f219951c0734d931e345b57c063e03e9cdcbb3aef02cfb5fa8c81a80f560f0"
+const Image = "docker.io/kindest/haproxy:v20230510-486859a6"
 
 // ConfigPath defines the path to the config file in the image
 const ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"


### PR DESCRIPTION
bumps all of the images recently updated to their latest builds