### PR TITLE
[WIP] DO NOT MERGE: testing runc 1.1.6

### DIFF
--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b"
+const Image = "kindest/node:v1.27.2@sha256:dfc3d4e956559d64fa5728f5b000acabf8a007a34c098d9f1efced0f2ecc7d60"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20230512-4855a7f1"
+const DefaultBaseImage = "docker.io/kindest/base:v20230519-a1cfca4e"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20230519-a1cfca4e"
+const DefaultBaseImage = "gcr.io/k8s-staging-kind/base:v20230519-a1cfca4e-runc_v1.1.6"

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -167,6 +167,11 @@ func commonArgs(cluster string, cfg *config.Cluster, networkName string, nodeNam
 		// this can be enabled by default in docker daemon.json, so we explicitly
 		// disable it, we want our entrypoint to be PID1, not docker-init / tini
 		"--init=false",
+		// note: requires API v1.41+ from Dec 2020 in Docker 20.10.0
+		// this is the default with cgroups v2 but not with cgroups v1, unless
+		// overridden in the daemon --default-cgroupns-mode
+		// https://github.com/docker/cli/pull/3699#issuecomment-1191675788
+		"--cgroupns=private",
 	}
 
 	// enable IPv6 if necessary

--- a/pkg/cluster/internal/providers/podman/OWNERS
+++ b/pkg/cluster/internal/providers/podman/OWNERS
@@ -1,13 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - amwat
   - aojea
   - BenTheElder
 approvers:
-  - amwat
   - aojea
   - BenTheElder
+emeritus_approvers:
+  - amwat
 
 labels:
   - area/provider/podman

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -136,6 +136,8 @@ func commonArgs(cfg *config.Cluster, networkName string, nodeNames []string) ([]
 		"--label", fmt.Sprintf("%s=%s", clusterLabelKey, cfg.Name),
 		// specify container implementation to systemd
 		"-e", "container=podman",
+		// this is the default in cgroupsv2 but not in v1
+		"--cgroupns=private",
 	}
 
 	// enable IPv6 if necessary


### PR DESCRIPTION
Image built with `make -C images/base push EXTRA_BUILD_OPT=--build-arg=RUNC_VERSION=v1.1.6 TAG=$(date +v%Y%m%d)-$(git describe --always --dirty)-runc_v1.1.6` for testing purposes, since I only get these failures in CI and not my local (cgroupsv2) environments.

(to do this yourself, also set REGISTRY=your-registry)

xref: #3220 / #3213 