### PR TITLE
Added iptables switch

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -228,6 +228,9 @@ COPY --from=build / /
 # first tell systemd that it is in docker (it will check for the container env)
 # https://systemd.io/CONTAINER_INTERFACE/
 ENV container docker
+# override the default iptables mode.
+# possible values are: legacy, nf_tables, auto
+ENV IPTABLES_MODE=auto 
 # systemd exits on SIGRTMIN+3, not SIGTERM (which re-executes it)
 # https://bugzilla.redhat.com/show_bug.cgi?id=1201657
 STOPSIGNAL SIGRTMIN+3

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -413,15 +413,26 @@ fix_product_uuid() {
 }
 
 select_iptables() {
-  # based on: https://github.com/kubernetes-sigs/iptables-wrappers/blob/97b01f43a8e8db07840fc4b95e833a37c0d36b12/iptables-wrapper-installer.sh
   local mode num_legacy_lines num_nft_lines
-  num_legacy_lines=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep -c '^-' || true)
-  num_nft_lines=$( (timeout 5 sh -c "iptables-nft-save; ip6tables-nft-save" || true) 2>/dev/null | grep -c '^-' || true)
-  if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
-    mode=legacy
-  else
-    mode=nft
-  fi
+  case "${IPTABLES_MODE}" in
+    "legacy")
+      mode=legacy
+    ;;
+    "nf_tables")
+      mode=nft
+    ;;
+    *)
+      # based on: https://github.com/kubernetes-sigs/iptables-wrappers/blob/97b01f43a8e8db07840fc4b95e833a37c0d36b12/iptables-wrapper-installer.sh
+      num_legacy_lines=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep -c '^-' || true)
+      num_nft_lines=$( (timeout 5 sh -c "iptables-nft-save; ip6tables-nft-save" || true) 2>/dev/null | grep -c '^-' || true)
+      if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
+        mode=legacy
+      else
+        mode=nft
+      fi    
+    ;;
+  esac
+  
   log_info "setting iptables to detected mode: ${mode}"
   update-alternatives --set iptables "/usr/sbin/iptables-${mode}" > /dev/null
   update-alternatives --set ip6tables "/usr/sbin/ip6tables-${mode}" > /dev/null

--- a/pkg/apis/config/v1alpha4/default.go
+++ b/pkg/apis/config/v1alpha4/default.go
@@ -76,6 +76,10 @@ func SetDefaultsCluster(obj *Cluster) {
 	if obj.Networking.KubeProxyMode == "" {
 		obj.Networking.KubeProxyMode = IPTablesProxyMode
 	}
+	// default the iptablesMode to auto
+	if obj.Networking.IptablesMode == "" {
+		obj.Networking.IptablesMode = AutoIptablesMode
+	}
 }
 
 // SetDefaultsNode sets uninitialized fields to their default value.

--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -191,6 +191,9 @@ type Networking struct {
 	KubeProxyMode ProxyMode `yaml:"kubeProxyMode,omitempty" json:"kubeProxyMode,omitempty"`
 	// DNSSearch defines the DNS search domain to use for nodes. If not set, this will be inherited from the host.
 	DNSSearch *[]string `yaml:"dnsSearch,omitempty" json:"dnsSearch,omitempty"`
+	// IptablesMode allows to force the iptables mode used by the node between "auto", "legacy" and "nf_tables".
+	// Defaults to "auto" mode.
+	IptablesMode IptablesMode `yaml:"iptablesMode,omitempty" json:"iptablesMode,omitempty"`
 }
 
 // ClusterIPFamily defines cluster network IP family
@@ -213,6 +216,18 @@ const (
 	IPTablesProxyMode ProxyMode = "iptables"
 	// IPVSProxyMode sets ProxyMode to ipvs
 	IPVSProxyMode ProxyMode = "ipvs"
+)
+
+// IptablesMode defines a iptables mode for the node
+type IptablesMode string
+
+const (
+	// AutoIptablesMode sets IptablesMode to auto
+	AutoIptablesMode IptablesMode = "auto"
+	// LegacyIptablesMode sets IptablesMode to legacy
+	LegacyIptablesMode IptablesMode = "legacy"
+	// NFTIptablesMode sets IptablesMode to nf_tables
+	NFTIptablesMode IptablesMode = "nf_tables"
 )
 
 // PatchJSON6902 represents an inline kustomize json 6902 patch

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -209,6 +209,8 @@ func commonArgs(cluster string, cfg *config.Cluster, networkName string, nodeNam
 		args = append(args, "-e", "KIND_DNS_SEARCH="+strings.Join(*cfg.Networking.DNSSearch, " "))
 	}
 
+	args = append(args, "-e", "IPTABLES_MODE="+string(cfg.Networking.IptablesMode))
+
 	return args, nil
 }
 

--- a/pkg/internal/apis/config/convert_v1alpha4.go
+++ b/pkg/internal/apis/config/convert_v1alpha4.go
@@ -83,6 +83,7 @@ func convertv1alpha4Networking(in *v1alpha4.Networking, out *Networking) {
 	out.APIServerAddress = in.APIServerAddress
 	out.PodSubnet = in.PodSubnet
 	out.KubeProxyMode = ProxyMode(in.KubeProxyMode)
+	out.IptablesMode = IptablesMode(in.IptablesMode)
 	out.ServiceSubnet = in.ServiceSubnet
 	out.DisableDefaultCNI = in.DisableDefaultCNI
 	out.DNSSearch = in.DNSSearch

--- a/pkg/internal/apis/config/default.go
+++ b/pkg/internal/apis/config/default.go
@@ -90,6 +90,11 @@ func SetDefaultsCluster(obj *Cluster) {
 	if obj.Networking.KubeProxyMode == "" {
 		obj.Networking.KubeProxyMode = IPTablesProxyMode
 	}
+
+	// default the IptablesMode to auto
+	if obj.Networking.IptablesMode == "" {
+		obj.Networking.IptablesMode = AutoIptablesMode
+	}
 }
 
 // SetDefaultsNode sets uninitialized fields to their default value.

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -152,6 +152,9 @@ type Networking struct {
 	KubeProxyMode ProxyMode
 	// DNSSearch defines the DNS search domain to use for nodes. If not set, this will be inherited from the host.
 	DNSSearch *[]string
+	// IptablesMode allows to force the iptables mode used by the node between "auto", "legacy" and "nf_tables".
+	// Defaults to "auto" mode.
+	IptablesMode IptablesMode `yaml:"iptablesMode,omitempty" json:"iptablesMode,omitempty"`
 }
 
 // ClusterIPFamily defines cluster network IP family
@@ -176,6 +179,18 @@ const (
 	IPVSProxyMode ProxyMode = "ipvs"
 	// NoneProxyMode disables kube-proxy
 	NoneProxyMode ProxyMode = "none"
+)
+
+// IptablesMode defines a iptables mode for the node
+type IptablesMode string
+
+const (
+	// AutoIptablesMode sets IptablesMode to auto
+	AutoIptablesMode IptablesMode = "auto"
+	// LegacyIptablesMode sets IptablesMode to legacy
+	LegacyIptablesMode IptablesMode = "legacy"
+	// NFTIptablesMode sets IptablesMode to nf_tables
+	NFTIptablesMode IptablesMode = "nf_tables"
 )
 
 // PatchJSON6902 represents an inline kustomize json 6902 patch


### PR DESCRIPTION
# Description

This PR adds the possibility to switch from iptables legacy/nf_tables from a config file.

A field has been added inside config files, called **iptablesMode**
It can accept 3 values:
- auto: the default value if the field is not specified, it preserves the old behavior
- nf_tables: force the usage of iptables-nft
- legacy: force the usage of iptables-legacy

The new file looks like this:
```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
networking:
  serviceSubnet: "${SERVICE_CIDR}"
  podSubnet: "${POD_CIDR}"
  disableDefaultCNI: ${DISABLEDEFAULTCNI}
  iptablesMode: "nf_tables"
```

# Steps

- [x] Implement the feature in docker
- [ ] Implement the feature in podman
- [ ] Write unit tests
- [ ] Add documentation

# Why it could be necessary

In the last period, cloud providers and Linux distributions are leaving **iptables-legacy** to switch to **nf_tables** (**iptables_nft** or **nft**).
A way to switch from an **iptables implementation** to another will be appreciated by developers who work on Kubernetes networking and use KinD as the development platform.