### PR TITLE
Add GitHub Workflow to publish to Winget

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,26 @@
+name: Publish to Winget
+
+on:
+  release:
+    types: [released]
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Komac
+        run: |
+          curl -fSsL -o komac.jar https://github.com/russellbanks/Komac/releases/download/v1.11.0/Komac-1.11.0-all.jar
+          echo '1c26bb7bee6228ad095fe67d10ed254363099b3395f809bd6d95a3f72b2740fc komac.jar' | sha256sum --check --status -
+      
+      - name: Update and submit manifest
+        run: |
+          $JAVA_HOME_17_X64/bin/java -jar komac.jar update \
+            --id Kubernetes.kind \
+            --version $(echo '${{ github.event.release.name }}' | sed 's/^v//') \
+            --urls https://github.com/kubernetes-sigs/kind/releases/download/${{ github.event.release.name }}/kind-windows-amd64
+            --token ${{ secrets.WINGET_TOKEN }}
+            --submit


### PR DESCRIPTION
Fixes #2187 by automating the publishing of the releases on [`Winget`](https://learn.microsoft.com/it-it/windows/package-manager/winget/). I decided to use `Komac` because the `YamlCreate` script requires cloning the entire [`winget-pkgs`](https://github.com/Trenly/winget-pkgs) repo to work, while `WinGetCreate` does not seems to work due to a failure in extracting the required metadata from the executable.

For the workflow to work, the `WINGET_TOKEN` secret should be added to the repository by the maintainers. The tool opens a PR in the upstream repo, so it has to be able to fork it.