### PR TITLE
CI: update Fedora to 38

### DIFF
--- a/.github/workflows/cgroup2.yaml
+++ b/.github/workflows/cgroup2.yaml
@@ -15,7 +15,7 @@ jobs:
   docker:
     name: Cgroup v2
     # nested virtualization is only available on macOS hosts
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -31,6 +31,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
+      #fix https://github.com/kubernetes-sigs/kind/issues/3411
+      # brew uninstall virtualbox
+      # vbcask_url="https://raw.githubusercontent.com/Homebrew/homebrew-cask/aa3c55951fc9d687acce43e5c0338f42c1ddff7b/Casks/virtualbox.rb"
+      # curl -LO $vbcask_url
+      # brew install ./virtualbox.rb
+      # rm ./virtualbox.rb
+      - name: Set up Virtualbox
+        run: |
+          brew install --cask vagrant
+          brew install --cask virtualbox
+         
       - name: Boot Fedora
         run: |
           ln -sf ./hack/ci/Vagrantfile ./Vagrantfile

--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -3,11 +3,7 @@
 
 # Vagrant box for testing kind with cgroup v2
 Vagrant.configure("2") do |config|
-  # `config.vm.box = "fedora/37-cloud-base"` seems flaky,
-  # so we specify the URL explicitly.
-  # Mirrors can be found at here: https://admin.fedoraproject.org/mirrormanager/mirrors/Fedora/37/x86_64
-  config.vm.box = "dummy"
-  config.vm.box_url = "https://iad.mirror.rackspace.com/fedora/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-37-1.7.x86_64.vagrant-virtualbox.box"
+  config.vm.box = "fedora/38-cloud-base"
   # macOS github actions runners have 3 cores and 14 GB of ram
   # assume some ram is needed for the host environment but very little CPU
   # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners


### PR DESCRIPTION
According the https://endoflife.date/fedora , the fedora 37 will EOL at (15 Dec 2023), so update it.

