### PR TITLE
use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install kubectl
         run: |
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+          curl -LO https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
           chmod +x ./kubectl
           sudo mv ./kubectl /usr/local/bin/kubectl
 

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install kubectl
         run: |
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+          curl -LO https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
           chmod +x ./kubectl
           sudo mv ./kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
This commit updates the GitHub Actions workflows for Docker and Podman.
It modifies the installation command for kubectl to use the updated URL:
`https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl`.
This ensures that the latest version of kubectl is downloaded and installed during the workflow execution.

The previous URL `storage.googleapis.com/kubernetes-release` is being
replaced

#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396


Signed-off-by: Ricky Sadowski <richard.j.sadowski@gmail.com>