### PR TITLE
Fix pathType setting in usage.yaml

### DIFF
--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -62,14 +62,14 @@ spec:
   rules:
   - http:
       paths:
-      - pathType: Prefix
+      - pathType: ImplementationSpecific
         path: /foo(/|$)(.*)
         backend:
           service:
             name: foo-service
             port:
               number: 8080
-      - pathType: Prefix
+      - pathType: ImplementationSpecific
         path: /bar(/|$)(.*)
         backend:
           service:


### PR DESCRIPTION
The pathType Prefix no longer works, it generates errors. This is the workaround suggested in ingress-nginx issue #10200.

https://github.com/kubernetes/ingress-nginx/issues/10200

I tested it and it worked for me.