### PR TITLE
bump base image

### DIFF
--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20240212-c4cadcab"
+const DefaultBaseImage = "docker.io/kindest/base:v20240401-f2cae93d"


### PR DESCRIPTION
It gets nftables plus all the security fixes of rebuilding the image