### PR TITLE
[WIP] add nerdctl ci minimal support

### DIFF
--- a/.github/workflows/nerdctl.yaml
+++ b/.github/workflows/nerdctl.yaml
@@ -1,0 +1,120 @@
+name: Nerdctl
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'site/**'
+
+permissions:
+  contents: read
+
+jobs:
+  nerdctl:
+    name: Nerdctl
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        ipFamily: [ipv4, ipv6]
+        deployment: [singleNode, multiNode]
+        exclude:
+          - ipFamily: ipv6
+    env:
+      JOB_NAME: "nerdctl-${{ matrix.deployment }}-${{ matrix.ipFamily }}"
+      IP_FAMILY: ${{ matrix.ipFamily }}
+      NERDCTL_VERSION: "1.7.0"
+      CONTAINERD_VERSION: "1.7.9"
+      CNI_PLUGINS_VERSION: "1.3.0"
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          fetch-depth: 0
+
+      - name: Install kind
+        run: sudo make install INSTALL_DIR=/usr/local/bin
+
+      - name: Install kubectl
+        run: |
+          curl -LO https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
+          chmod +x ./kubectl
+          sudo mv ./kubectl /usr/local/bin/kubectl
+
+      - name: Enable ipv4 and ipv6 forwarding
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.forwarding=1
+          sudo sysctl -w net.ipv4.ip_forward=1
+
+      - name: Install nerdctl
+        run: |
+          sudo systemctl is-active --quiet docker.service || systemctl stop docker.service
+          sudo apt-get remove -y docker-ce docker-ce-cli docker-buildx-plugin podman
+          # Install Containerd
+          sudo curl -sSL https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-amd64.tar.gz|sudo tar -xvz -C /usr
+          sudo systemctl restart containerd.service
+          sudo ctr version
+          # Install CNI
+          sudo mkdir -p /opt/cni/bin
+          sudo curl -sSL https://github.com/containernetworking/plugins/releases/download/v${CNI_PLUGINS_VERSION}/cni-plugins-linux-amd64-v${CNI_PLUGINS_VERSION}.tgz |sudo tar -xvz -C /opt/cni/bin
+          # Install nerdctl
+          sudo curl -sSL https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-amd64.tar.gz|sudo tar -xvz -C /usr/local/bin
+          sudo ln -s /usr/local/bin/nerdctl /usr/local/bin/docker
+          sudo docker version
+
+      - name: Create single node cluster
+        if: ${{ matrix.deployment == 'singleNode' }}
+        run: |
+          cat <<EOF | sudo /usr/local/bin/kind create cluster -v7 --wait 1m --retain --config=-
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          networking:
+            ipFamily: ${IP_FAMILY}
+          EOF
+
+      - name: Create multi node cluster
+        if: ${{ matrix.deployment == 'multiNode' }}
+        run: |
+          cat <<EOF | sudo /usr/local/bin/kind create cluster -v7 --wait 1m --retain --config=-
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          networking:
+            ipFamily: ${IP_FAMILY}
+          nodes:
+          - role: control-plane
+          - role: worker
+          - role: worker
+          EOF
+
+      - name: Get Cluster status
+        run: |
+          # wait network is ready
+          sudo kubectl wait --for=condition=ready pods --namespace=kube-system -l k8s-app=kube-dns
+          sudo kubectl get nodes -o wide
+          sudo kubectl get pods -A
+
+      - name: Load nerdctl image
+        run: |
+          sudo nerdctl pull busybox
+          sudo /usr/local/bin/kind load docker-image busybox
+
+      - name: Export logs
+        if: always()
+        run: |
+          sudo cat /etc/cni/net.d/* 
+          sudo mkdir -p /tmp/kind/logs
+          sudo /usr/local/bin/kind export logs /tmp/kind/logs
+          sudo chown -R $USER:$USER /tmp/kind/logs
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
+          path: /tmp/kind/logs
+
+      - name: Delete cluster
+        run: sudo /usr/local/bin/kind delete cluster


### PR DESCRIPTION
Add basic ci to test that kind can create clusters with nerdctl , and using the docker provider.

The issue: https://github.com/kubernetes-sigs/kind/issues/2317#issuecomment-1788561567

The PR is wating: https://github.com/containerd/nerdctl/issues/2600