### PR TITLE
more upgrades for v0.26.0

### DIFF
--- a/images/local-path-provisioner/Makefile
+++ b/images/local-path-provisioner/Makefile
@@ -11,6 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-VERSION=v0.0.24
+VERSION=v0.0.30
 EXTRA_BUILD_OPT=--build-arg=VERSION=$(VERSION)
 include $(CURDIR)/../Makefile.common.in

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20241108-5c6d2daf"
+const DefaultBaseImage = "docker.io/kindest/base:v20241212-9f82dd49"


### PR DESCRIPTION
1) pickup new base image (but not new node image yet, less disruptive when we're in-flight upgrading the rest, and we already tested a staging node image)

2) bump local-path-provisioner to build v0.0.30, I looked over this and will do an upgrade as the next PR, after the image builds. there are some nice improvements and it should be compatible based on release notes and the manifest etc.