### PR TITLE
fix getting version from tarball

### DIFF
--- a/pkg/build/nodeimage/internal/kube/builder_remote.go
+++ b/pkg/build/nodeimage/internal/kube/builder_remote.go
@@ -77,7 +77,7 @@ func (b *remoteBuilder) Build() (Bits, error) {
 	}
 
 	binDir := filepath.Join(tmpDir, "kubernetes/server/bin")
-	contents, err := os.ReadFile(filepath.Join(binDir, "kube-apiserver.docker_tag"))
+	contents, err := os.ReadFile(filepath.Join(tmpDir, "kubernetes/version"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/build/nodeimage/internal/kube/builder_tarball.go
+++ b/pkg/build/nodeimage/internal/kube/builder_tarball.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sigs.k8s.io/kind/pkg/log"
 	"strings"
+
+	"sigs.k8s.io/kind/pkg/log"
 )
 
 // TODO(bentheelder): plumb through arch
@@ -57,7 +58,7 @@ func (b *directoryBuilder) Build() (Bits, error) {
 	}
 
 	binDir := filepath.Join(tmpDir, "kubernetes/server/bin")
-	contents, err := os.ReadFile(filepath.Join(binDir, "kube-apiserver.docker_tag"))
+	contents, err := os.ReadFile(filepath.Join(tmpDir, "kubernetes/version"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
the docker tags are mangled, and the tarball has the `version` file matching what we'd get from a local source build

fixes https://github.com/kubernetes-sigs/kind/issues/3714

cc @dims @aojea @stmcginnis 