### PR TITLE
Add argument to control passing proxy envs from host

### DIFF
--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -35,7 +35,7 @@ import (
 )
 
 // planCreation creates a slice of funcs that will create the containers
-func planCreation(cfg *config.Cluster, networkName string) (createContainerFuncs []func() error, err error) {
+func planCreation(cfg *config.Cluster, networkName string, noEnvPass bool) (createContainerFuncs []func() error, err error) {
 	// these apply to all container creation
 	nodeNamer := common.MakeNodeNamer(cfg.Name)
 	names := make([]string, len(cfg.Nodes))
@@ -47,7 +47,7 @@ func planCreation(cfg *config.Cluster, networkName string) (createContainerFuncs
 	if haveLoadbalancer {
 		names = append(names, nodeNamer(constants.ExternalLoadBalancerNodeRoleValue))
 	}
-	genericArgs, err := commonArgs(cfg, networkName, names)
+	genericArgs, err := commonArgs(cfg, networkName, names, noEnvPass)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func planCreation(cfg *config.Cluster, networkName string) (createContainerFuncs
 }
 
 // commonArgs computes static arguments that apply to all containers
-func commonArgs(cfg *config.Cluster, networkName string, nodeNames []string) ([]string, error) {
+func commonArgs(cfg *config.Cluster, networkName string, nodeNames []string, noEnvPass bool) ([]string, error) {
 	// standard arguments all nodes containers need, computed once
 	args := []string{
 		"--detach",           // run the container detached
@@ -158,6 +158,16 @@ func commonArgs(cfg *config.Cluster, networkName string, nodeNames []string) ([]
 	// https://github.com/kubernetes-sigs/kind/issues/1416#issuecomment-606514724
 	if mountDevMapper() {
 		args = append(args, "--volume", "/dev/mapper:/dev/mapper")
+	}
+
+	if !noEnvPass {
+		proxyEnv, err := getProxyEnv(cfg, networkName, nodeNames)
+		if err != nil {
+			return nil, errors.Wrap(err, "proxy setup error")
+		}
+		for key, val := range proxyEnv {
+			args = append(args, "-e", fmt.Sprintf("%s=%s", key, val))
+		}
 	}
 
 	// rootless: use fuse-overlayfs by default

--- a/site/layouts/shortcodes/codeFromFile.html
+++ b/site/layouts/shortcodes/codeFromFile.html
@@ -12,7 +12,7 @@
       <th>
         <a href="/{{ $virtualPath }}">{{ $virtualPath }}</a>
         <button onclick='copyText("code-{{ $virtualPath }}-hidden-copy-text", "button-{{ $virtualPath }}");' title="Copy to clipboard">
-          <img src="site/static/copycode.svg" alt="Copy">
+          &#128203; <!-- Initial copy button icon -->
         </button>
         
         <span class="copy-success" id="button-{{ $virtualPath }}-success"></span>

--- a/site/layouts/shortcodes/codeFromFile.html
+++ b/site/layouts/shortcodes/codeFromFile.html
@@ -11,9 +11,11 @@
     <tr>
       <th>
         <a href="/{{ $virtualPath }}">{{ $virtualPath }}</a>
-        <button onclick='copyText("code-{{ $virtualPath }}-hidden-copy-text");' title="Copy to clipboard">
+        <button onclick='copyText("code-{{ $virtualPath }}-hidden-copy-text", "button-{{ $virtualPath }}");' title="Copy to clipboard">
           <img src="{{ "copycode.svg" | relURL }}" alt="Copy">
+          <img src="{{ "tick.svg" | relURL }}" alt="Tick" class="hidden-tick" id="button-{{ $virtualPath }}-tick">
         </button>
+        <span class="copy-success" id="button-{{ $virtualPath }}-success"></span>
       </th>
     </tr>
   </thead>
@@ -24,3 +26,18 @@
   </tbody>
   <textarea class="hidden-copy-text" id="code-{{ $virtualPath }}-hidden-copy-text">{{ ($file | readFile) }}</textarea>
 </table>
+
+<script>
+  function copyText(elementId, successElementId) {
+    const textarea = document.getElementById(elementId);
+    textarea.select();
+    document.execCommand("copy");
+  
+    // Add visual confirmation
+    const tickElement = document.getElementById(`${successElementId}-tick`);
+    tickElement.classList.remove("hidden-tick");
+    setTimeout(() => {
+      tickElement.classList.add("hidden-tick");
+    }, 2000);
+  }
+  </script>

--- a/site/layouts/shortcodes/codeFromFile.html
+++ b/site/layouts/shortcodes/codeFromFile.html
@@ -12,9 +12,9 @@
       <th>
         <a href="/{{ $virtualPath }}">{{ $virtualPath }}</a>
         <button onclick='copyText("code-{{ $virtualPath }}-hidden-copy-text", "button-{{ $virtualPath }}");' title="Copy to clipboard">
-          <img src="{{ "copycode.svg" | relURL }}" alt="Copy">
-          <img src="{{ "tick.svg" | relURL }}" alt="Tick" class="hidden-tick" id="button-{{ $virtualPath }}-tick">
+          <img src="site/static/copycode.svg" alt="Copy">
         </button>
+        
         <span class="copy-success" id="button-{{ $virtualPath }}-success"></span>
       </th>
     </tr>

--- a/site/layouts/shortcodes/codeFromFile.html
+++ b/site/layouts/shortcodes/codeFromFile.html
@@ -1,11 +1,11 @@
 {{ $file := .Get "file" }}
 {{ $lang := "" }}
 {{ $suffix := findRE "(\\.[^.]+)$" $file 1 }}
-{{ with  $suffix }}
-{{ $lang = (index . 0 | strings.TrimPrefix ".") }}
+{{ with $suffix }}
+  {{ $lang = (index . 0 | strings.TrimPrefix ".") }}
 {{ end }}
 {{ with .Get "lang" }}{{ $lang = . }}{{ end }}
-{{ $virtualPath :=  strings.TrimPrefix `static/` $file }}
+{{ $virtualPath := strings.TrimPrefix "static/" $file }}
 <table class="includecode" id="code-{{ $virtualPath }}">
   <thead>
     <tr>
@@ -21,10 +21,10 @@
   </thead>
   <tbody>
     <tr>
-      <td>{{- highlight (trim ($file | readFile) "\n") $lang "" | -}}</td>
+      <td>{{- highlight (trim ($file | readFile) "\n") $lang "" -}}</td>
     </tr>
   </tbody>
-  <textarea class="hidden-copy-text" id="code-{{ $virtualPath }}-hidden-copy-text">{{ ($file | readFile) }}</textarea>
+  <textarea class="hidden-copy-text" id="code-{{ $virtualPath }}-hidden-copy-text">{{ $file | readFile }}</textarea>
 </table>
 
 <script>
@@ -40,4 +40,4 @@
       tickElement.classList.add("hidden-tick");
     }, 2000);
   }
-  </script>
+</script>

--- a/site/layouts/shortcodes/codeFromInline.html
+++ b/site/layouts/shortcodes/codeFromInline.html
@@ -7,8 +7,9 @@
   <tr>
     <th>
       <button id="copy-button-inline-code-{{ $hash }}" onclick='copyText("inline-code-{{ $hash }}-hidden-copy-text", "copy-button-inline-code-{{ $hash }}");' title="Copy to clipboard">
-        &#128203; <!-- Initial copy button icon -->
+        <img src="site/static/copycode.svg" alt="Copy">
       </button>
+      
     </th>
   </tr>
   </thead>
@@ -28,7 +29,7 @@
   
     // Add visual confirmation
     const button = document.getElementById(buttonId);
-    button.innerHTML = "&#10004; Copied";
+    button.innerHTML = "&#10003; Copied";
     setTimeout(() => {
       button.innerHTML = "&#128203;"; // Reset the button text after a delay
     }, 2000);

--- a/site/layouts/shortcodes/codeFromInline.html
+++ b/site/layouts/shortcodes/codeFromInline.html
@@ -6,8 +6,8 @@
   <thead>
   <tr>
     <th>
-      <button onclick='copyText("inline-code-{{ $hash }}-hidden-copy-text");' title="Copy to clipboard">
-        <img src="{{ "copycode.svg" | relURL }}" alt="Copy">
+      <button id="copy-button-inline-code-{{ $hash }}" onclick='copyText("inline-code-{{ $hash }}-hidden-copy-text");' title="Copy to clipboard">
+        &#128203; <!-- Initial copy button icon -->
       </button>
     </th>
   </tr>
@@ -19,3 +19,18 @@
   </tbody>
   <textarea class="hidden-copy-text" id="inline-code-{{ $hash }}-hidden-copy-text">{{ $code }}</textarea>
 </table>
+
+<script>
+  function copyText(elementId) {
+    const textarea = document.getElementById(elementId);
+    textarea.select();
+    document.execCommand("copy");
+  
+    // Add visual confirmation
+    const button = document.getElementById(`copy-button-${elementId}`);
+    button.innerHTML = "&#10004; Copied";
+    setTimeout(() => {
+      button.innerHTML = "&#128203;"; // Reset the button text after a delay
+    }, 2000);
+  }
+  </script>

--- a/site/layouts/shortcodes/codeFromInline.html
+++ b/site/layouts/shortcodes/codeFromInline.html
@@ -7,7 +7,7 @@
   <tr>
     <th>
       <button id="copy-button-inline-code-{{ $hash }}" onclick='copyText("inline-code-{{ $hash }}-hidden-copy-text", "copy-button-inline-code-{{ $hash }}");' title="Copy to clipboard">
-        <img src="site/static/copycode.svg" alt="Copy">
+        &#128203; <!-- Initial copy button icon -->
       </button>
       
     </th>

--- a/site/layouts/shortcodes/codeFromInline.html
+++ b/site/layouts/shortcodes/codeFromInline.html
@@ -1,4 +1,4 @@
-{{ $code := trim .Inner  "\n"  }}
+{{ $code := trim .Inner "\n" }}
 {{ $lang := "" }}
 {{ with .Get "lang" }}{{ $lang = . }}{{ end }}
 {{ $hash := md5 $code }}
@@ -6,7 +6,7 @@
   <thead>
   <tr>
     <th>
-      <button id="copy-button-inline-code-{{ $hash }}" onclick='copyText("inline-code-{{ $hash }}-hidden-copy-text");' title="Copy to clipboard">
+      <button id="copy-button-inline-code-{{ $hash }}" onclick='copyText("inline-code-{{ $hash }}-hidden-copy-text", "copy-button-inline-code-{{ $hash }}");' title="Copy to clipboard">
         &#128203; <!-- Initial copy button icon -->
       </button>
     </th>
@@ -21,16 +21,16 @@
 </table>
 
 <script>
-  function copyText(elementId) {
+  function copyText(elementId, buttonId) {
     const textarea = document.getElementById(elementId);
     textarea.select();
     document.execCommand("copy");
   
     // Add visual confirmation
-    const button = document.getElementById(`copy-button-${elementId}`);
+    const button = document.getElementById(buttonId);
     button.innerHTML = "&#10004; Copied";
     setTimeout(() => {
       button.innerHTML = "&#128203;"; // Reset the button text after a delay
     }, 2000);
   }
-  </script>
+</script>


### PR DESCRIPTION
Added argument to control passing proxy envs from host #3293

Here I added a new feature to kind that allows users to control the passing of proxy environment variables to containers. By introducing a --no-env-pass argument, users can disable the inclusion of proxy environment variables when creating kind clusters. This gives users more control over their development environment, especially when proxy settings may interfere with cluster functionality.
