### PR TITLE
Switch to debian bookworm as base image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -20,7 +20,7 @@
 # start from debian slim, this image is reasonably small as a starting point
 # for a kubernetes node image, it doesn't contain much (anything?) we don't need
 # this stage will install basic files and packages
-ARG BASE_IMAGE=debian:bullseye-slim
+ARG BASE_IMAGE=debian:bookworm-slim
 FROM $BASE_IMAGE as base
 
 # copy in static files

--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -15,7 +15,7 @@
 # This image is a haproxy image + minimal config so the container will not exit
 # while we rewrite the config at runtime and signal haproxy to reload.
 
-ARG BASE="registry.k8s.io/build-image/debian-base:bullseye-v1.4.3"
+ARG BASE="registry.k8s.io/build-image/debian-base:bookworm-v1.0.0"
 FROM ${BASE} as build
 
 # NOTE: copyrights.tar.gz is a quirk of Kubernetes's debian-base image
@@ -50,7 +50,7 @@ RUN mkdir -p "${STAGE_DIR}" && \
 
 # See: https://github.com/GoogleContainerTools/distroless/tree/main/base
 # This has /etc/passwd, tzdata, cacerts
-FROM "gcr.io/distroless/static-debian11"
+FROM "gcr.io/distroless/static-debian12"
 
 ARG STAGE_DIR="/opt/stage"
 

--- a/images/local-path-helper/Dockerfile
+++ b/images/local-path-helper/Dockerfile
@@ -15,7 +15,7 @@
 # This image is contains the binaries needed for the local-path-provisioner
 # helper pod. Currently that means: sh, rm, mkdir
 
-ARG BASE="registry.k8s.io/build-image/debian-base:bullseye-v1.4.3"
+ARG BASE="registry.k8s.io/build-image/debian-base:bookworm-v1.0.0"
 FROM ${BASE} as build
 
 # NOTE: copyrights.tar.gz is a quirk of Kubernetes's debian-base image
@@ -42,6 +42,6 @@ RUN mkdir -p "${STAGE_DIR}" && \
     find "${STAGE_DIR}"
 
 # copy staged binary + deps + copyright into distroless
-FROM "gcr.io/distroless/static-debian11"
+FROM "gcr.io/distroless/static-debian12"
 ARG STAGE_DIR="/opt/stage"
 COPY --from=build "${STAGE_DIR}/" /

--- a/images/local-path-provisioner/Dockerfile
+++ b/images/local-path-provisioner/Dockerfile
@@ -27,7 +27,7 @@ RUN eval "$(gimme "${GO_VERSION}")" \
     && GOBIN=/usr/local/bin go install github.com/google/go-licenses@latest \
     && GOARCH=$TARGETARCH go-licenses save --save_path=/_LICENSES .
 
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base-debian12
 COPY --from=0 /usr/local/bin/local-path-provisioner /usr/local/bin/local-path-provisioner
 COPY --from=0 /_LICENSES/* /LICENSES/
 COPY --chmod=0644 files/LICENSES/* /LICENSES/*


### PR DESCRIPTION
Use the latest debian distribution for the haproxy and local-path-helper images.

Required by https://github.com/kubernetes/kubernetes/pull/118996