### PR TITLE
Remove DOCKER_CLI_EXPERIMENTAL usage

### DIFF
--- a/hack/build/init-buildx.sh
+++ b/hack/build/init-buildx.sh
@@ -15,8 +15,6 @@
 
 set -o errexit -o nounset -o pipefail
 
-export DOCKER_CLI_EXPERIMENTAL=enabled
-
 # We can skip setup if the current builder already has multi-arch
 # AND if it isn't the docker driver, which doesn't work
 current_builder="$(docker buildx inspect)"

--- a/hack/release/build/push-node.sh
+++ b/hack/release/build/push-node.sh
@@ -71,7 +71,6 @@ for arch in "${__arches__[@]}"; do
 done
 
 # combine to manifest list tagged with kubernetes version
-export DOCKER_CLI_EXPERIMENTAL=enabled
 # images must be pushed to be referenced by docker manifest
 # we push only after all builds have succeeded
 for image in "${images[@]}"; do

--- a/images/Makefile.common.in
+++ b/images/Makefile.common.in
@@ -27,9 +27,6 @@ IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)$(TAG_SUFFIX)
 # Go version to use, respected by images that build go binaries
 GO_VERSION=$(shell cat $(CURDIR)/../../.go-version | head -n1)
 
-# required to enable buildx
-export DOCKER_CLI_EXPERIMENTAL=enabled
-
 # build with buildx
 PLATFORMS?=linux/amd64,linux/arm64
 OUTPUT?=


### PR DESCRIPTION
The DOCKER_CLI_EXPERIMENTAL environment variable was used to enable experimental features in the docker CLI. This capability was [deprecated in Docker v19.03 and completely removed in v23.0](https://docs.docker.com/engine/deprecated/#configuration-options-for-experimental-cli-features).

This removes the setting of DOCKER_CLI_EXPERIMENTAL from our scripts as it no longer has any effect and is not needed.