### PR TITLE
Node-image: tag the core bundled images that we want to preserve with a pinned label

### DIFF
--- a/pkg/build/nodeimage/imageimporter.go
+++ b/pkg/build/nodeimage/imageimporter.go
@@ -55,7 +55,7 @@ func (c *containerdImporter) Pull(image, platform string) error {
 func (c *containerdImporter) LoadCommand() exec.Cmd {
 	return c.containerCmder.Command(
 		// TODO: ideally we do not need this in the future. we have fixed at least one image
-		"ctr", "--namespace=k8s.io", "images", "import", "--all-platforms", "--no-unpack", "--digests", "-",
+		"ctr", "--namespace=k8s.io", "images", "import", "--label=io.cri-containerd.pinned=pinned", "--all-platforms", "--no-unpack", "--digests", "-",
 	)
 }
 


### PR DESCRIPTION
Ref #3441 

Tag the core bundled images with `pinned` label.

```shell
crictl inspecti registry.k8s.io/coredns/coredns:v1.11.1
{
  "status": {
    "id": "sha256:2437cf762177702dec2dfe99a09c37427a15af6d9a57c456b65352667c223d93",
    "repoTags": [
      "registry.k8s.io/coredns/coredns:v1.11.1"
    ],
    "repoDigests": [],
    "size": "16482581",
    "uid": null,
    "username": "nonroot",
    "spec": null,
    "pinned": true
  },
```

Additional context

- kubernetes/kubernetes#103299
- https://github.com/containerd/containerd/pull/7944