### PR TITLE
update images

### DIFF
--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -20,7 +20,7 @@ package nodeimage
 The default CNI manifest and images are our own tiny kindnet
 */
 
-const kindnetdImage = "docker.io/kindest/kindnetd:v20230511-dc714da8"
+const kindnetdImage = "docker.io/kindest/kindnetd:v20230809-80a64d96"
 
 var defaultCNIImages = []string{kindnetdImage}
 

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20230525-4c49613f"
+const DefaultBaseImage = "docker.io/kindest/base:v20230831-c80399bf"


### PR DESCRIPTION
picks up #3342 and #3327, for CI where we build node images. does not currently contain a node image bump