### PR TITLE
Force using /etc/containerd/certs.d for registry config.

### DIFF
--- a/images/base/files/etc/containerd/config.toml
+++ b/images/base/files/etc/containerd/config.toml
@@ -40,3 +40,6 @@ version = 2
   tolerate_missing_hugepages_controller = true
   # restrict_oom_score_adj needs to be true when running inside UserNS (rootless)
   restrict_oom_score_adj = false
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"

--- a/pkg/cluster/nodeutils/util_test.go
+++ b/pkg/cluster/nodeutils/util_test.go
@@ -150,15 +150,7 @@ func TestParseSnapshotter(t *testing.T) {
 		  key_model = "node"
 	
 		[plugins."io.containerd.grpc.v1.cri".registry]
-		  config_path = ""
-	
-		  [plugins."io.containerd.grpc.v1.cri".registry.auths]
-	
-		  [plugins."io.containerd.grpc.v1.cri".registry.configs]
-	
-		  [plugins."io.containerd.grpc.v1.cri".registry.headers]
-	
-		  [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+		  config_path = "/etc/containerd/certs.d"
 	
 		[plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
 		  tls_cert_file = ""

--- a/site/content/docs/user/private-registries.md
+++ b/site/content/docs/user/private-registries.md
@@ -91,8 +91,8 @@ See Google's [upstream docs][keyFileAuthentication] on key file authentication f
 #### Use a Certificate
 
 If you have a registry authenticated with certificates, and both certificates and keys
-reside on your host folder, it is possible to mount and use them into the `containerd` plugin
-patching the default configuration, like in the example:
+reside on your host folder, it is possible to mount to docker config which is compatible
+with containerd, like in this example:
 
 {{< codeFromInline lang="yaml" >}}
 kind: Cluster
@@ -100,13 +100,13 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
     # This option mounts the host docker registry folder into
-    # the control-plane node, allowing containerd to access them. 
+    # the control-plane node, allowing containerd to access them.
     extraMounts:
       - containerPath: /etc/docker/certs.d/registry.dev.example.com
-        hostPath: /etc/docker/certs.d/registry.dev.example.com
-containerdConfigPatches:
-  - |-
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.dev.example.com".tls]
-      cert_file = "/etc/docker/certs.d/registry.dev.example.com/ba_client.cert"
-      key_file  = "/etc/docker/certs.d/registry.dev.example.com/ba_client.key"
+        hostPath: /etc/containerd/certs.d/registry.dev.example.com
 {{< /codeFromInline >}}
+
+Note that if you have a hosts.toml file inside the registry configuration, this file needs
+to explicitly mention the TLS certificates/keys, see the [CRI documentation][criDocumentation]
+
+[criDocumentation]: https://github.com/containerd/containerd/blob/main/docs/hosts.md


### PR DESCRIPTION
This is a breaking change, announced in release v0.20. See https://kind.sigs.k8s.io/docs/user/local-registry/ how to setup a local registry.

Note: users who used to patch the containerd config to set explicitly:

```
[plugins."io.containerd.grpc.v1.cri".registry]
  config_path = "/etc/containerd/certs.d"
```

should now remove this patch as it is now kind's default configuration.

This is a more brutal change than #3574 in which it was suggested to go the hard way and switch the default now.