### PR TITLE
Remove redundant default type value from flag doc

### DIFF
--- a/pkg/cmd/kind/build/nodeimage/nodeimage.go
+++ b/pkg/cmd/kind/build/nodeimage/nodeimage.go
@@ -60,7 +60,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		&flags.BuildType,
 		"type",
 		"docker",
-		"build type, default is docker",
+		"build type",
 	)
 	cmd.Flags().StringVar(
 		&flags.Image,


### PR DESCRIPTION
This change set removes the redundant mention of the `--type` flag default value of the `kind build node-image` command. This basically changes the help message from:

```
--type string         build type, default is docker (default "docker")
```

to:

```
--type string         build type (default "docker")
```