### PR TITLE
enforce private cgroupns

### DIFF
--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b"
+const Image = "kindest/node:v1.27.2@sha256:dfc3d4e956559d64fa5728f5b000acabf8a007a34c098d9f1efced0f2ecc7d60"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20230512-4855a7f1"
+const DefaultBaseImage = "docker.io/kindest/base:v20230519-a1cfca4e"

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -167,6 +167,11 @@ func commonArgs(cluster string, cfg *config.Cluster, networkName string, nodeNam
 		// this can be enabled by default in docker daemon.json, so we explicitly
 		// disable it, we want our entrypoint to be PID1, not docker-init / tini
 		"--init=false",
+		// note: requires API v1.41+ from Dec 2020 in Docker 20.10.0
+		// this is the default with cgroups v2 but not with cgroups v1, unless
+		// overridden in the daemon --default-cgroupns-mode
+		// https://github.com/docker/cli/pull/3699#issuecomment-1191675788
+		"--cgroupns=private",
 	}
 
 	// enable IPv6 if necessary

--- a/pkg/cluster/internal/providers/podman/OWNERS
+++ b/pkg/cluster/internal/providers/podman/OWNERS
@@ -1,13 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - amwat
   - aojea
   - BenTheElder
 approvers:
-  - amwat
   - aojea
   - BenTheElder
+emeritus_approvers:
+  - amwat
 
 labels:
   - area/provider/podman

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -136,6 +136,8 @@ func commonArgs(cfg *config.Cluster, networkName string, nodeNames []string) ([]
 		"--label", fmt.Sprintf("%s=%s", clusterLabelKey, cfg.Name),
 		// specify container implementation to systemd
 		"-e", "container=podman",
+		// this is the default in cgroupsv2 but not in v1
+		"--cgroupns=private",
 	}
 
 	// enable IPv6 if necessary


### PR DESCRIPTION
Docker's had an option for this since 20.10.0 (https://docs.docker.com/engine/release-notes/20.10/#20100) but last time we looked at this that was too recent.

20.10.0 was released 2020-12-08 (2.5 years ago) and I think we can afford to require it now.

Podman added this in https://github.com/containers/podman/pull/3509 circa July 8th, 2019 which appears to be tagged all the way back to v1.5.0, so it should be available in all working podman versions anyhow.

Tentatively this should resolve issues with #3223, but it first requires #3240.
More generally this makes the node cgroups much easier to deal with.