### PR TITLE
Fixed Documentation Bug

### DIFF
--- a/site/static/examples/ingress/kong/deployment.patch.json
+++ b/site/static/examples/ingress/kong/deployment.patch.json
@@ -10,7 +10,7 @@
               {
                 "containerPort": 8000,
                 "hostPort": 80,
-                "name": "proxy",
+                "name": "proxy-tcp",
                 "protocol": "TCP"
               },
               {


### PR DESCRIPTION
I updated the Kubernetes Deployment object for "proxy-kong" by applying the following patch that fixes #3265 .

Explanation:
The error you encountered was due to a duplicate value for the name of the second port in the Kubernetes Deployment object. To resolve this, I have made the following changes:

Port Name: The second port is named "proxy-tcp" (instead of "proxy") to ensure uniqueness.
These unique names for the ports will resolve the duplicate value error when applying the patch to the Deployment object.