### PR TITLE
Support podman runc runtime

### DIFF
--- a/pkg/cluster/internal/providers/podman/command.go
+++ b/pkg/cluster/internal/providers/podman/command.go
@@ -1,0 +1,30 @@
+package podman
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+// newPodmanCmd returns a new exec.Cmd for podman.
+func newPodmanCmd(args ...string) exec.Cmd {
+	args = appendPodmanRuntimeArg(args...)
+	return exec.Command("podman", args...)
+}
+
+// newPodmanCmdWithContext returns a new exec.Cmd for podman with the given context.
+func newPodmanCmdWithContext(ctx context.Context, args ...string) exec.Cmd {
+	args = appendPodmanRuntimeArg(args...)
+	return exec.CommandContext(ctx, "podman", args...)
+}
+
+// appendPodmanRuntimeArg use the KIND_PODMAN_RUNTIME environment variable if set.
+func appendPodmanRuntimeArg(args ...string) []string {
+	runtime := os.Getenv("KIND_PODMAN_RUNTIME")
+	if runtime != "" {
+		args = append(args, fmt.Sprintf("--runtime=%s", runtime))
+	}
+	return args
+}

--- a/pkg/cluster/internal/providers/podman/images.go
+++ b/pkg/cluster/internal/providers/podman/images.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"sigs.k8s.io/kind/pkg/errors"
-	"sigs.k8s.io/kind/pkg/exec"
 	"sigs.k8s.io/kind/pkg/log"
 
 	"sigs.k8s.io/kind/pkg/cluster/internal/providers/common"
@@ -53,7 +52,7 @@ func pullIfNotPresent(logger log.Logger, image string, retries int) (pulled bool
 	// TODO(bentheelder): switch most (all) of the logging here to debug level
 	// once we have configurable log levels
 	// if this did not return an error, then the image exists locally
-	cmd := exec.Command("podman", "inspect", "--type=image", image)
+	cmd := newPodmanCmd("inspect", "--type=image", image)
 	if err := cmd.Run(); err == nil {
 		logger.V(1).Infof("Image: %s present locally", image)
 		return false, nil
@@ -65,14 +64,14 @@ func pullIfNotPresent(logger log.Logger, image string, retries int) (pulled bool
 // pull pulls an image, retrying up to retries times
 func pull(logger log.Logger, image string, retries int) error {
 	logger.V(1).Infof("Pulling image: %s ...", image)
-	err := exec.Command("podman", "pull", image).Run()
+	err := newPodmanCmd("pull", image).Run()
 	// retry pulling up to retries times if necessary
 	if err != nil {
 		for i := 0; i < retries; i++ {
 			time.Sleep(time.Second * time.Duration(i+1))
 			logger.V(1).Infof("Trying again to pull image: %q ... %v", image, err)
 			// TODO(bentheelder): add some backoff / sleep?
-			err = exec.Command("podman", "pull", image).Run()
+			err = newPodmanCmd("pull", image).Run()
 			if err == nil {
 				break
 			}

--- a/pkg/cluster/internal/providers/podman/network.go
+++ b/pkg/cluster/internal/providers/podman/network.go
@@ -88,15 +88,15 @@ func ensureNetwork(name string) error {
 
 func createNetwork(name, ipv6Subnet string) error {
 	if ipv6Subnet == "" {
-		return exec.Command("podman", "network", "create", "-d=bridge", name).Run()
+		return newPodmanCmd("network", "create", "-d=bridge", name).Run()
 	}
-	return exec.Command("podman", "network", "create", "-d=bridge",
+	return newPodmanCmd("network", "create", "-d=bridge",
 		"--ipv6", "--subnet", ipv6Subnet, name).Run()
 }
 
 func checkIfNetworkExists(name string) bool {
-	_, err := exec.Output(exec.Command(
-		"podman", "network", "inspect",
+	_, err := exec.Output(newPodmanCmd(
+		"network", "inspect",
 		regexp.QuoteMeta(name),
 	))
 	return err == nil

--- a/pkg/cluster/internal/providers/podman/node.go
+++ b/pkg/cluster/internal/providers/podman/node.go
@@ -36,7 +36,7 @@ func (n *node) String() string {
 }
 
 func (n *node) Role() (string, error) {
-	cmd := exec.Command("podman", "inspect",
+	cmd := newPodmanCmd("inspect",
 		"--format", fmt.Sprintf(`{{ index .Config.Labels "%s"}}`, nodeRoleLabelKey),
 		n.name,
 	)
@@ -52,7 +52,7 @@ func (n *node) Role() (string, error) {
 
 func (n *node) IP() (ipv4 string, ipv6 string, err error) {
 	// retrieve the IP address of the node using podman inspect
-	cmd := exec.Command("podman", "inspect",
+	cmd := newPodmanCmd("inspect",
 		"-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}",
 		n.name, // ... against the "node" container
 	)
@@ -130,9 +130,9 @@ func (c *nodeCmd) Run() error {
 	)
 	var cmd exec.Cmd
 	if c.ctx != nil {
-		cmd = exec.CommandContext(c.ctx, "podman", args...)
+		cmd = newPodmanCmdWithContext(c.ctx, args...)
 	} else {
-		cmd = exec.Command("podman", args...)
+		cmd = newPodmanCmd(args...)
 	}
 	if c.stdin != nil {
 		cmd.SetStdin(c.stdin)
@@ -167,5 +167,5 @@ func (c *nodeCmd) SetStderr(w io.Writer) exec.Cmd {
 }
 
 func (n *node) SerialLogs(w io.Writer) error {
-	return exec.Command("podman", "logs", n.name).SetStdout(w).SetStderr(w).Run()
+	return newPodmanCmd("logs", n.name).SetStdout(w).SetStderr(w).Run()
 }

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -300,7 +300,7 @@ type podmanNetworks []struct {
 }
 
 func getSubnets(networkName string) ([]string, error) {
-	cmd := exec.Command("podman", "network", "inspect", networkName)
+	cmd := newPodmanCmd("network", "inspect", networkName)
 	out, err := exec.Output(cmd)
 
 	if err != nil {
@@ -418,19 +418,19 @@ func generatePortMappings(clusterIPFamily config.ClusterIPFamily, portMappings .
 }
 
 func createContainer(name string, args []string) error {
-	if err := exec.Command("podman", append([]string{"run", "--name", name}, args...)...).Run(); err != nil {
+	if err := newPodmanCmd(append([]string{"run", "--name", name}, args...)...).Run(); err != nil {
 		return err
 	}
 	return nil
 }
 
 func createContainerWithWaitUntilSystemdReachesMultiUserSystem(name string, args []string) error {
-	if err := exec.Command("podman", append([]string{"run", "--name", name}, args...)...).Run(); err != nil {
+	if err := newPodmanCmd(append([]string{"run", "--name", name}, args...)...).Run(); err != nil {
 		return err
 	}
 
 	logCtx, logCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer logCancel()
-	logCmd := exec.CommandContext(logCtx, "podman", "logs", "-f", name)
+	logCmd := newPodmanCmdWithContext(logCtx, "logs", "-f", name)
 	return common.WaitUntilLogRegexpMatches(logCtx, logCmd, common.NodeReachedCgroupsReadyRegexp())
 }

--- a/pkg/cluster/internal/providers/podman/util.go
+++ b/pkg/cluster/internal/providers/podman/util.go
@@ -29,7 +29,7 @@ import (
 
 // IsAvailable checks if podman is available in the system
 func IsAvailable() bool {
-	cmd := exec.Command("podman", "-v")
+	cmd := newPodmanCmd("-v")
 	lines, err := exec.OutputLines(cmd)
 	if err != nil || len(lines) != 1 {
 		return false
@@ -38,7 +38,7 @@ func IsAvailable() bool {
 }
 
 func getPodmanVersion() (*version.Version, error) {
-	cmd := exec.Command("podman", "--version")
+	cmd := newPodmanCmd("--version")
 	lines, err := exec.OutputLines(cmd)
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func ensureMinVersion() error {
 // with the specified label=true
 // returns the name of the volume created
 func createAnonymousVolume(label string) (string, error) {
-	cmd := exec.Command("podman",
+	cmd := newPodmanCmd(
 		"volume",
 		"create",
 		// podman only support filter on key during list
@@ -90,7 +90,7 @@ func createAnonymousVolume(label string) (string, error) {
 
 // getVolumes gets volume names filtered on specified label
 func getVolumes(label string) ([]string, error) {
-	cmd := exec.Command("podman",
+	cmd := newPodmanCmd(
 		"volume",
 		"ls",
 		"--filter", fmt.Sprintf("label=%s", label),
@@ -117,13 +117,13 @@ func deleteVolumes(names []string) error {
 		"--force",
 	}
 	args = append(args, names...)
-	cmd := exec.Command("podman", args...)
+	cmd := newPodmanCmd(args...)
 	return cmd.Run()
 }
 
 // mountDevMapper checks if the podman storage driver is Btrfs or ZFS
 func mountDevMapper() bool {
-	cmd := exec.Command("podman", "info", "--format", "json")
+	cmd := newPodmanCmd("info", "--format", "json")
 	out, err := exec.Output(cmd)
 	if err != nil {
 		return false


### PR DESCRIPTION
Actually, I am fixing https://github.com/kubernetes-sigs/kind/issues/3459, I found the cgroups has some problem.

So I force to use runc as the podman's container, then it works.

I think we can provide a env to use runc.

as you know, `--runtime` is a global flag of podman, so we can use a `newPodmanCmd` for all the podman command execution.