### PR TITLE
update comments regarding skipping preflight kubeadm phase

### DIFF
--- a/pkg/cluster/internal/create/actions/kubeadminit/init.go
+++ b/pkg/cluster/internal/create/actions/kubeadminit/init.go
@@ -81,8 +81,8 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 
 	// Newer versions set this in the config file.
 	if kubeVersion.LessThan(version.MustParseSemantic("v1.23.0")) {
-		// skip preflight checks, as these have undesirable side effects
-		// and don't tell us much. requires kubeadm 1.13+
+		// Skip preflight to avoid pulling images.
+		// Kind pre-pulls images and preflight may conflict with that.
 		skipPhases := "preflight"
 		if a.skipKubeProxy {
 			skipPhases += ",addon/kube-proxy"

--- a/pkg/cluster/internal/create/actions/kubeadmjoin/join.go
+++ b/pkg/cluster/internal/create/actions/kubeadmjoin/join.go
@@ -136,8 +136,8 @@ func runKubeadmJoin(logger log.Logger, node nodes.Node) error {
 	}
 	// Newer versions set this in the config file.
 	if kubeVersion.LessThan(version.MustParseSemantic("v1.23.0")) {
-		// skip preflight checks, as these have undesirable side effects
-		// and don't tell us much. requires kubeadm 1.13+
+		// Skip preflight to avoid pulling images.
+		// Kind pre-pulls images and preflight may conflict with that.
 		args = append(args, "--skip-phases=preflight")
 	}
 

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -171,8 +171,9 @@ func (c *ConfigData) Derive() {
 	}
 	c.RuntimeConfigString = strings.Join(runtimeConfig, ",")
 
-	// skip preflight checks, as these have undesirable side effects
-	// and don't tell us much. requires kubeadm 1.22+
+	// Skip preflight to avoid pulling images.
+	// Kind pre-pulls images and preflight may conflict with that.
+	// requires kubeadm 1.22+
 	c.JoinSkipPhases = []string{"preflight"}
 	c.InitSkipPhases = []string{"preflight"}
 	if c.KubeProxyMode == string(config.NoneProxyMode) {


### PR DESCRIPTION
Follow-up from https://github.com/kubernetes-sigs/kind/pull/3624#discussion_r1608929179 to clarify why the `preflight` phase is skipped for `kubeadm init` and `kubeadm join`.