### PR TITLE
upgrade base/node image

### DIFF
--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.27.2@sha256:f8c4cbfb438b777ad84c2707efee91571294593a871071486369229102411e20"
+const Image = "kindest/node:v1.27.2@sha256:ee77a85d1146ba4f1df9f836c828845a7dbe1f1a094ee670879d7c14f41e31f2"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20230523-4ec19579"
+const DefaultBaseImage = "docker.io/kindest/base:v20230525-4c49613f"


### PR DESCRIPTION
picks up #3255 
fixes #3223 (well #3255 is the main fix but this is what actually moves us to 1.1.7 and finishes shipping that PR)