### PR TITLE
Update pathType to ImplementationSpecific

### DIFF
--- a/site/static/examples/ingress/usage.yaml
+++ b/site/static/examples/ingress/usage.yaml
@@ -57,19 +57,20 @@ kind: Ingress
 metadata:
   name: example-ingress
   annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   rules:
   - http:
       paths:
-      - pathType: Prefix
+      - pathType: ImplementationSpecific
         path: /foo(/|$)(.*)
         backend:
           service:
             name: foo-service
             port:
               number: 8080
-      - pathType: Prefix
+      - pathType: ImplementationSpecific
         path: /bar(/|$)(.*)
         backend:
           service:


### PR DESCRIPTION
While following the guide at https://kind.sigs.k8s.io/docs/user/ingress/#using-ingress the following errors came up when applying the ingress

```
Warning: path /foo(/|$)(.*) cannot be used with pathType Prefix
Warning: path /bar(/|$)(.*) cannot be used with pathType Prefix
Error from server (BadRequest): error when creating "usage.yaml": admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: ingress contains invalid paths: path /foo(/|$)(.*) cannot be used with pathType Prefix
path /bar(/|$)(.*) cannot be used with pathType Prefix
```
I was able to get it to work by changing pathType to ImplementationSpecific which I got from the example at https://kubernetes.github.io/ingress-nginx/examples/rewrite/#examples