### PR TITLE
bump containerd / runc to v1.7.23 / v1.1.14

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -122,7 +122,7 @@ RUN eval "$(gimme "${GO_VERSION}")" \
 # stage for building containerd
 FROM go-build AS build-containerd
 ARG TARGETARCH GO_VERSION
-ARG CONTAINERD_VERSION="v1.7.18"
+ARG CONTAINERD_VERSION="v1.7.23"
 ARG CONTAINERD_CLONE_URL="https://github.com/containerd/containerd"
 # we don't build with optional snapshotters, we never select any of these
 # they're not ideal inside kind anyhow, and we save some disk space
@@ -140,7 +140,7 @@ RUN git clone --filter=tree:0 "${CONTAINERD_CLONE_URL}" /containerd \
 # stage for building runc
 FROM go-build AS build-runc
 ARG TARGETARCH GO_VERSION
-ARG RUNC_VERSION="v1.1.13"
+ARG RUNC_VERSION="v1.1.14"
 ARG RUNC_CLONE_URL="https://github.com/opencontainers/runc"
 RUN git clone --filter=tree:0 "${RUNC_CLONE_URL}" /runc \
     && cd /runc \


### PR DESCRIPTION
Bump containerd to v1.7.22 to fix [pod deletion failure](https://github.com/kubeovn/kube-ovn/actions/runs/12002458122/job/33454663485) introduced in v1.7.14.

I cannot figure out which version/commit fixes the problem. After upgrading containerd to v1.7.22 no failure occurs anymore in [our test](https://github.com/kubeovn/kube-ovn/actions/runs/12006969275?pr=4760).