### PR TITLE
feat: Ability to set SANs to the API server certificate

### DIFF
--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -177,6 +177,10 @@ type Networking struct {
 	//
 	// Defaults to 127.0.0.1
 	APIServerAddress string `yaml:"apiServerAddress,omitempty" json:"apiServerAddress,omitempty"`
+	// APIServerExtraSANs is the list of additional SANs to add to the Kubernetes API server certificate
+	//
+	// Defaults to []
+	APIServerExtraSANs []string `yaml:"apiServerExtraSANs,omitempty" json:"apiServerExtraSANs,omitempty"`
 	// PodSubnet is the CIDR used for pod IPs
 	// kind will select a default if unspecified
 	PodSubnet string `yaml:"podSubnet,omitempty" json:"podSubnet,omitempty"`

--- a/pkg/cluster/internal/create/actions/config/config.go
+++ b/pkg/cluster/internal/create/actions/config/config.go
@@ -73,6 +73,7 @@ func (a *Action) Execute(ctx *actions.ActionContext) error {
 		ControlPlaneEndpoint: controlPlaneEndpoint,
 		APIBindPort:          common.APIServerInternalPort,
 		APIServerAddress:     ctx.Config.Networking.APIServerAddress,
+		APIServerExtraSANs:   ctx.Config.Networking.APIServerExtraSANs,
 		Token:                kubeadm.Token,
 		PodSubnet:            ctx.Config.Networking.PodSubnet,
 		KubeProxyMode:        string(ctx.Config.Networking.KubeProxyMode),

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -43,6 +43,9 @@ type ConfigData struct {
 	// The API server external listen IP (which we will port forward)
 	APIServerAddress string
 
+	// The API server SANs to add to the API Server certificates
+	APIServerExtraSANs []string
+
 	// this should really be used for the --provider-id flag
 	// ideally cluster config should not depend on the node backend otherwise ...
 	NodeProvider string
@@ -199,7 +202,7 @@ controlPlaneEndpoint: "{{ .ControlPlaneEndpoint }}"
 # so we need to ensure the cert is valid for localhost so we can talk
 # to the cluster after rewriting the kubeconfig to point to localhost
 apiServer:
-  certSANs: [localhost, "{{.APIServerAddress}}"]
+  certSANs: [localhost, "{{.APIServerAddress}}", {{ range .APIServerExtraSANs}}"{{.}}",{{end}}]
   extraArgs:
     "runtime-config": "{{ .RuntimeConfigString }}"
 {{ if .FeatureGates }}
@@ -235,7 +238,7 @@ metadata:
 # we use a well know token for TLS bootstrap
 bootstrapTokens:
 - token: "{{ .Token }}"
-# we use a well know port for making the API server discoverable inside docker network. 
+# we use a well know port for making the API server discoverable inside docker network.
 # from the host machine such port will be accessible via a random local port instead.
 localAPIEndpoint:
   advertiseAddress: "{{ .AdvertiseAddress }}"
@@ -342,7 +345,7 @@ controlPlaneEndpoint: "{{ .ControlPlaneEndpoint }}"
 # so we need to ensure the cert is valid for localhost so we can talk
 # to the cluster after rewriting the kubeconfig to point to localhost
 apiServer:
-  certSANs: [localhost, "{{.APIServerAddress}}"]
+  certSANs: [localhost, "{{.APIServerAddress}}", {{ range .APIServerExtraSANs}}"{{.}}",{{end}}]
   extraArgs:
     "runtime-config": "{{ .RuntimeConfigString }}"
 {{ if .FeatureGates }}
@@ -378,7 +381,7 @@ metadata:
 # we use a well know token for TLS bootstrap
 bootstrapTokens:
 - token: "{{ .Token }}"
-# we use a well know port for making the API server discoverable inside docker network. 
+# we use a well know port for making the API server discoverable inside docker network.
 # from the host machine such port will be accessible via a random local port instead.
 localAPIEndpoint:
   advertiseAddress: "{{ .AdvertiseAddress }}"

--- a/pkg/internal/apis/config/convert_v1alpha4.go
+++ b/pkg/internal/apis/config/convert_v1alpha4.go
@@ -81,6 +81,7 @@ func convertv1alpha4Networking(in *v1alpha4.Networking, out *Networking) {
 	out.IPFamily = ClusterIPFamily(in.IPFamily)
 	out.APIServerPort = in.APIServerPort
 	out.APIServerAddress = in.APIServerAddress
+	out.APIServerExtraSANs = in.APIServerExtraSANs
 	out.PodSubnet = in.PodSubnet
 	out.KubeProxyMode = ProxyMode(in.KubeProxyMode)
 	out.ServiceSubnet = in.ServiceSubnet

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -139,6 +139,10 @@ type Networking struct {
 	//
 	// Defaults to 127.0.0.1
 	APIServerAddress string
+	// APIServerExtraSANs is the list of additional SANs to add to the Kubernetes API server certificate
+	//
+	// Defaults to []
+	APIServerExtraSANs []string
 	// PodSubnet is the CIDR used for pod IPs
 	// kind will select a default if unspecified
 	PodSubnet string

--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -170,6 +170,19 @@ kind does not ship with state of the art security or any update strategy (other 
 disposing your cluster and creating a new one)! We strongly discourage exposing kind
 to anything other than loopback.{{</ securitygoose >}}
 
+##### API Server Cert SANs
+
+The API Server certificate SANscan be customized with `apiServerExtraSANs`:
+{{< codeFromInline lang="yaml" >}}
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  # WARNING: It is _strongly_ recommended that you keep this the default
+  # ([]) for security reasons. However it is possible to change this.
+  apiServerExtraSANs: ["1.1.1.1"]
+{{< /codeFromInline  >}}
+
+
 #### Pod Subnet
 
 You can configure the subnet used for pod IPs by setting


### PR DESCRIPTION
In some cases, if `apiServerAddress` is modified (which is highly not recommended for sure, and should be done if implications are clear) it may be needed to se custom SANs. Example use-case:
* Temporary AWS instance with the ephemeral pub IP
* Kind cluster set up in that AWS instance
* `apiServerAddress` is set to the internal EC2 IP
* External CI system communicates with the temporary Kind cluster
* Error `Unable to connect to the server: tls: failed to verify certificate: x509: certificate is valid for 10.96.0.1, 172.18.0.2, 0.0.0.0, not 18.118.189.168`


Fixes #3755