### PR TITLE
Support multiple -1 ExtraPortMappings

### DIFF
--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -155,6 +155,11 @@ func validatePortMappings(portMappings []PortMapping) error {
 		addr := net.ParseIP(portMapping.ListenAddress)
 		addrString := addr.String()
 
+		if portMapping.HostPort == -1 {
+			// Port -1 causes a random port to be selected by the backend, thus duplicates are allowed
+			continue
+		}
+
 		portProtocol := formatPortProtocol(portMapping.HostPort, portMapping.Protocol)
 		possibleErr := fmt.Errorf("%s: %s:%s", errMsg, addrString, portProtocol)
 

--- a/pkg/internal/apis/config/validate_test.go
+++ b/pkg/internal/apis/config/validate_test.go
@@ -357,6 +357,24 @@ func TestNodeValidate(t *testing.T) {
 			}(),
 			ExpectErrors: 1,
 		},
+		{
+			TestName: "Multiple -1 HostPort",
+			Node: func() Node {
+				cfg := newDefaultedNode(ControlPlaneRole)
+				cfg.ExtraPortMappings = []PortMapping{
+					{
+						ContainerPort: 80,
+						HostPort:      -1,
+					},
+					{
+						ContainerPort: 443,
+						HostPort:      -1,
+					},
+				}
+				return cfg
+			}(),
+			ExpectErrors: 0,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
When the value -1 is used then Kind will translate this to 0 and pass it to the backend, which causes the backend to assign a random port. Since these ports are random, duplicates can be allowed.

This is an alternative to https://github.com/kubernetes-sigs/kind/pull/3513 as discussed in https://github.com/kubernetes-sigs/kind/issues/3512