### PR TITLE
Add github workflow for approve to run github action.

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -1,0 +1,40 @@
+---
+name: Approve GitHub Workflows
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - synchronize
+
+jobs:
+  approve:
+    name: Approve ok-to-test
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Update PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        continue-on-error: true
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          debug: ${{ secrets.ACTIONS_RUNNER_DEBUG == 'true' }}
+          script: |
+            const result = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: "pull_request",
+              status: "action_required",
+              head_sha: context.payload.pull_request.head.sha,
+              per_page: 100
+            });
+
+            for (var run of result.data.workflow_runs) {
+              await github.rest.actions.approveWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id
+              });
+            }


### PR DESCRIPTION
I have see that this PR have `approve` & `lgtm` & `ok-to-test` and pending for github action approval. https://github.com/kubernetes-sigs/kind/pull/3595

> 4 workflows awaiting approval
This workflow requires approval from a maintainer. [Learn more about approving workflows.](https://docs.github.com/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)
9 pending, 2 neutral, and 6 successful checks

So i open this PR to add a github workflow for approve to run github action if PR have label of `ok-to-test`, Speed up the PR process.

Basically, this is copied from https://github.com/etcd-io/etcd/blob/main/.github/workflows/gh-workflow-approve.yaml


