### PR TITLE
cleanup long-deprecated flags

### DIFF
--- a/pkg/cmd/kind/build/nodeimage/nodeimage.go
+++ b/pkg/cmd/kind/build/nodeimage/nodeimage.go
@@ -30,7 +30,6 @@ type flagpole struct {
 	BuildType string
 	Image     string
 	BaseImage string
-	KubeRoot  string
 	Arch      string
 }
 
@@ -44,12 +43,6 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Short: "Build the node image",
 		Long:  "Build the node image which contains Kubernetes build artifacts and other kind requirements",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Flags().Lookup("kube-root").Changed {
-				if len(args) != 0 {
-					return errors.New("passing an argument and deprecated --kube-root is not supported, please switch to just the argument")
-				}
-				logger.Warn("--kube-root is deprecated, please switch to passing this as an argument")
-			}
 			return runE(logger, flags, args)
 		},
 	}
@@ -64,12 +57,6 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		"image",
 		nodeimage.DefaultImage,
 		"name:tag of the resulting image to be built",
-	)
-	cmd.Flags().StringVar(
-		&flags.KubeRoot,
-		"kube-root",
-		"",
-		"DEPRECATED: please switch to just the argument. Path to the Kubernetes source directory (if empty, the path is autodetected)",
 	)
 	cmd.Flags().StringVar(
 		&flags.BaseImage,
@@ -87,14 +74,14 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 }
 
 func runE(logger log.Logger, flags *flagpole, args []string) error {
-	kubeRoot := flags.KubeRoot
+	sourceSpec := ""
 	if len(args) > 0 {
-		kubeRoot = args[0]
+		sourceSpec = args[0]
 	}
 	if err := nodeimage.Build(
 		nodeimage.WithImage(flags.Image),
 		nodeimage.WithBaseImage(flags.BaseImage),
-		nodeimage.WithKubeParam(kubeRoot),
+		nodeimage.WithKubeParam(sourceSpec),
 		nodeimage.WithLogger(logger),
 		nodeimage.WithArch(flags.Arch),
 		nodeimage.WithBuildType(flags.BuildType),

--- a/pkg/cmd/kind/root.go
+++ b/pkg/cmd/kind/root.go
@@ -35,7 +35,6 @@ import (
 )
 
 type flagpole struct {
-	LogLevel  string
 	Verbosity int32
 	Quiet     bool
 }
@@ -49,7 +48,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Short: "kind is a tool for managing local Kubernetes clusters",
 		Long:  "kind creates and manages local Kubernetes clusters using Docker container 'nodes'",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return runE(logger, flags, cmd)
+			return runE(logger, flags)
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -57,12 +56,6 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	}
 	cmd.SetOut(streams.Out)
 	cmd.SetErr(streams.ErrOut)
-	cmd.PersistentFlags().StringVar(
-		&flags.LogLevel,
-		"loglevel",
-		"",
-		"DEPRECATED: see -v instead",
-	)
 	cmd.PersistentFlags().Int32VarP(
 		&flags.Verbosity,
 		"verbosity",
@@ -89,18 +82,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	return cmd
 }
 
-func runE(logger log.Logger, flags *flagpole, command *cobra.Command) error {
-	// handle limited migration for --loglevel
-	setLogLevel := command.Flag("loglevel").Changed
-	setVerbosity := command.Flag("verbosity").Changed
-	if setLogLevel && !setVerbosity {
-		switch flags.LogLevel {
-		case "debug":
-			flags.Verbosity = 3
-		case "trace":
-			flags.Verbosity = 2147483647
-		}
-	}
+func runE(logger log.Logger, flags *flagpole) error {
 	// normal logger setup
 	if flags.Quiet {
 		// NOTE: if we are coming from app.Run handling this flag is
@@ -108,14 +90,6 @@ func runE(logger log.Logger, flags *flagpole, command *cobra.Command) error {
 		maybeSetWriter(logger, io.Discard)
 	}
 	maybeSetVerbosity(logger, log.Level(flags.Verbosity))
-	// warn about deprecated flag if used
-	if setLogLevel {
-		if cmd.ColorEnabled(logger) {
-			logger.Warn("\x1b[93mWARNING\x1b[0m: --loglevel is deprecated, please switch to -v and -q!")
-		} else {
-			logger.Warn("WARNING: --loglevel is deprecated, please switch to -v and -q!")
-		}
-	}
 	return nil
 }
 

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -130,7 +130,8 @@ Flags:
       --type string         build type, default is docker (default "docker")
 
 Global Flags:
-      --loglevel string   logrus log level [panic, fatal, error, warning, info, debug] (default "warning")
+  -q, --quiet             silence all stderr output
+  -v, --verbosity int32   info log verbosity, higher value produces more output
 
 error building node image: failed to build kubernetes: failed to build images: exit status 2
 ```

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -127,7 +127,6 @@ Flags:
       --base-image string   name:tag of the base image to use for the build (default "kindest/base:v20181203-d055041")
   -h, --help                help for node-image
       --image string        name:tag of the resulting image to be built (default "kindest/node:latest")
-      --kube-root string    Path to the Kubernetes source directory (if empty, the path is autodetected)
       --type string         build type, default is docker (default "docker")
 
 Global Flags:

--- a/site/content/docs/user/working-offline.md
+++ b/site/content/docs/user/working-offline.md
@@ -109,7 +109,7 @@ You can clone Kubernetes source code.
 ### Building image
 
 ```sh
-➜  ~ kind build node-image --image kindest/node:main --kube-root $GOPATH/src/k8s.io/kubernetes 
+➜  ~ kind build node-image --image kindest/node:main $GOPATH/src/k8s.io/kubernetes 
 Starting to build Kubernetes
 ...
 Image build completed.


### PR DESCRIPTION
/hold

We need to cleanup references around the project first, a number of subprojects are still using these:

https://cs.k8s.io/?q=--kube-root&i=nope&files=&excludeFiles=&repos=

Most of them appear to be copies of a CSI script (which uses both flags)