### PR TITLE
fix: ensure update-ca-certificates during startup

### DIFF
--- a/images/base/files/usr/local/bin/entrypoint
+++ b/images/base/files/usr/local/bin/entrypoint
@@ -567,6 +567,7 @@ fix_product_name
 fix_product_uuid
 select_iptables
 enable_network_magic
+update-ca-certificates
 
 # we want the command (expected to be systemd) to be PID1, so exec to it
 log_info 'starting init'


### PR DESCRIPTION
Related issue https://github.com/kubernetes-sigs/kind/issues/2826

In some environments it's common to configure Podman/Docker to unconditionally mount in certificates with all containers via [mounts.conf](https://www.mankier.com/5/containers-mounts.conf)

This ensures during bootup `update-ca-certificates` is ran