### PR TITLE
[Chore] Change TEMPDIR to TMPDIR

### DIFF
--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -107,7 +107,7 @@ If you installed Docker with [snap], it is likely that `docker` commands do not
 have access to `$TMPDIR`. This may break some kind commands which depend
 on using temp directories (`kind build ...`).
 
-Currently a workaround for this is setting the `TEMPDIR` environment variable to
+Currently a workaround for this is setting the `TMPDIR` environment variable to
 a directory snap does have access to when working with kind.
 This can for example be some directory under `$HOME`.
 


### PR DESCRIPTION
The underlying Golang function reads TMPDIR instead of TEMPDIR.

https://cs.opensource.google/go/go/+/master:src/os/file_unix.go;drc=99ee616250e865ca8eff8a91bef3824038b411f1;l=408