### PR TITLE
Add description to delete cluster subcommands

### DIFF
--- a/pkg/cmd/kind/delete/cluster/deletecluster.go
+++ b/pkg/cmd/kind/delete/cluster/deletecluster.go
@@ -38,11 +38,17 @@ type flagpole struct {
 func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	flags := &flagpole{}
 	cmd := &cobra.Command{
-		Args: cobra.NoArgs,
-		// TODO(bentheelder): more detailed usage
+		Args:  cobra.NoArgs,
 		Use:   "cluster",
 		Short: "Deletes a cluster",
-		Long:  "Deletes a resource",
+		Long: `Deletes a Kind cluster from the system.
+
+This is an idempotent operation, meaning it may be called multiple times without
+failing (like "rm -f"). If the cluster resources exist they will be deleted, and
+if the cluster is already gone it will just return success.
+
+Errors will only occur if the cluster resources exist and are not able to be deleted.
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cli.OverrideDefaultName(cmd.Flags())
 			return deleteCluster(logger, flags)

--- a/pkg/cmd/kind/delete/clusters/deleteclusters.go
+++ b/pkg/cmd/kind/delete/clusters/deleteclusters.go
@@ -37,11 +37,17 @@ type flagpole struct {
 func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	flags := &flagpole{}
 	cmd := &cobra.Command{
-		Args: cobra.MinimumNArgs(0),
-		// TODO(bentheelder): more detailed usage
+		Args:  cobra.MinimumNArgs(0),
 		Use:   "clusters",
 		Short: "Deletes one or more clusters",
-		Long:  "Deletes a resource",
+		Long: `Deletes one or more Kind clusters from the system.
+
+This is an idempotent operation, meaning it may be called multiple times without
+failing (like "rm -f"). If the cluster resources exist they will be deleted, and
+if the cluster is already gone it will just return success.
+
+Errors will only occur if the cluster resources exist and are not able to be deleted.
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !flags.All && len(args) == 0 {
 				return errors.New("no cluster names provided")


### PR DESCRIPTION
This adds a more detailed description to the `kind delete cluster` and `kind delete clusters` commands explaining expected delete behavior.

Hopefully this reduces some of the regular confusion from users submitting issues due to expecting an error deleting a cluster that does not exist.

Updated command output:

```txt
$ kind delete cluster --help
Deletes a Kind cluster from the system.

This is an idempotent operation, meaning it may be called multiple times without
failing. If the cluster exists it will be deleted, and if the cluster is already
gone it will just return success. Errors will only occur if the cluster exists
and was not able to be deleted.

Usage:
  kind delete cluster [flags]

Flags:
  -h, --help                help for cluster
      --kubeconfig string   sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config
  -n, --name string         the cluster name (default "kind")

Global Flags:
  -q, --quiet             silence all stderr output
  -v, --verbosity int32   info log verbosity, higher value produces more output
```