### PR TITLE
Add exclued node flag for load image command

### DIFF
--- a/pkg/cluster/nodeutils/util.go
+++ b/pkg/cluster/nodeutils/util.go
@@ -154,3 +154,14 @@ func ReTagImage(n nodes.Node, imageID, imageName string) error {
 	var out bytes.Buffer
 	return n.Command("ctr", "--namespace=k8s.io", "images", "tag", "--force", imageID, imageName).SetStdout(&out).Run()
 }
+
+// RemoveNode remove a node from a node list.
+func RemoveNode(nodeName string, nodes []nodes.Node) []nodes.Node {
+	for i := 0; i < len(nodes); i++ {
+		if nodes[i].String() == nodeName {
+			nodes = append(nodes[:i], nodes[i+1:]...)
+			i--
+		}
+	}
+	return nodes
+}

--- a/pkg/cmd/kind/load/docker-image/docker-image.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image.go
@@ -43,8 +43,9 @@ type (
 )
 
 type flagpole struct {
-	Name  string
-	Nodes []string
+	Name         string
+	Nodes        []string
+	ExcludeNodes []string
 }
 
 // NewCommand returns a new cobra.Command for loading an image into a cluster
@@ -77,6 +78,12 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		"nodes",
 		nil,
 		"comma separated list of nodes to load images into",
+	)
+	cmd.Flags().StringSliceVar(
+		&flags.ExcludeNodes,
+		"exclude-nodes",
+		nil,
+		"comma separated list of exclude nodes not to load images into",
 	)
 	return cmd
 }
@@ -126,6 +133,16 @@ func runE(logger log.Logger, flags *flagpole, args []string) error {
 				return fmt.Errorf("unknown node: %q", name)
 			}
 			candidateNodes = append(candidateNodes, node)
+		}
+	}
+
+	if len(flags.ExcludeNodes) > 0 {
+		for _, name := range flags.ExcludeNodes {
+			_, ok := nodesByName[name]
+			if !ok {
+				return fmt.Errorf("unknown node: %q", name)
+			}
+			candidateNodes = nodeutils.RemoveNode(name, candidateNodes)
 		}
 	}
 


### PR DESCRIPTION
When using kind load command I want to exclude some nodes，for example，I want to load to all nodes except master node，because it has taint and is just a control plane and I don't want load image to this node，so add a new flag just exclude the specific node would be helpful.