### PR TITLE
fix host network mode boot cluster failure

### DIFF
--- a/pkg/cluster/internal/providers/docker/provider.go
+++ b/pkg/cluster/internal/providers/docker/provider.go
@@ -166,6 +166,21 @@ func (p *provider) GetAPIServerEndpoint(cluster string) (string, error) {
 		return "", errors.Wrap(err, "failed to get api server endpoint")
 	}
 
+	{
+		cmd := exec.Command(
+			"docker", "inspect",
+			"--format", `{{ .HostConfig.NetworkMode }}`,
+			n.String(),
+		)
+		lines, err := exec.OutputLines(cmd)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to get api server port")
+		}
+		if len(lines) == 1 && lines[0] == "host" {
+			return "127.0.0.1:6443", nil
+		}
+	}
+
 	// if the 'desktop.docker.io/ports/<PORT>/tcp' label is present,
 	// defer to its value for the api server endpoint
 	//

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -108,6 +108,10 @@ func planCreation(cfg *config.Cluster, networkName string) (createContainerFuncs
 						ContainerPort: common.APIServerInternalPort,
 					},
 				)
+
+				if networkName == "host" {
+					genericArgs = append(genericArgs, "--add-host", fmt.Sprintf("%s:127.0.0.1", name))
+				}
 				args, err := runArgsForNode(node, cfg.Networking.IPFamily, name, genericArgs)
 				if err != nil {
 					return err


### PR DESCRIPTION
KIND_EXPERIMENTAL_DOCKER_NETWORK=host doesn't work because the DNS cannot be resolved in container.