### PR TITLE
GitHub Actions: use Linux runners for nested virt

### DIFF
--- a/.github/workflows/cgroup2.yaml
+++ b/.github/workflows/cgroup2.yaml
@@ -14,8 +14,7 @@ permissions:
 jobs:
   docker:
     name: Cgroup v2
-    # nested virtualization is only available on macOS hosts
-    runs-on: macos-12
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -31,6 +30,15 @@ jobs:
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      # https://github.com/containerd/containerd/blob/420503072e58f27a7192ddea4e6e41dced911cb9/.github/workflows/ci.yml#L569-L581
+      - name: Set up vagrant
+        run: |
+          # Canonical's Vagrant 2.2.19 dpkg cannot download Fedora 38 image: https://bugs.launchpad.net/vagrant/+bug/2017828
+          # So we have to install Vagrant >= 2.3.1 from the upstream: https://github.com/opencontainers/runc/blob/v1.1.8/.cirrus.yml#L41-L49
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt-get update
+          sudo apt-get install -y vagrant virtualbox
       - name: Boot Fedora
         run: |
           ln -sf ./hack/ci/Vagrantfile ./Vagrantfile

--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -8,9 +8,7 @@ Vagrant.configure("2") do |config|
   # Mirrors can be found at here: https://admin.fedoraproject.org/mirrormanager/mirrors/Fedora/37/x86_64
   config.vm.box = "dummy"
   config.vm.box_url = "https://iad.mirror.rackspace.com/fedora/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-37-1.7.x86_64.vagrant-virtualbox.box"
-  # macOS github actions runners have 3 cores and 14 GB of ram
   # assume some ram is needed for the host environment but very little CPU
-  # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
   memory = 10240
   cpus = 3
   config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
"Larger" runners are no longer needed for Linux with nested virt.

Replaces:
- #3382