### PR TITLE
WSL: Update package list to build image

### DIFF
--- a/site/content/docs/user/using-wsl2.md
+++ b/site/content/docs/user/using-wsl2.md
@@ -103,11 +103,11 @@ WSL2 kernel is missing `xt_recent` kernel module, which is used by Kube Proxy to
     {{< codeFromInline lang="bash" >}}
 docker run --name wsl-kernel-builder --rm -it ubuntu:latest bash
 
-WSL_COMMIT_REF=linux-msft-5.4.72 # change this line to the version you want to build
+WSL_COMMIT_REF=linux-msft-wsl-5.15.146.1 # change this line to the version you want to build
 
 # Install dependencies
 apt update
-apt install -y git build-essential flex bison libssl-dev libelf-dev bc
+apt install -y git build-essential flex bison libssl-dev libelf-dev bc dwarves python3
 
 # Checkout WSL2 Kernel repo
 mkdir src
@@ -115,8 +115,8 @@ cd src
 git init
 git remote add origin https://github.com/microsoft/WSL2-Linux-Kernel.git
 git config --local gc.auto 0
-git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +${WSL_COMMIT_REF}:refs/remotes/origin/build/linux-msft-wsl-5.4.y
-git checkout --progress --force -B build/linux-msft-wsl-5.4.y refs/remotes/origin/build/linux-msft-wsl-5.4.y
+git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +${WSL_COMMIT_REF}:refs/remotes/origin/build/linux-msft-wsl-5.15.y
+git checkout --progress --force -B build/linux-msft-wsl-5.15.y refs/remotes/origin/build/linux-msft-wsl-5.15.y
 
 # Enable xt_recent kernel module
 sed -i 's/# CONFIG_NETFILTER_XT_MATCH_RECENT is not set/CONFIG_NETFILTER_XT_MATCH_RECENT=y/' Microsoft/config-wsl


### PR DESCRIPTION
When I change version 5.4 to 5.15, current manual is not work.

* `python3` is required.
  - build error without python3

```
/usr/bin/env: 'python3': No such file or directory
make[3]: *** [Makefile:161: /src/tools/bpf/resolve_btfids/libbpf/bpf_helper_defs.h] Error 127
make[3]: *** Deleting file '/src/tools/bpf/resolve_btfids/libbpf/bpf_helper_defs.h'
make[2]: *** [Makefile:48: /src/tools/bpf/resolve_btfids//libbpf/libbpf.a] Error 2
make[1]: *** [Makefile:72: bpf/resolve_btfids] Error 2
make: *** [Makefile:1414: tools/bpf/resolve_btfids] Error 2
make: *** Waiting for unfinished jobs....
```

* `dwarves` is required.
  - ref: [WSL-Linux-Kernel](https://github.com/microsoft/WSL2-Linux-Kernel/blob/linux-msft-wsl-5.15.y/README.md )

It's better to add them for insurance purposes.