### PR TITLE
deploy local registry with ssl

### DIFF
--- a/site/content/docs/user/local-registry.md
+++ b/site/content/docs/user/local-registry.md
@@ -25,7 +25,4 @@ The registry can be used like this.
 1. First we'll pull an image `docker pull gcr.io/google-samples/hello-app:1.0`
 2. Then we'll tag the image to use the local registry `docker tag gcr.io/google-samples/hello-app:1.0 localhost:5001/hello-app:1.0`
 3. Then we'll push it to the registry `docker push localhost:5001/hello-app:1.0`
-4. And now we can use the image `kubectl create deployment hello-server --image=localhost:5001/hello-app:1.0`
-
-If you build your own image and tag it like `localhost:5001/image:foo` and then use
-it in kubernetes as `localhost:5001/image:foo`. And use it from inside of your cluster application as `kind-registry:5000`.
+4. And now we can use the image `kubectl create deployment hello-server --image=kind-registry:443/hello-app:1.0`

--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -1,55 +1,58 @@
 #!/bin/sh
 set -o errexit
 
+# new version of kubernetes doesn't allow to use a non tls registry
+
 # 1. Create registry container unless it already exists
 reg_name='kind-registry'
 reg_port='5001'
+cluster_name="${1:-kind}"
 if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
+  # create a directory for certificates use to expose the registry
+  mkdir -p certs
+  
+  # create a self-signed certificate
+  openssl req \
+  -newkey rsa:4096 -nodes -sha256 -keyout certs/domain.key \
+  -addext "subjectAltName = DNS:${reg_name}" \
+  -subj "/C=EU/ST=State/L=Locality/O=Organization/CN=${reg_name}" \
+  -x509 -days 365 -out certs/domain.crt
+  
+  # allow access to cert from the container
+  chmod 755 -R ./certs
+
+  # run the registry
   docker run \
-    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --network bridge --name "${reg_name}" \
+    -d --restart=always -v "$(pwd)"/certs:/certs -p ${reg_port}:443  \
+    -e REGISTRY_HTTP_ADDR=0.0.0.0:443 -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
+    --network bridge --name "${reg_name}" \
     registry:2
 fi
 
-# 2. Create kind cluster with containerd registry config dir enabled
-# TODO: kind will eventually enable this by default and this patch will
-# be unnecessary.
-#
-# See:
-# https://github.com/kubernetes-sigs/kind/issues/2875
-# https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
-# See: https://github.com/containerd/containerd/blob/main/docs/hosts.md
-cat <<EOF | kind create cluster --config=-
+# 2. Create kind cluster with containerd registry config for the local registry
+# as the certificate is autosigned, we have to disable TLS verification on containerd for the registry
+cat <<EOF | kind create cluster --name ${cluster_name} --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry]
-    config_path = "/etc/containerd/certs.d"
+  [plugins."io.containerd.grpc.v1.cri"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."${reg_name}:443"]
+          endpoint = ["https://${reg_name}:443"]
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."${reg_name}:443".tls]
+          insecure_skip_verify = true
 EOF
 
-# 3. Add the registry config to the nodes
-#
-# This is necessary because localhost resolves to loopback addresses that are
-# network-namespace local.
-# In other words: localhost in the container is not localhost on the host.
-#
-# We want a consistent name that works from both ends, so we tell containerd to
-# alias localhost:${reg_port} to the registry container when pulling images
-REGISTRY_DIR="/etc/containerd/certs.d/localhost:${reg_port}"
-for node in $(kind get nodes); do
-  docker exec "${node}" mkdir -p "${REGISTRY_DIR}"
-  cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
-[host."http://${reg_name}:5000"]
-EOF
-done
-
-# 4. Connect the registry to the cluster network if not already connected
+# 3. Connect the registry to the cluster network if not already connected
 # This allows kind to bootstrap the network but ensures they're on the same network
-if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
+if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' ${reg_name})" = 'null' ]; then
   docker network connect "kind" "${reg_name}"
 fi
 
-# 5. Document the local registry
+# 4. Document the local registry
 # https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -59,6 +62,6 @@ metadata:
   namespace: kube-public
 data:
   localRegistryHosting.v1: |
-    host: "localhost:${reg_port}"
+    host: "${reg_name}:443"
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF

--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -6,6 +6,7 @@ set -o errexit
 # 1. Create registry container unless it already exists
 reg_name='kind-registry'
 reg_port='5001'
+# the user is allow to chose a custom name for the kinc cluster. default is "kind"
 cluster_name="${1:-kind}"
 if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
   # create a directory for certificates use to expose the registry
@@ -18,7 +19,7 @@ if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true
   -subj "/C=EU/ST=State/L=Locality/O=Organization/CN=${reg_name}" \
   -x509 -days 365 -out certs/domain.crt
   
-  # allow access to cert from the container
+  # allow access to cert from the container. 
   chmod 755 -R ./certs
 
   # run the registry


### PR DESCRIPTION
Due to kubernetes not allowing plain http image registry, 

i modify the script to generate a self signed certificate and deploy the registry with it. The script also configure kubernetes to use the registry with ssl enabled.

the registry is still available from the host using the same address localhost:5001 to push images. 


