### PR TITLE
`kind build node-image`: Support Docker v25.0.1

### DIFF
--- a/pkg/build/nodeimage/imageimporter.go
+++ b/pkg/build/nodeimage/imageimporter.go
@@ -59,6 +59,12 @@ func (c *containerdImporter) LoadCommand() exec.Cmd {
 	)
 }
 
+func (c *containerdImporter) Tag(src, target string) error {
+	return c.containerCmder.Command(
+		"ctr", "--namespace=k8s.io", "images", "tag", "--force", src, target,
+	).Run()
+}
+
 func (c *containerdImporter) ListImported() ([]string, error) {
 	return exec.OutputLines(c.containerCmder.Command("ctr", "--namespace=k8s.io", "images", "list", "-q"))
 }


### PR DESCRIPTION
`docker save` in Docker v25 produces Docker/OCI dual-format archives:
- `repositories`, `manifest.json`: for legacy Docker format
- `oci-layout`, `index.json` (and blobs): for OCI format

However, `pkg/build/nodeimage/internal/container/docker.EditArchive` did not support rewriting OCI Index.

This was resulting in producing broken images with Docker v25:
- https://github.com/kubernetes/kubernetes/issues/122894#issuecomment-1902608073

We can just drop `docker.EditArchive` and use `ctr images tag` instead.

NOTE: This is still incompatible with Docker v25.0.0 due to moby/moby#47150. The issue was fixed in v25.0.1.