### PR TITLE
Detect /etc/containerd/certs.d automatically for mirror registry config.

### DIFF
--- a/images/base/files/etc/containerd/config.toml
+++ b/images/base/files/etc/containerd/config.toml
@@ -40,3 +40,9 @@ version = 2
   tolerate_missing_hugepages_controller = true
   # restrict_oom_score_adj needs to be true when running inside UserNS (rootless)
   restrict_oom_score_adj = false
+
+# For now it is not the default, but eventually it will. This config is added
+# automatically at run time if the folder /etc/containerd/certs.d is detected in
+# the node image.
+#[plugins."io.containerd.grpc.v1.cri".registry]
+#  config_path = "/etc/containerd/certs.d"

--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -145,6 +145,12 @@ configure_containerd() {
       systemctl enable containerd-fuse-overlayfs
     fi
   fi
+
+  if [[ -e "/etc/containerd/certs.d" ]]; then
+    cat >> /etc/containerd/config.toml <<EOF
+[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
+EOF
 }
 
 configure_proxy() {

--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -12,7 +12,9 @@ fi
 
 # 2. Create kind cluster with containerd registry config dir enabled
 # TODO: kind will eventually enable this by default and this patch will
-# be unnecessary.
+# be unnecessary. Current versions don't need to be patched if the node
+# image comes with a /etc/containerd/certs.d directory, or if this folder
+# is created at runtime via bind mounts.
 #
 # See:
 # https://github.com/kubernetes-sigs/kind/issues/2875


### PR DESCRIPTION
This will allow a slightly smoother transition for people who wish to already move to the new non deprecated way to configure registries in containerd and who build their own node image (or bind mount the config).

Eventually since the old way won't work, this should be the default configuration, written directly in the config.toml main file.