### PR TITLE
Support multiple random ExtraPortMappings

### DIFF
--- a/pkg/cluster/internal/providers/common/getport_test.go
+++ b/pkg/cluster/internal/providers/common/getport_test.go
@@ -41,7 +41,10 @@ func TestPortOrGetFreePort(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := PortOrGetFreePort(tt.port, "localhost")
+			got, releaseHostPortFn, err := PortOrGetFreePort(tt.port, "localhost")
+			if releaseHostPortFn != nil {
+				releaseHostPortFn()
+			}
 			if (err != nil) != tt.wantErr {
 				t.Errorf("PortOrGetFreePort() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -84,7 +87,10 @@ func TestGetFreePort(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := GetFreePort(tt.listenAddr)
+			got, releaseHostPortFn, err := GetFreePort(tt.listenAddr)
+			if releaseHostPortFn != nil {
+				releaseHostPortFn()
+			}
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetFreePort() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -386,9 +386,12 @@ func generatePortMappings(clusterIPFamily config.ClusterIPFamily, portMappings .
 		}
 
 		// get a random port if necessary (port = 0)
-		hostPort, err := common.PortOrGetFreePort(pm.HostPort, pm.ListenAddress)
+		hostPort, releaseHostPortFn, err := common.PortOrGetFreePort(pm.HostPort, pm.ListenAddress)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get random host port for port mapping")
+		}
+		if releaseHostPortFn != nil {
+			defer releaseHostPortFn()
 		}
 
 		// generate the actual mapping arg

--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -399,9 +399,12 @@ func generatePortMappings(clusterIPFamily config.ClusterIPFamily, portMappings .
 		}
 
 		// get a random port if necessary (port = 0)
-		hostPort, err := common.PortOrGetFreePort(pm.HostPort, pm.ListenAddress)
+		hostPort, releaseHostPortFn, err := common.PortOrGetFreePort(pm.HostPort, pm.ListenAddress)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get random host port for port mapping")
+		}
+		if releaseHostPortFn != nil {
+			defer releaseHostPortFn()
 		}
 
 		// generate the actual mapping arg

--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -155,6 +155,11 @@ func validatePortMappings(portMappings []PortMapping) error {
 		addr := net.ParseIP(portMapping.ListenAddress)
 		addrString := addr.String()
 
+		if (portMapping.HostPort == -1 || portMapping.HostPort == 0) && (portMapping.Protocol == PortMappingProtocolTCP || portMapping.Protocol == "") {
+			// Port -1 and 0 cause a random port to be selected, thus duplicates are allowed
+			continue
+		}
+
 		portProtocol := formatPortProtocol(portMapping.HostPort, portMapping.Protocol)
 		possibleErr := fmt.Errorf("%s: %s:%s", errMsg, addrString, portProtocol)
 

--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -152,13 +152,13 @@ func validatePortMappings(portMappings []PortMapping) error {
 	}
 
 	for _, portMapping := range portMappings {
-		addr := net.ParseIP(portMapping.ListenAddress)
-		addrString := addr.String()
-
-		if (portMapping.HostPort == -1 || portMapping.HostPort == 0) && (portMapping.Protocol == PortMappingProtocolTCP || portMapping.Protocol == "") {
+		if portMapping.HostPort == -1 || portMapping.HostPort == 0 {
 			// Port -1 and 0 cause a random port to be selected, thus duplicates are allowed
 			continue
 		}
+
+		addr := net.ParseIP(portMapping.ListenAddress)
+		addrString := addr.String()
 
 		portProtocol := formatPortProtocol(portMapping.HostPort, portMapping.Protocol)
 		possibleErr := fmt.Errorf("%s: %s:%s", errMsg, addrString, portProtocol)

--- a/pkg/internal/apis/config/validate_test.go
+++ b/pkg/internal/apis/config/validate_test.go
@@ -357,6 +357,40 @@ func TestNodeValidate(t *testing.T) {
 			}(),
 			ExpectErrors: 1,
 		},
+		{
+			TestName: "Multiple random HostPort",
+			Node: func() Node {
+				cfg := newDefaultedNode(ControlPlaneRole)
+				cfg.ExtraPortMappings = []PortMapping{
+					{
+						ContainerPort: 80,
+					},
+					{
+						ContainerPort: 443,
+					},
+				}
+				return cfg
+			}(),
+			ExpectErrors: 0,
+		},
+		{
+			TestName: "Multiple random -1 HostPort",
+			Node: func() Node {
+				cfg := newDefaultedNode(ControlPlaneRole)
+				cfg.ExtraPortMappings = []PortMapping{
+					{
+						ContainerPort: 80,
+						HostPort:      -1,
+					},
+					{
+						ContainerPort: 443,
+						HostPort:      -1,
+					},
+				}
+				return cfg
+			}(),
+			ExpectErrors: 0,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
When the default value, 0, is used for the HostPort in ExtraPortMappings then Kind will determine a random HostPort to use for this mapping. The validation only allowed a single instance of such a mapping, but now allows multiple.

Also delay the closing of the randomly determined port until all random ports have been determined to ensure the same port cannot be returned multiple times by the operating system.

Fixes #3512