### PR TITLE
fix kind version unit test failures for released versions

### DIFF
--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -58,7 +58,7 @@ const versionCore = "0.23.0"
 
 // versionPreRelease is the base pre-release portion of the kind CLI version per
 // Semantic Versioning 2.0.0
-const versionPreRelease = "alpha"
+var versionPreRelease = "alpha"
 
 // gitCommitCount count the commits since the last release.
 // It is injected at build time.

--- a/pkg/cmd/kind/version/version_test.go
+++ b/pkg/cmd/kind/version/version_test.go
@@ -63,34 +63,53 @@ func TestTruncate(t *testing.T) {
 
 func TestVersion(t *testing.T) {
 	tests := []struct {
-		name           string
-		gitCommit      string
-		gitCommitCount string
-		want           string
+		name              string
+		versionPreRelease string
+		gitCommit         string
+		gitCommitCount    string
+		want              string
 	}{
 		{
-			name:           "With git commit count and with commit hash",
-			gitCommit:      "mocked-hash",
-			gitCommitCount: "mocked-count",
-			want:           versionCore + "-" + versionPreRelease + "." + "mocked-count" + "+" + "mocked-hash",
+			name:              "With git commit count and with commit hash",
+			versionPreRelease: "alpha",
+			gitCommit:         "mocked-hash",
+			gitCommitCount:    "mocked-count",
+			want:              versionCore + "-" + "alpha" + "." + "mocked-count" + "+" + "mocked-hash",
 		},
 		{
-			name:           "Without git commit count and and with hash",
-			gitCommit:      "mocked-hash",
-			gitCommitCount: "",
-			want:           versionCore + "-" + versionPreRelease + "+" + "mocked-hash",
+			name:              "Without git commit count and and with hash",
+			versionPreRelease: "beta",
+			gitCommit:         "mocked-hash",
+			gitCommitCount:    "",
+			want:              versionCore + "-" + "beta" + "+" + "mocked-hash",
 		},
 		{
-			name:           "Without git commit hash and with commit count",
-			gitCommit:      "",
-			gitCommitCount: "mocked-count",
-			want:           versionCore + "-" + versionPreRelease + "." + "mocked-count",
+			name:              "Without git commit hash and with commit count",
+			versionPreRelease: "alpha",
+			gitCommit:         "",
+			gitCommitCount:    "mocked-count",
+			want:              versionCore + "-" + "alpha" + "." + "mocked-count",
 		},
 		{
-			name:           "Without git commit hash and without commit count",
-			gitCommit:      "",
-			gitCommitCount: "",
-			want:           versionCore + "-" + versionPreRelease,
+			name:              "Without git commit hash and without commit count",
+			versionPreRelease: "alpha",
+			gitCommit:         "",
+			gitCommitCount:    "",
+			want:              versionCore + "-" + "alpha",
+		},
+		{
+			name:              "Without pre release version",
+			versionPreRelease: "",
+			gitCommit:         "",
+			gitCommitCount:    "",
+			want:              versionCore,
+		},
+		{
+			name:              "Without pre release version and with git commit hash and count",
+			versionPreRelease: "",
+			gitCommit:         "mocked-commit",
+			gitCommitCount:    "mocked-count",
+			want:              versionCore,
 		},
 	}
 	for _, tt := range tests {
@@ -110,6 +129,12 @@ func TestVersion(t *testing.T) {
 					gitCommitCount = gitCommitCountBackup
 				}()
 			}
+
+			versionPreReleaseBackup := versionPreRelease
+			versionPreRelease = tt.versionPreRelease
+			defer func() {
+				versionPreRelease = versionPreReleaseBackup
+			}()
 			if got := Version(); got != tt.want {
 				t.Errorf("Version() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Version() string assumes that preRelease version is set for commit hash and count to be taken into account. Update the unit tests to pass in a pre release version per test case