### PR TITLE
Kindnetd: ignore nodes with empty PodCIDR.

### DIFF
--- a/images/kindnetd/cmd/kindnetd/main.go
+++ b/images/kindnetd/cmd/kindnetd/main.go
@@ -236,11 +236,14 @@ func makeNodesReconciler(cniConfig *CNIConfigWriter, hostIP string, ipFamily IPF
 		}
 
 		// This is another node. Add routes to the POD subnets in the other nodes
-		// don't do anything unless there is a PodCIDR
+		// don't do anything unless there is a non-empty PodCIDR
 		var podCIDRs []string
 		if ipFamily == DualStackFamily {
 			podCIDRs = node.Spec.PodCIDRs
 		} else {
+			if node.Spec.PodCIDR == "" {
+				klog.Infof("IPFamily is not dual and node %s has no CIDR, ignoring", node.Name)
+			}
 			podCIDRs = []string{node.Spec.PodCIDR}
 		}
 		if len(podCIDRs) == 0 {

--- a/images/kindnetd/cmd/kindnetd/main.go
+++ b/images/kindnetd/cmd/kindnetd/main.go
@@ -240,10 +240,7 @@ func makeNodesReconciler(cniConfig *CNIConfigWriter, hostIP string, ipFamily IPF
 		var podCIDRs []string
 		if ipFamily == DualStackFamily {
 			podCIDRs = node.Spec.PodCIDRs
-		} else {
-			if node.Spec.PodCIDR == "" {
-				klog.Infof("IPFamily is not dual and node %s has no CIDR, ignoring", node.Name)
-			}
+		} else if node.Spec.PodCIDR != "" {
 			podCIDRs = []string{node.Spec.PodCIDR}
 		}
 		if len(podCIDRs) == 0 {


### PR DESCRIPTION
Nodes don't get podCIDR assigned when controller manager is run with [allocate-node-cidrs=false](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#options). In this case node routing set up should be skipped.
This patch adds check if a node's `node.Spec.PodCIDR` is empty (because even if the field is optional the type is string, so the default value is ""). `node.Spec.PodCIDRs` is not checked because the default value for the `[]string` will be nil.