### PR TITLE
Use version tags for 3rd party GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,5 +13,4 @@ updates:
     groups:
       actions:
         update-types:
-          - "minor"
-          - "patch"
+          - "major"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -26,7 +26,7 @@ jobs:
       IP_FAMILY: ${{ matrix.ipFamily }}
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-env
 
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
           path: /tmp/kind/logs

--- a/.github/workflows/nerdctl.yaml
+++ b/.github/workflows/nerdctl.yaml
@@ -30,7 +30,7 @@ jobs:
       KIND_EXPERIMENTAL_PROVIDER: "nerdctl"
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-env
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
           path: /tmp/kind/logs

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -30,7 +30,7 @@ jobs:
       PODMAN_VERSION: "stable"
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-env
 
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
           path: /tmp/kind/logs

--- a/.github/workflows/vm.yaml
+++ b/.github/workflows/vm.yaml
@@ -30,7 +30,7 @@ jobs:
       JOB_NAME: "cgroup2-${{ matrix.provider }}-${{ matrix.rootless }}"
     steps:
       - name: Check out code
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4
 
       - name: Get go version
         id: golangversion
@@ -39,7 +39,7 @@ jobs:
 
       - name: Set up Go
         id: go
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.golangversion.outputs.go_version }}
           check-latest: true
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
           path: /tmp/kind/logs


### PR DESCRIPTION
This switches our third party GitHub Action references to use the major version tag rather than the SHA. This means the actions will automatically use the latest tag within that versions, and Dependabot updates will only be necessary when there is a major version bump where we will want to evaluate the included changes before updating.