### PR TITLE
bump containerd, cri-tools, CNI plugins, and containerd-fuse-overlayfs

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -152,7 +152,7 @@ RUN git clone --filter=tree:0 "${RUNC_CLONE_URL}" /runc \
 FROM go-build as build-crictl
 ARG TARGETARCH GO_VERSION
 ARG CRI_TOOLS_CLONE_URL="https://github.com/kubernetes-sigs/cri-tools"
-ARG CRICTL_VERSION="v1.28.0"
+ARG CRICTL_VERSION="v1.29.0"
 RUN git clone --filter=tree:0 "${CRI_TOOLS_CLONE_URL}" /cri-tools \
     && cd /cri-tools \
     && git checkout "${CRICTL_VERSION}" \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -164,7 +164,7 @@ RUN git clone --filter=tree:0 "${CRI_TOOLS_CLONE_URL}" /cri-tools \
 # stage for building cni-plugins
 FROM go-build as build-cni
 ARG TARGETARCH GO_VERSION
-ARG CNI_PLUGINS_VERSION="v1.3.0"
+ARG CNI_PLUGINS_VERSION="v1.4.1"
 ARG CNI_PLUGINS_CLONE_URL="https://github.com/containernetworking/plugins"
 RUN git clone --filter=tree:0 "${CNI_PLUGINS_CLONE_URL}" /cni-plugins \
     && cd /cni-plugins \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -121,7 +121,7 @@ RUN eval "$(gimme "${GO_VERSION}")" \
 # stage for building containerd
 FROM go-build as build-containerd
 ARG TARGETARCH GO_VERSION
-ARG CONTAINERD_VERSION="v1.7.13"
+ARG CONTAINERD_VERSION="v1.7.14"
 ARG CONTAINERD_CLONE_URL="https://github.com/containerd/containerd"
 # we don't build with optional snapshotters, we never select any of these
 # they're not ideal inside kind anyhow, and we save some disk space

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -184,7 +184,7 @@ RUN git clone --filter=tree:0 "${CNI_PLUGINS_CLONE_URL}" /cni-plugins \
 # stage for building containerd-fuse-overlayfs
 FROM go-build as build-fuse-overlayfs
 ARG TARGETARCH GO_VERSION
-ARG CONTAINERD_FUSE_OVERLAYFS_VERSION="v1.0.6"
+ARG CONTAINERD_FUSE_OVERLAYFS_VERSION="v1.0.8"
 ARG CONTAINERD_FUSE_OVERLAYFS_CLONE_URL="https://github.com/containerd/fuse-overlayfs-snapshotter"
 RUN git clone --filter=tree:0 "${CONTAINERD_FUSE_OVERLAYFS_CLONE_URL}" /fuse-overlayfs-snapshotter \
     && cd /fuse-overlayfs-snapshotter \


### PR DESCRIPTION
containerd:
- https://github.com/containerd/containerd/releases/tag/v1.7.14

cri-tools:
- https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.29.0

CNI plugins:
- https://github.com/containernetworking/plugins/releases/tag/v1.4.0
- https://github.com/containernetworking/plugins/releases/tag/v1.4.1

containerd-fuse-overlayfs
- https://github.com/containerd/fuse-overlayfs-snapshotter/releases/tag/v1.0.7
- https://github.com/containerd/fuse-overlayfs-snapshotter/releases/tag/v1.0.8