### PR TITLE
skip setting up default pod subnet when disabling default CNI

### DIFF
--- a/pkg/apis/config/v1alpha4/default.go
+++ b/pkg/apis/config/v1alpha4/default.go
@@ -47,8 +47,8 @@ func SetDefaultsCluster(obj *Cluster) {
 			obj.Networking.APIServerAddress = "::1"
 		}
 	}
-	// default the pod CIDR
-	if obj.Networking.PodSubnet == "" {
+	// default the pod CIDR if not disabling default CNI
+	if obj.Networking.PodSubnet == "" && !obj.Networking.DisableDefaultCNI {
 		obj.Networking.PodSubnet = "10.244.0.0/16"
 		if obj.Networking.IPFamily == IPv6Family {
 			// node-mask cidr default is /64 so we need a larger subnet, we use /56 following best practices

--- a/pkg/internal/apis/config/default.go
+++ b/pkg/internal/apis/config/default.go
@@ -60,8 +60,8 @@ func SetDefaultsCluster(obj *Cluster) {
 		}
 	}
 
-	// default the pod CIDR
-	if obj.Networking.PodSubnet == "" {
+	// default the pod CIDR if not disabling default CNI
+	if obj.Networking.PodSubnet == "" && !obj.Networking.DisableDefaultCNI {
 		obj.Networking.PodSubnet = "10.244.0.0/16"
 		if obj.Networking.IPFamily == IPv6Family {
 			// node-mask cidr default is /64 so we need a larger subnet, we use /56 following best practices

--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -53,8 +53,10 @@ func (c *Cluster) Validate() error {
 	}
 
 	// podSubnet should be a valid CIDR
-	if err := validateSubnets(c.Networking.PodSubnet, c.Networking.IPFamily); err != nil {
-		errs = append(errs, errors.Errorf("invalid pod subnet %v", err))
+	if !c.Networking.DisableDefaultCNI {
+		if err := validateSubnets(c.Networking.PodSubnet, c.Networking.IPFamily); err != nil {
+			errs = append(errs, errors.Errorf("invalid pod subnet %v", err))
+		}
 	}
 
 	// serviceSubnet should be a valid CIDR


### PR DESCRIPTION
default pod subnet is optional in kubernetes. the default subnet brought into kubelet/kube-proxy can bring extra NAT rules in kind node for service and bring unexpected troubles for custom cni.

here is the default NAT rule in kind node:

```
KUBE-MARK-MASQ  all  -- !10.244.0.0/16        anywhere             /* Kubernetes service cluster ip + port for masquerade purpose */ match-set KUBE-CLUSTER-IP dst,dst
```