### PR TITLE
chores: add a warning message when delete a not-exists cluster

### DIFF
--- a/pkg/cluster/internal/delete/delete.go
+++ b/pkg/cluster/internal/delete/delete.go
@@ -44,6 +44,8 @@ func Cluster(logger log.Logger, p providers.Provider, name, explicitKubeconfigPa
 			return err
 		}
 		logger.V(0).Infof("Deleted nodes: %q", n)
+	} else {
+		logger.V(0).Infof("Whooops, no nodes found for cluster %q", name)
 	}
 
 	if kerr != nil {


### PR DESCRIPTION
a typo error of clean-script cause we have more and more clusters in our test machine, and we don't observe any message.

So I think this error message is useful to help others to encounter this similar problem