### PR TITLE
fix missing space in ip6tables error matching

### DIFF
--- a/pkg/cluster/internal/providers/docker/network.go
+++ b/pkg/cluster/internal/providers/docker/network.go
@@ -270,7 +270,7 @@ func isIPv6UnavailableError(err error) bool {
 	// TODO: this is fragile, and only necessary due to docker enabling ipv6 by default
 	// even on hosts that lack ip6tables setup.
 	// Preferably users would either have ip6tables setup properly or else disable ipv6 in docker
-	const dockerIPV6TablesError = "Error response from daemon: Failed to Setup IP tables: Unable to enable NAT rule: (iptables failed: ip6tables"
+	const dockerIPV6TablesError = "Error response from daemon: Failed to Setup IP tables: Unable to enable NAT rule:  (iptables failed: ip6tables"
 	return strings.HasPrefix(errorMessage, dockerIPV6DisabledError) || strings.HasPrefix(errorMessage, dockerIPV6TablesError)
 }
 


### PR DESCRIPTION
follow up to #3749 based on user testing in https://github.com/kubernetes-sigs/kind/issues/3748#issuecomment-2414946811

... the error message from docker has two spaces.

It might make sense to instead check a regex, but I want to put out a trivial fix before thinking about how we want to handle that (we should probably establish a better pattern consistently)