### PR TITLE
feat(pkg/cluster/internal/providers): log container init and before

### DIFF
--- a/pkg/cluster/internal/providers/docker/provider.go
+++ b/pkg/cluster/internal/providers/docker/provider.go
@@ -85,7 +85,7 @@ func (p *provider) Provision(status *cli.Status, cfg *config.Cluster) (err error
 	defer func() { status.End(err == nil) }()
 
 	// plan creating the containers
-	createContainerFuncs, err := planCreation(cfg, networkName)
+	createContainerFuncs, err := planCreation(cfg, networkName, p.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -25,17 +25,17 @@ import (
 	"time"
 
 	"sigs.k8s.io/kind/pkg/cluster/constants"
+	"sigs.k8s.io/kind/pkg/cluster/internal/loadbalancer"
+	"sigs.k8s.io/kind/pkg/cluster/internal/providers/common"
 	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/exec"
 	"sigs.k8s.io/kind/pkg/fs"
-
-	"sigs.k8s.io/kind/pkg/cluster/internal/loadbalancer"
-	"sigs.k8s.io/kind/pkg/cluster/internal/providers/common"
 	"sigs.k8s.io/kind/pkg/internal/apis/config"
+	"sigs.k8s.io/kind/pkg/log"
 )
 
 // planCreation creates a slice of funcs that will create the containers
-func planCreation(cfg *config.Cluster, networkName string) (createContainerFuncs []func() error, err error) {
+func planCreation(cfg *config.Cluster, networkName string, logger log.Logger) (createContainerFuncs []func() error, err error) {
 	// we need to know all the names for NO_PROXY
 	// compute the names first before any actual node details
 	nodeNamer := common.MakeNodeNamer(cfg.Name)
@@ -112,7 +112,7 @@ func planCreation(cfg *config.Cluster, networkName string) (createContainerFuncs
 				if err != nil {
 					return err
 				}
-				return createContainerWithWaitUntilSystemdReachesMultiUserSystem(name, args)
+				return createContainerWithWaitUntilSystemdReachesMultiUserSystem(name, args, logger)
 			})
 		case config.WorkerRole:
 			createContainerFuncs = append(createContainerFuncs, func() error {
@@ -120,7 +120,7 @@ func planCreation(cfg *config.Cluster, networkName string) (createContainerFuncs
 				if err != nil {
 					return err
 				}
-				return createContainerWithWaitUntilSystemdReachesMultiUserSystem(name, args)
+				return createContainerWithWaitUntilSystemdReachesMultiUserSystem(name, args, logger)
 			})
 		default:
 			return nil, errors.Errorf("unknown node role: %q", node.Role)
@@ -406,7 +406,7 @@ func createContainer(name string, args []string) error {
 	return exec.Command("docker", append([]string{"run", "--name", name}, args...)...).Run()
 }
 
-func createContainerWithWaitUntilSystemdReachesMultiUserSystem(name string, args []string) error {
+func createContainerWithWaitUntilSystemdReachesMultiUserSystem(name string, args []string, logger log.Logger) error {
 	if err := exec.Command("docker", append([]string{"run", "--name", name}, args...)...).Run(); err != nil {
 		return err
 	}
@@ -414,5 +414,5 @@ func createContainerWithWaitUntilSystemdReachesMultiUserSystem(name string, args
 	logCtx, logCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	logCmd := exec.CommandContext(logCtx, "docker", "logs", "-f", name)
 	defer logCancel()
-	return common.WaitUntilLogRegexpMatches(logCtx, logCmd, common.NodeReachedCgroupsReadyRegexp())
+	return common.WaitUntilLogRegexpMatches(logCtx, logCmd, common.NodeReachedCgroupsReadyRegexp(), logger)
 }

--- a/pkg/cluster/internal/providers/nerdctl/provider.go
+++ b/pkg/cluster/internal/providers/nerdctl/provider.go
@@ -101,7 +101,7 @@ func (p *provider) Provision(status *cli.Status, cfg *config.Cluster) (err error
 	defer func() { status.End(err == nil) }()
 
 	// plan creating the containers
-	createContainerFuncs, err := planCreation(cfg, fixedNetworkName, p.Binary())
+	createContainerFuncs, err := planCreation(cfg, fixedNetworkName, p.Binary(), p.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -91,7 +91,7 @@ func (p *provider) Provision(status *cli.Status, cfg *config.Cluster) (err error
 	defer func() { status.End(err == nil) }()
 
 	// plan creating the containers
-	createContainerFuncs, err := planCreation(cfg, networkName)
+	createContainerFuncs, err := planCreation(cfg, networkName, p.logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What it introduces**

This PR proposes to log all the container logs from before init, when setting the maximum verbosity supported.

**Why is needed**

This is extremely helpful to debug at runtime with logs from init and before, without the need to read individual logs afterward with export logs.

A lot of points can go wrong e.g. when setting up cgroups and in that case logs from Systemd are essential.
Combining them with logs from kind itself first and from Kubernetes then in a single output can be vital to better understand at runtime the initialization sequence of the containerized nodes, and possibly debug and resolve issues.

Closes #3575 