### PR TITLE
add fallback version detection for tarballs < v1.31

### DIFF
--- a/pkg/build/nodeimage/internal/kube/builder_remote.go
+++ b/pkg/build/nodeimage/internal/kube/builder_remote.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/log"
 )
 
@@ -78,8 +79,15 @@ func (b *remoteBuilder) Build() (Bits, error) {
 
 	binDir := filepath.Join(tmpDir, "kubernetes/server/bin")
 	contents, err := os.ReadFile(filepath.Join(tmpDir, "kubernetes/version"))
+	// fallback for Kubernetes < v1.31 which doesn't have the version file
+	// this approach only works for release tags as the format happens to match
+	// for pre-release builds the docker tag is mangled and not valid semver
+	if err != nil && os.IsNotExist(err) {
+		b.logger.Warn("WARNING: Using fallback version detection due to missing version file (This command works best with Kubernetes v1.31+)")
+		contents, err = os.ReadFile(filepath.Join(binDir, "kube-apiserver.docker_tag"))
+	}
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to get version")
 	}
 	sourceVersionRaw := strings.TrimSpace(string(contents))
 	return &bits{

--- a/pkg/build/nodeimage/internal/kube/builder_tarball.go
+++ b/pkg/build/nodeimage/internal/kube/builder_tarball.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/log"
 )
 
@@ -59,8 +60,15 @@ func (b *directoryBuilder) Build() (Bits, error) {
 
 	binDir := filepath.Join(tmpDir, "kubernetes/server/bin")
 	contents, err := os.ReadFile(filepath.Join(tmpDir, "kubernetes/version"))
+	// fallback for Kubernetes < v1.31 which doesn't have the version file
+	// this approach only works for release tags as the format happens to match
+	// for pre-release builds the docker tag is mangled and not valid semver
+	if err != nil && os.IsNotExist(err) {
+		b.logger.Warn("WARNING: Using fallback version detection due to missing version file (This command works best with Kubernetes v1.31+)")
+		contents, err = os.ReadFile(filepath.Join(binDir, "kube-apiserver.docker_tag"))
+	}
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to get version")
 	}
 	sourceVersionRaw := strings.TrimSpace(string(contents))
 	return &bits{


### PR DESCRIPTION
ref https://github.com/kubernetes-sigs/kind/issues/3797

This effectively restores the behavior before https://github.com/kubernetes-sigs/kind/pull/3715 only when we can't get the `version` file, along with a warning. It will not work with pre-release builds or builds with custom version metadata appended, as before, but it will work with normal upstream tagged stable release builds < v1.31.

For 1.31+ we should continue to use the `version` file, which will work with pre-release builds and builds with custom build metadata (`v1.31.1+foo`)

Alternative to https://github.com/kubernetes-sigs/kind/pull/3800