### PR TITLE
Remove `-sf 7` from haproxy image entrypoint

### DIFF
--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -62,4 +62,4 @@ COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
 
 # below roughly matches the standard haproxy image
 STOPSIGNAL SIGUSR1
-ENTRYPOINT ["haproxy", "-sf", "7", "-W", "-db", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]
+ENTRYPOINT ["haproxy", "-W", "-db", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]


### PR DESCRIPTION
Remove `-sf 7` from the haproxy entrypoint. This arg caused an issue in the Cluster API e2e tests causing the load balancer to exit prematurely. More info on the CAPI issue: https://github.com/kubernetes-sigs/cluster-api/issues/8641 