### PR TITLE
Add note to configuration about HA control plane

### DIFF
--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -261,6 +261,9 @@ nodes:
 - role: worker
 {{< /codeFromInline >}}
 
+Multiple `control-plane` nodes may be specified in order to test a "high availability"
+control plane.
+
 ## Per-Node Options
 
 The following options are available for setting on each entry in `nodes`.


### PR DESCRIPTION
Adds a small note to the Nodes configuration section to point out that multiple control plane nodes may be added to set up a "high availability" control plane cluster.

Closes: #3743