### PR TITLE
ExtraPortMapping Validation

### DIFF
--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -102,9 +102,10 @@ func planCreation(cfg *config.Cluster, networkName string) (createContainerFuncs
 						ListenAddress: apiServerAddress,
 						HostPort:      apiServerPort,
 						ContainerPort: common.APIServerInternalPort,
+						Protocol:      config.PortMappingProtocolTCP,
 					},
 				)
-				args, err := runArgsForNode(node, cfg.Networking.IPFamily, name, genericArgs)
+				args, err := runArgsForNode(node, name, genericArgs)
 				if err != nil {
 					return err
 				}
@@ -112,7 +113,7 @@ func planCreation(cfg *config.Cluster, networkName string) (createContainerFuncs
 			})
 		case config.WorkerRole:
 			createContainerFuncs = append(createContainerFuncs, func() error {
-				args, err := runArgsForNode(node, cfg.Networking.IPFamily, name, genericArgs)
+				args, err := runArgsForNode(node, name, genericArgs)
 				if err != nil {
 					return err
 				}
@@ -173,7 +174,7 @@ func commonArgs(cfg *config.Cluster, networkName string, nodeNames []string) ([]
 	return args, nil
 }
 
-func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, name string, args []string) ([]string, error) {
+func runArgsForNode(node *config.Node, name string, args []string) ([]string, error) {
 	// Pre-create anonymous volumes to enable specifying mount options
 	// during container run time
 	varVolume, err := createAnonymousVolume(name)
@@ -214,7 +215,7 @@ func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, n
 
 	// convert mounts and port mappings to container run args
 	args = append(args, generateMountBindings(node.ExtraMounts...)...)
-	mappingArgs, err := generatePortMappings(clusterIPFamily, node.ExtraPortMappings...)
+	mappingArgs, err := generatePortMappings(node.ExtraPortMappings...)
 	if err != nil {
 		return nil, err
 	}
@@ -240,13 +241,12 @@ func runArgsForLoadBalancer(cfg *config.Cluster, name string, args []string) ([]
 	)
 
 	// load balancer port mapping
-	mappingArgs, err := generatePortMappings(cfg.Networking.IPFamily,
-		config.PortMapping{
-			ListenAddress: cfg.Networking.APIServerAddress,
-			HostPort:      cfg.Networking.APIServerPort,
-			ContainerPort: common.APIServerInternalPort,
-		},
-	)
+	mappingArgs, err := generatePortMappings(config.PortMapping{
+		ListenAddress: cfg.Networking.APIServerAddress,
+		HostPort:      cfg.Networking.APIServerPort,
+		ContainerPort: common.APIServerInternalPort,
+		Protocol:      config.PortMappingProtocolTCP,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -370,25 +370,9 @@ func generateMountBindings(mounts ...config.Mount) []string {
 }
 
 // generatePortMappings converts the portMappings list to a list of args for podman
-func generatePortMappings(clusterIPFamily config.ClusterIPFamily, portMappings ...config.PortMapping) ([]string, error) {
+func generatePortMappings(portMappings ...config.PortMapping) ([]string, error) {
 	args := make([]string, 0, len(portMappings))
 	for _, pm := range portMappings {
-		// do provider internal defaulting
-		// in a future API revision we will handle this at the API level and remove this
-		if pm.ListenAddress == "" {
-			switch clusterIPFamily {
-			case config.IPv4Family, config.DualStackFamily:
-				pm.ListenAddress = "0.0.0.0"
-			case config.IPv6Family:
-				pm.ListenAddress = "::"
-			default:
-				return nil, errors.Errorf("unknown cluster IP family: %v", clusterIPFamily)
-			}
-		}
-		if string(pm.Protocol) == "" {
-			pm.Protocol = config.PortMappingProtocolTCP // TCP is the default
-		}
-
 		// validate that the provider can handle this binding
 		switch pm.Protocol {
 		case config.PortMappingProtocolTCP:


### PR DESCRIPTION
Using random host ports for validating extra port mapping defined without host ports  (default behaviour for provider docker and podman)

Fixes #3301