### PR TITLE
clarify when port-mapping is needed

### DIFF
--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -308,6 +308,9 @@ With the installation of the Docker Desktop Application, whether it is on macOs,
 
 You may also want to see the [Ingress Guide].
 
+> **NOTE**: If you're running Kind on a remote host and need to send traffic to Kind node
+> IPs from a different host than where kind is running, you need to configure port-mapping.
+
 {{< codeFromFile file="static/examples/config-with-port-mapping.yaml" lang="yaml" >}}
 
 An example http pod mapping host ports to a container port.


### PR DESCRIPTION
This PR clarifies when port-mapping is needed.

### Why is this important?

When developers are studying for the CKS exam, they may want to study using a Kind cluster running on a public cloud VM. Stating this information helps them configure use cases that involve exposing a nodePort; ingress, exposing the API server, accessing a pod via a browser, etc.

Referenced page: https://kind.sigs.k8s.io/docs/user/configuration/#extra-port-mappings