### PR TITLE
Nftables be liberal with TCP

### DIFF
--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -285,7 +285,7 @@ evictionHard:
 {{ range $index, $gate := .SortedFeatureGates }}
   "{{ (StructuralData $gate.Name) }}": {{ $gate.Value }}
 {{end}}{{end}}
-{{if ne .KubeProxyMode "None"}}
+{{if ne .KubeProxyMode "none"}}
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
@@ -423,7 +423,7 @@ evictionHard:
   "{{ (StructuralData $gate.Name) }}": {{ $gate.Value }}
 {{end}}{{end}}
 {{if .DisableLocalStorageCapacityIsolation}}localStorageCapacityIsolation: false{{end}}
-{{if ne .KubeProxyMode "None"}}
+{{if ne .KubeProxyMode "none"}}
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -302,6 +302,12 @@ conntrack:
 # Skip setting sysctl value "net.netfilter.nf_conntrack_max"
 # It is a global variable that affects other namespaces
   maxPerCore: 0
+# Set sysctl value "net.netfilter.nf_conntrack_tcp_be_liberal"
+# for nftables proxy (theoretically for kernels older than 6.1)
+# xref: https://github.com/kubernetes/kubernetes/issues/117924
+{{if and (eq .KubeProxyMode "nftables") (not .RootlessProvider)}}
+  tcpBeLiberal: true
+{{end}}
 {{if .RootlessProvider}}
 # Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
   tcpEstablishedTimeout: 0s
@@ -440,6 +446,12 @@ conntrack:
 # Skip setting sysctl value "net.netfilter.nf_conntrack_max"
 # It is a global variable that affects other namespaces
   maxPerCore: 0
+# Set sysctl value "net.netfilter.nf_conntrack_tcp_be_liberal"
+# for nftables proxy (theoretically for kernels older than 6.1)
+# xref: https://github.com/kubernetes/kubernetes/issues/117924
+{{if and (eq .KubeProxyMode "nftables") (not .RootlessProvider)}}
+  tcpBeLiberal: true
+{{end}}
 {{if .RootlessProvider}}
 # Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
   tcpEstablishedTimeout: 0s


### PR DESCRIPTION
The TL;DR is that if we don't set this kernel sysctl there is a bug that will reset connections and there is a regression test that keeps failing

https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20nftables,%20master

In theory new kernels 6.1 https://github.com/torvalds/linux/commit/6e250dcbff1d have this bug fixed, but CI runs with 5.15 and a lot of people use old kernels.

The flag is not set to true by default because we have decided that kube-proxy should not be managing the host kernel stack and more reasons explained in https://github.com/kubernetes/kubernetes/issues/117924

KIND always try to bring sane defaults and a has a more tighter control of the environment, so we set always set tcpBeLiberal to true if kube-proxy uses nftables and is not rootless