### PR TITLE
site: simplify ingress example

### DIFF
--- a/site/content/docs/user/ingress.md
+++ b/site/content/docs/user/ingress.md
@@ -149,8 +149,8 @@ Refer [Using Ingress](#using-ingress) for a basic example usage.
 
 ## Using Ingress
 
-The following example creates simple http-echo services
-and an Ingress object to route to these services.
+The following example creates a simple agnhost service
+and an Ingress object to route to that service.
 
 ```yaml
 {{% readFile "static/examples/ingress/usage.yaml" %}}
@@ -165,8 +165,6 @@ kubectl apply -f {{< absURL "examples/ingress/usage.yaml" >}}
 Now verify that the ingress works
 
 {{< codeFromInline lang="bash" >}}
-# should output "foo-app"
-curl localhost/foo/hostname
-# should output "bar-app"
-curl localhost/bar/hostname
+# should output "agnhost"
+curl http://localhost/hostname
 {{< /codeFromInline >}}

--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -1,9 +1,9 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  name: foo-app
+  name: agnhost
   labels:
-    app: foo
+    app: agnhost
 spec:
   containers:
   - command:
@@ -17,37 +17,10 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: foo-service
+  name: agnhost-service
 spec:
   selector:
-    app: foo
-  ports:
-  # Default port used by the image
-  - port: 8080
----
-kind: Pod
-apiVersion: v1
-metadata:
-  name: bar-app
-  labels:
-    app: bar
-spec:
-  containers:
-  - command:
-    - /agnhost
-    - netexec
-    - --http-port
-    - "8080"
-    image: registry.k8s.io/e2e-test-images/agnhost:2.39
-    name: bar-app
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: bar-service
-spec:
-  selector:
-    app: bar
+    app: agnhost
   ports:
   # Default port used by the image
   - port: 8080
@@ -56,24 +29,15 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   rules:
   - http:
       paths:
       - pathType: Prefix
-        path: /foo(/|$)(.*)
+        path: /
         backend:
           service:
-            name: foo-service
-            port:
-              number: 8080
-      - pathType: Prefix
-        path: /bar(/|$)(.*)
-        backend:
-          service:
-            name: bar-service
+            name: agnhost-service
             port:
               number: 8080
 ---


### PR DESCRIPTION
Simplifies the ingress example to use a single
rule with basic prefix matching and no impl-
specific annotations.

Closes #3181.