### PR TITLE
Fix nerdctl create multi-node cluster fail by do not create container concurrently

### DIFF
--- a/pkg/cluster/internal/providers/nerdctl/provider.go
+++ b/pkg/cluster/internal/providers/nerdctl/provider.go
@@ -107,6 +107,8 @@ func (p *provider) Provision(status *cli.Status, cfg *config.Cluster) (err error
 	}
 
 	// actually create nodes
+	// TODO: remove once nerdctl handles concurrency better
+	// xref: https://github.com/containerd/nerdctl/issues/2908
 	for _, f := range createContainerFuncs {
 		if err := f(); err != nil {
 			return err

--- a/pkg/cluster/internal/providers/nerdctl/provider.go
+++ b/pkg/cluster/internal/providers/nerdctl/provider.go
@@ -107,7 +107,12 @@ func (p *provider) Provision(status *cli.Status, cfg *config.Cluster) (err error
 	}
 
 	// actually create nodes
-	return errors.UntilErrorConcurrent(createContainerFuncs)
+	for _, f := range createContainerFuncs {
+		if err := f(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ListClusters is part of the providers.Provider interface


### PR DESCRIPTION
Fix: #3533

The issue is caused by creating a concurrent container with the network.
Because there is no lock for the container creation, there is some conflict with the CNI creation.

And there are no test cases of nerdctl for creating containers concurrently.