### PR TITLE
bump images with containerd 1.7.1

### DIFF
--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.27.2@sha256:dfc3d4e956559d64fa5728f5b000acabf8a007a34c098d9f1efced0f2ecc7d60"
+const Image = "kindest/node:v1.27.2@sha256:f8c4cbfb438b777ad84c2707efee91571294593a871071486369229102411e20"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20230519-a1cfca4e"
+const DefaultBaseImage = "docker.io/kindest/base:v20230523-4ec19579"


### PR DESCRIPTION
replaces https://github.com/kubernetes-sigs/kind/pull/3250