### PR TITLE
[RFC] Network policies

### DIFF
--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -186,6 +186,8 @@ type Networking struct {
 	// If DisableDefaultCNI is true, kind will not install the default CNI setup.
 	// Instead the user should install their own CNI after creating the cluster.
 	DisableDefaultCNI bool `yaml:"disableDefaultCNI,omitempty" json:"disableDefaultCNI,omitempty"`
+	// If NetworkPolicies is true, kind will install the default Network Policy setup.
+	NetworkPolicies bool `yaml:"networkPolicies,omitempty" json:"networkPolicies,omitempty"`
 	// KubeProxyMode defines if kube-proxy should operate in iptables, ipvs or nftables mode
 	// Defaults to 'iptables' mode
 	KubeProxyMode ProxyMode `yaml:"kubeProxyMode,omitempty" json:"kubeProxyMode,omitempty"`

--- a/pkg/build/nodeimage/buildcontext.go
+++ b/pkg/build/nodeimage/buildcontext.go
@@ -251,6 +251,14 @@ func (c *buildContext) prePullImagesAndWriteManifests(bits kube.Bits, parsedVers
 	// all builds should install the default storage driver images currently
 	requiredImages = append(requiredImages, defaultStorageImages...)
 
+	// write the default Network Policy manifest
+	if err := createFile(cmder, defaultNetworkPolicyManifestLocation, defaultNetworkPolicyManifest); err != nil {
+		c.logger.Errorf("Image build Failed! Failed write default Network Policy Manifest: %v", err)
+		return nil, err
+	}
+	// all builds should install the default network policies images currently
+	requiredImages = append(requiredImages, defaultNetworkPolicyImage...)
+
 	// setup image importer
 	importer := newContainerdImporter(cmder)
 	if err := importer.Prepare(); err != nil {

--- a/pkg/build/nodeimage/const.go
+++ b/pkg/build/nodeimage/const.go
@@ -19,7 +19,8 @@ package nodeimage
 // these are well known paths within the node image
 const (
 	// TODO: refactor kubernetesVersionLocation to a common internal package
-	kubernetesVersionLocation      = "/kind/version"
-	defaultCNIManifestLocation     = "/kind/manifests/default-cni.yaml"
-	defaultStorageManifestLocation = "/kind/manifests/default-storage.yaml"
+	kubernetesVersionLocation            = "/kind/version"
+	defaultCNIManifestLocation           = "/kind/manifests/default-cni.yaml"
+	defaultStorageManifestLocation       = "/kind/manifests/default-storage.yaml"
+	defaultNetworkPolicyManifestLocation = "/kind/manifests/default-network-policy.yaml"
 )

--- a/pkg/build/nodeimage/const_network_policy.go
+++ b/pkg/build/nodeimage/const_network_policy.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeimage
+
+/*
+The default network policy manifest and images are https://github.com/kubernetes-sigs/kube-network-policies
+*/
+
+const networkPolicyImage = "registry.k8s.io/networking/kube-network-policies:v0.2.0"
+
+var defaultNetworkPolicyImage = []string{networkPolicyImage}
+
+const defaultNetworkPolicyManifest = `
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-network-policies
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+     - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-network-policies
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-network-policies
+subjects:
+- kind: ServiceAccount
+  name: kube-network-policies
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-network-policies
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-network-policies
+  namespace: kube-system
+  labels:
+    tier: node
+    app: kube-network-policies
+    k8s-app: kube-network-policies
+spec:
+  selector:
+    matchLabels:
+      app: kube-network-policies
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: kube-network-policies
+        k8s-app: kube-network-policies
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: kube-network-policies
+      containers:
+      - name: kube-network-policies
+        image: ` + networkPolicyImage + `
+        args:
+        - /bin/netpol
+        - -v
+        - "2"
+        volumeMounts:
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+      volumes:
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+---
+`

--- a/pkg/cluster/internal/create/actions/installnetworkpolicies/networkpolicies.go
+++ b/pkg/cluster/internal/create/actions/installnetworkpolicies/networkpolicies.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package installnetworkpolicies implements the install Network Policy action
+package installnetworkpolicies
+
+import (
+	"bytes"
+	"strings"
+
+	"sigs.k8s.io/kind/pkg/errors"
+
+	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions"
+	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
+)
+
+type action struct{}
+
+// NewAction returns a new action for installing storage
+func NewAction() actions.Action {
+	return &action{}
+}
+
+// Execute runs the action
+func (a *action) Execute(ctx *actions.ActionContext) error {
+	ctx.Status.Start("Installing Network Policies 🔒")
+	defer ctx.Status.End(false)
+
+	allNodes, err := ctx.Nodes()
+	if err != nil {
+		return err
+	}
+
+	// get the target node for this task
+	controlPlanes, err := nodeutils.ControlPlaneNodes(allNodes)
+	if err != nil {
+		return err
+	}
+	node := controlPlanes[0] // kind expects at least one always
+
+	// read the manifest from the node
+	var raw bytes.Buffer
+	if err := node.Command("cat", "/kind/manifests/default-network-policy.yaml").SetStdout(&raw).Run(); err != nil {
+		return errors.Wrap(err, "failed to read Network Policies manifest")
+	}
+	manifest := raw.String()
+
+	// apply the manifest
+	in := strings.NewReader(manifest)
+	cmd := node.Command(
+		"kubectl",
+		"--kubeconfig=/etc/kubernetes/admin.conf", "apply", "-f", "-",
+	)
+	cmd.SetStdin(in)
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// mark success
+	ctx.Status.End(true)
+	return nil
+}

--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions"
 	configaction "sigs.k8s.io/kind/pkg/cluster/internal/create/actions/config"
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/installcni"
+	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/installnetworkpolicies"
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/installstorage"
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/kubeadminit"
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/kubeadmjoin"
@@ -119,6 +120,11 @@ func Cluster(logger log.Logger, p providers.Provider, opts *ClusterOptions) erro
 		if !opts.Config.Networking.DisableDefaultCNI {
 			actionsToRun = append(actionsToRun,
 				installcni.NewAction(), // install CNI
+			)
+		}
+		if opts.Config.Networking.NetworkPolicies {
+			actionsToRun = append(actionsToRun,
+				installnetworkpolicies.NewAction(), // install Network Policies
 			)
 		}
 		// add remaining steps

--- a/pkg/internal/apis/config/convert_v1alpha4.go
+++ b/pkg/internal/apis/config/convert_v1alpha4.go
@@ -85,6 +85,7 @@ func convertv1alpha4Networking(in *v1alpha4.Networking, out *Networking) {
 	out.KubeProxyMode = ProxyMode(in.KubeProxyMode)
 	out.ServiceSubnet = in.ServiceSubnet
 	out.DisableDefaultCNI = in.DisableDefaultCNI
+	out.NetworkPolicies = in.NetworkPolicies
 	out.DNSSearch = in.DNSSearch
 }
 

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -148,6 +148,8 @@ type Networking struct {
 	// If DisableDefaultCNI is true, kind will not install the default CNI setup.
 	// Instead the user should install their own CNI after creating the cluster.
 	DisableDefaultCNI bool
+	// If NetworkPolicies is true, kind will install the default Network Policy setup.
+	NetworkPolicies bool
 	// KubeProxyMode defines if kube-proxy should operate in iptables, ipvs or nftables mode
 	KubeProxyMode ProxyMode
 	// DNSSearch defines the DNS search domain to use for nodes. If not set, this will be inherited from the host.

--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -214,6 +214,20 @@ networking:
   disableDefaultCNI: true
 {{< /codeFromInline >}}
 
+#### Network Policies
+
+KIND ships with an implementation of Kubernetes Network Policies
+[kube-network-policies](https://github.com/kubernetes-sigs/kube-network-policies) that
+is disabled by default.
+
+You may enable this option by setting the corresponding configuration.
+{{< codeFromInline lang="yaml" >}}
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  networkPolicies: true
+{{< /codeFromInline >}}
+
 
 #### kube-proxy mode
 


### PR DESCRIPTION
Add support for network policies in KIND

/hold

Fixes: https://github.com/kubernetes-sigs/kind/issues/842

1. Build kind 

```
make
go build -v -o "/usr/local/google/home/aojea/src/kind/bin/kind" -trimpath -ldflags="-buildid= -w -X=sigs.k8s.io/kind/pkg/cmd/kind/version.gitCommit=d3c7631e37eed1714a7a1ea923a7393842a384d3 -X=sigs.k8s.io/kind/pkg/cmd/kind/version.gitCommitCount=6"
```

2. Create node image
```
bin/kind build node-image ~/src/kubernetes/
Starting to build Kubernetes
+++ [0514 11:25:11] Verifying Prerequisites....
+++ [0514 11:25:11] Building Docker image kube-build:build-300e2a667e-5-v1.31.0-go1.22.3-bullseye.0
+++ [0514 11:26:57] Creating data container kube-build-data-300e2a667e-5-v1.31.0-go1.22.3-bullseye.0
+++ [0514 11:27:02] Syncing sources to container
+++ [0514 11:27:21] Running build command...
+++ [0514 11:27:28] Building go targets for linux/amd64
    k8s.io/kubernetes/cmd/kube-apiserver (static)
    k8s.io/kubernetes/cmd/kube-controller-manager (static)
    k8s.io/kubernetes/cmd/kube-proxy (static)
    k8s.io/kubernetes/cmd/kube-scheduler (static)
    k8s.io/kubernetes/cmd/kubeadm (static)
    k8s.io/kubernetes/cmd/kubectl (static)
    k8s.io/kubernetes/cmd/kubelet (non-static)
+++ [0514 11:28:37] Syncing out of container
+++ [0514 11:28:45] Building images: linux-amd64
+++ [0514 11:28:45] Starting docker build for image: kube-apiserver-amd64
+++ [0514 11:28:45] Starting docker build for image: kube-controller-manager-amd64
+++ [0514 11:28:45] Starting docker build for image: kube-scheduler-amd64
+++ [0514 11:28:45] Starting docker build for image: kube-proxy-amd64
+++ [0514 11:28:45] Starting docker build for image: kubectl-amd64
+++ [0514 11:28:51] Deleting docker image registry.k8s.io/kubectl-amd64:v1.31.0-alpha.0.740_caafc211407c66-dirty
+++ [0514 11:28:51] Deleting docker image registry.k8s.io/kube-scheduler-amd64:v1.31.0-alpha.0.740_caafc211407c66-dirty
+++ [0514 11:28:51] Deleting docker image registry.k8s.io/kube-proxy-amd64:v1.31.0-alpha.0.740_caafc211407c66-dirty
+++ [0514 11:28:52] Deleting docker image registry.k8s.io/kube-controller-manager-amd64:v1.31.0-alpha.0.740_caafc211407c66-dirty
+++ [0514 11:28:53] Deleting docker image registry.k8s.io/kube-apiserver-amd64:v1.31.0-alpha.0.740_caafc211407c66-dirty
+++ [0514 11:28:53] Docker builds done
Finished building Kubernetes
Building node image ...
Building in container: kind-build-1715686140-869641220
Image "kindest/node:latest" build completed.
```

3. Create cluster 

```
bin/kind create cluster --config kind-config.yaml --name netpol --image kindest/node:latest
Creating cluster "netpol" ...
 ✓ Ensuring node image (kindest/node:latest) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing Network Policies 🔒 
 ✓ Installing StorageClass 💾 
Set kubectl context to "kind-netpol"
You can now use your cluster with:

kubectl cluster-info --context kind-netpol

Have a nice day! 👋
```

4. Check network policies pods are running

```
 kubectl -n kube-system get pods | grep network-policies
kube-network-policies-lvmvz                    1/1     Running   0          3m7s
```