### PR TITLE
Fix CI create multi node cluster failures by nerdctl

### DIFF
--- a/.github/workflows/nerdctl.yaml
+++ b/.github/workflows/nerdctl.yaml
@@ -26,9 +26,7 @@ jobs:
     env:
       JOB_NAME: "nerdctl-${{ matrix.deployment }}-${{ matrix.ipFamily }}"
       IP_FAMILY: ${{ matrix.ipFamily }}
-      NERDCTL_VERSION: "1.7.3"
-      CONTAINERD_VERSION: "1.7.13"
-      CNI_PLUGINS_VERSION: "1.3.0"
+      NERDCTL_VERSION: "1.7.4"
       KIND_EXPERIMENTAL_PROVIDER: "nerdctl"
     steps:
       - name: Check out code into the Go module directory
@@ -52,17 +50,18 @@ jobs:
 
       - name: Install nerdctl
         run: |
+          # Remove Docker and Podman
           sudo systemctl is-active --quiet docker.service || systemctl stop docker.service
-          sudo apt-get remove -y docker-ce docker-ce-cli docker-buildx-plugin podman
-          # Install Containerd
-          sudo curl -sSL https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-amd64.tar.gz|sudo tar -xvz -C /usr
-          sudo systemctl restart containerd.service
+          sudo apt-get remove -y docker-ce docker-ce-cli podman containerd.io
+          sudo rm -rf /etc/systemd/system/containerd.service # clean up the cotnainerd systemd file
+          # Install nerdctl full package
+          sudo curl -sSL https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-full-${NERDCTL_VERSION}-linux-amd64.tar.gz | sudo tar -xvz -C /usr/local
+          # Start Containerd
+          sudo systemctl daemon-reload
+          sudo systemctl enable --now containerd
+          # Show Versions
           sudo ctr version
-          # Install CNI
-          sudo mkdir -p /opt/cni/bin
-          sudo curl -sSL https://github.com/containernetworking/plugins/releases/download/v${CNI_PLUGINS_VERSION}/cni-plugins-linux-amd64-v${CNI_PLUGINS_VERSION}.tgz |sudo tar -xvz -C /opt/cni/bin
-          # Install nerdctl
-          sudo curl -sSL https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-amd64.tar.gz|sudo tar -xvz -C /usr/local/bin
+          sudo nerdctl version
 
       - name: Create single node cluster
         if: ${{ matrix.deployment == 'singleNode' }}


### PR DESCRIPTION
The CI uses the container installed by `apt-get install docker-ce.` The version may not be right.
So, it has been changed to the "nerdctl full package" to fix CI nerdctl test failures.

Fixes https://github.com/kubernetes-sigs/kind/issues/3533