### PR TITLE
CI: rename cgroup2.yaml to vm.yaml

### DIFF
--- a/.github/workflows/vm.yaml
+++ b/.github/workflows/vm.yaml
@@ -1,4 +1,4 @@
-name: Cgroup v2
+name: VM
 
 on:
   workflow_dispatch:
@@ -12,8 +12,9 @@ permissions:
   contents: read
 
 jobs:
-  docker:
-    name: Cgroup v2
+  vm:
+    # Fedora is different from Ubuntu in LSM (SELinux), filesystem (btrfs), kernel version, etc.
+    name: "VM (Fedora)"
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:

--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Vagrant box for testing kind with cgroup v2
+# Vagrant box for testing kind with non-Ubuntu
 Vagrant.configure("2") do |config|
   # `config.vm.box = "fedora/37-cloud-base"` seems flaky,
   # so we specify the URL explicitly.


### PR DESCRIPTION
"cgroup2.yaml" is becoming misnomer, as PR #3409 is going to enable native ubuntu-22.04 runners with cgroup2.