### PR TITLE
fix `kind get clusters` via nerdctl

### DIFF
--- a/pkg/cluster/internal/providers/nerdctl/provider.go
+++ b/pkg/cluster/internal/providers/nerdctl/provider.go
@@ -125,7 +125,7 @@ func (p *provider) ListClusters() ([]string, error) {
 		// filter for nodes with the cluster label
 		"--filter", "label="+clusterLabelKey,
 		// format to include the cluster name
-		"--format", fmt.Sprintf(`{{index .Labels "%s"}}`, clusterLabelKey),
+		"--format", fmt.Sprintf(`{{.Label "%s"}}`, clusterLabelKey),
 	)
 	lines, err := exec.OutputLines(cmd)
 	if err != nil {


### PR DESCRIPTION
Fixes #3813

nerdctl fixed the `.Label` behavior in v1.7.0.
https://github.com/containerd/nerdctl/pull/2619

However `index .Labels` syntax is not yet supported at least in v2.0.1.
(The style is also used for podman provider, and it is available)
    
This PR aims to follow up https://github.com/kubernetes-sigs/kind/pull/3429
