### PR TITLE
Fix Kubeadm template format

### DIFF
--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -391,7 +391,7 @@ nodeRegistration:
     node-labels: "{{ .NodeLabels }}"
 {{ if .InitSkipPhases -}}
 skipPhases:
-  {{ range $phase := .InitSkipPhases -}}
+  {{- range $phase := .InitSkipPhases }}
   - "{{ $phase }}"
   {{- end }}
 {{- end }}


### PR DESCRIPTION
When using `kubeProxyMode: none` The current kubeadm template will produce  

> ERROR: failed to create cluster: failed to generate kubeadm config content: error executing config template: Invalid YAML Template

I found out the kubeadm template will drop the line breaker if  `InitSkipPhases` is more than one, playground  https://go.dev/play/p/-wJhmxW6w43 . 
