### PR TITLE
Connect container run to kind network as bridge

### DIFF
--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -6,7 +6,7 @@ reg_name='kind-registry'
 reg_port='5001'
 if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
   docker run \
-    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --net=kind --name "${reg_name}" \
     registry:2
 fi
 
@@ -43,13 +43,7 @@ for node in $(kind get nodes); do
 EOF
 done
 
-# 4. Connect the registry to the cluster network if not already connected
-# This allows kind to bootstrap the network but ensures they're on the same network
-if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
-  docker network connect "kind" "${reg_name}"
-fi
-
-# 5. Document the local registry
+# 4. Document the local registry
 # https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
 cat <<EOF | kubectl apply -f -
 apiVersion: v1


### PR DESCRIPTION
I am coming to this b/c I ran into the **Error: "slirp4netns" is not supported: invalid network mode** problem.

Than I saw the comment [here](https://github.com/kubernetes-sigs/kind/issues/2694#issuecomment-1080946864)

Which made me think to update the example script and do the `run` with a `--net`. this seems to also make the `docker network connect` not needed (at least for `podman` this is fine).

**UPDATE:**
After discussing on the PR I updated the script and we `run` the regisrty by default as `bridge` network mode, which is supported by both: `docker` and `podman`


