### PR TITLE
Add ipFamily validation

### DIFF
--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -52,6 +52,11 @@ func (c *Cluster) Validate() error {
 		}
 	}
 
+	// ipFamily should be ipv4, ipv6, or dual
+	if c.Networking.IPFamily != IPv4Family && c.Networking.IPFamily != IPv6Family && c.Networking.IPFamily != DualStackFamily {
+		errs = append(errs, errors.Errorf("invalid ipFamily: %s", c.Networking.IPFamily))
+	}
+
 	// podSubnet should be a valid CIDR
 	if err := validateSubnets(c.Networking.PodSubnet, c.Networking.IPFamily); err != nil {
 		errs = append(errs, errors.Errorf("invalid pod subnet %v", err))

--- a/pkg/internal/apis/config/validate_test.go
+++ b/pkg/internal/apis/config/validate_test.go
@@ -98,6 +98,16 @@ func TestClusterValidate(t *testing.T) {
 			ExpectErrors: 1,
 		},
 		{
+			Name: "bogus ipFamily",
+			Cluster: func() Cluster {
+				c := Cluster{}
+				SetDefaultsCluster(&c)
+				c.Networking.IPFamily = "ds"
+				return c
+			}(),
+			ExpectErrors: 1,
+		},
+		{
 			Name: "bogus serviceSubnet",
 			Cluster: func() Cluster {
 				c := Cluster{}


### PR DESCRIPTION
Setting ipFamily to invalid value didn't return any error and kind just created an ipv4 cluster silently. It could be a bit confusing when it is set to some plausible but invalid values like IPv4, IPv6, Dual, ds.