### PR TITLE
docs: Fix quick start formatting issues

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -314,12 +314,13 @@ dedicated to the virtual machine (VM) running the Docker engine. 8GB is recommen
 
 To change the resource limits for the Docker on Mac, you'll need to open the
 **Preferences** menu.
+
 <img src="/docs/user/images/docker-pref-1.png"/>
 
 Now, go to the **Advanced** settings page, and change the
 settings there, see [changing Docker's resource limits][Docker resource lims].
-<img src="/docs/user/images/docker-pref-2.png" alt="Setting 8Gb of memory in Docker for Mac" />
 
+<img src="/docs/user/images/docker-pref-build.png" alt="Setting 8Gb of memory in Docker for Mac" />
 
 To change the resource limits for the Docker on Windows, you'll need to right-click the Moby
 icon on the taskbar, and choose "Settings". If you see "Switch to Linux Containers", then you'll need


### PR DESCRIPTION
There were a couple problems in the Quick Start page under the Settings for Docker Desktop section. There was a broken link to one of the macOS Docker Desktop settings screenshots. There were also a couple missing newlines that caused the formatting to be slightly off, running the text in to the image rather than having a clean separation between them.