### PR TITLE
Fix: update wait command for nginx ingress setup

### DIFF
--- a/site/content/docs/user/ingress.md
+++ b/site/content/docs/user/ingress.md
@@ -71,6 +71,10 @@ Now the Ingress is all setup. Wait until is ready to process requests running:
 
 {{< codeFromInline lang="bash" >}}
 kubectl wait --namespace ingress-nginx \
+  --for=condition=complete job/ingress-nginx-admission-patch \
+  --timeout=30s \
+&& \
+kubectl wait --namespace ingress-nginx \
   --for=condition=ready pod \
   --selector=app.kubernetes.io/component=controller \
   --timeout=90s


### PR DESCRIPTION
This pull request updates the wait command in the nginx ingress setup documentation to address timing issues on slower systems. The original documentation suggested waiting for the ingress controller pod readiness, but did not account for the time required for ingress-nginx-admission-patch and ingress-nginx-admission-create jobs to complete, especially on slower networks or systems.

Changes:

1.)Added a command to wait for the ingress-nginx-admission-patch job to complete before checking the readiness of the ingress controller.
2.)Updated command sequence:
kubectl wait --namespace ingress-nginx \
  --for=condition=complete job/ingress-nginx-admission-patch \
  --timeout=30s \
&& \
kubectl wait --namespace ingress-nginx \
  --for=condition=ready pod \
  --selector=app.kubernetes.io/component=controller \
  --timeout=90s
This improvement will prevent premature command errors (such as no matching resources found) by ensuring the patch job has completed before readiness is checked.

Issue Reference: Resolves #2293

