### PR TITLE
Switch to new containerd version - v1.7.11

### DIFF
--- a/images/Makefile.common.in
+++ b/images/Makefile.common.in
@@ -26,6 +26,7 @@ TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git describe --always --dirty)")
 IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)$(TAG_SUFFIX)
 # Go version to use, respected by images that build go binaries
 GO_VERSION=$(shell cat $(CURDIR)/../../.go-version | head -n1)
+CONTAINERD_VERSION?=v1.7.11
 
 # required to enable buildx
 export DOCKER_CLI_EXPERIMENTAL=enabled
@@ -36,7 +37,7 @@ OUTPUT?=
 PROGRESS=auto
 EXTRA_BUILD_OPT?=
 build: ensure-buildx
-	docker buildx build $(if $(PLATFORMS),--platform=$(PLATFORMS),) $(OUTPUT) --progress=$(PROGRESS) -t ${IMAGE} --pull --build-arg GO_VERSION=$(GO_VERSION) $(EXTRA_BUILD_OPT) .
+	docker buildx build $(if $(PLATFORMS),--platform=$(PLATFORMS),) $(OUTPUT) --progress=$(PROGRESS) -t ${IMAGE} --pull --build-arg CONTAINERD_VERSION=$(CONTAINERD_VERSION) --build-arg GO_VERSION=$(GO_VERSION) $(EXTRA_BUILD_OPT) .
 
 # push the cross built image
 push: OUTPUT=--push

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -116,9 +116,10 @@ RUN eval "$(gimme "${GO_VERSION}")" \
 
 
 # stage for building containerd
+# set by makefile to the desired containerd version
+ARG CONTAINERD_VERSION
 FROM go-build as build-containerd
 ARG TARGETARCH GO_VERSION
-ARG CONTAINERD_VERSION="v1.7.5"
 ARG CONTAINERD_CLONE_URL="https://github.com/containerd/containerd"
 # we don't build with optional snapshotters, we never select any of these
 # they're not ideal inside kind anyhow, and we save some disk space


### PR DESCRIPTION
While we are at it, ability to set the desired containerd version in the make file itself, rather than hardcoding in the Dockerfile