### PR TITLE
Fix haproxy image build

### DIFF
--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -28,7 +28,7 @@ RUN [ ! -f /usr/share/copyrights.tar.gz ] || tar -C / -xzvf /usr/share/copyright
 # - bash (ldd is a bash script and debian-base removes bash)
 # - procps (for `kill` which kind needs)
 RUN apt update && \
-    apt install -y --no-install-recommends haproxy=2.2.\* \
+    apt install -y --no-install-recommends haproxy=2.6.\* \
       procps bash
 
 # copy in script for staging distro provided binary to distroless


### PR DESCRIPTION
Inherited from:

- https://github.com/kubernetes/release/pull/3235
- https://github.com/kubernetes/release/pull/3237

As well as bumping the haproxy version.

Tested via:

```
docker buildx build --platform=linux/amd64,linux/arm64  --progress=auto -t gcr.io/k8s-staging-kind/haproxy:v20230905-7dc7aad7 --pull --build-arg GO_VERSION=1.20.4  .
```

Follow-up of https://github.com/kubernetes-sigs/kind/pull/3294