### PR TITLE
Added `winget` install method for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Move-Item .\kind-windows-amd64.exe c:\some-dir-in-your-PATH\kind.exe
 
 # OR via Chocolatey (https://chocolatey.org/packages/kind)
 choco install kind
+
+# OR via Winget (https://github.com/microsoft/winget-cli)
+winget install Kubernetes.kind
 ```
 
 To use kind, you will need to [install docker].


### PR DESCRIPTION
The KinD [winget package](https://github.com/microsoft/winget-pkgs/tree/master/manifests/k/Kubernetes/kind) has been created for v0.20.0 and updated since then by a community member.

The latest version is 0.22.0.

Signed-off-by: Nuno do Carmo (nuno.carmo@suse.com)