### PR TITLE
Use `ImplementationSpecific` instead of `Prefix` for pathType example

### DIFF
--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -62,14 +62,14 @@ spec:
   rules:
   - http:
       paths:
-      - pathType: Prefix
+      - pathType: ImplementationSpecific
         path: /foo(/|$)(.*)
         backend:
           service:
             name: foo-service
             port:
               number: 8080
-      - pathType: Prefix
+      - pathType: ImplementationSpecific
         path: /bar(/|$)(.*)
         backend:
           service:


### PR DESCRIPTION
Since the example is using a regular express to match more than the prefix I think the recommendation would be to use
`ImplementationSpecific` instead.  You receive:

```
❯ k apply -f ingress.yml 
Warning: path /httpbin(/|$)(.*) cannot be used with pathType Prefix
```

When doing that.