### PR TITLE
update to latest base image with containerd 2.0.2, ensure containerd is ready before importing images

### DIFF
--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027"
+const Image = "kindest/node:v1.32.1@sha256:6afef2b7f69d627ea7bf27ee6696b6868d18e03bf98167c420df486da4662db6"

--- a/pkg/build/nodeimage/buildcontext.go
+++ b/pkg/build/nodeimage/buildcontext.go
@@ -267,18 +267,22 @@ func (c *buildContext) prePullImagesAndWriteManifests(bits kube.Bits, parsedVers
 	}()
 
 	fns := []func() error{}
+	osArch := dockerBuildOsAndArch(c.arch)
 	for _, image := range requiredImages {
 		image := image // https://golang.org/doc/faq#closures_and_goroutines
-		fns = append(fns, func() error {
-			if !builtImages.Has(image) {
-				if err = importer.Pull(image, dockerBuildOsAndArch(c.arch)); err != nil {
+		if !builtImages.Has(image) {
+			fns = append(fns, func() error {
+				if err = importer.Pull(image, osArch); err != nil {
 					c.logger.Warnf("Failed to pull %s with error: %v", image, err)
 					runE := exec.RunErrorForError(err)
 					c.logger.Warn(string(runE.Output))
+					c.logger.Warnf("Retrying %s pull after 1s ...", image)
+					time.Sleep(time.Second)
+					return importer.Pull(image, osArch)
 				}
-			}
-			return nil
-		})
+				return nil
+			})
+		}
 	}
 	if err := errors.AggregateConcurrent(fns); err != nil {
 		return nil, err

--- a/pkg/build/nodeimage/buildcontext.go
+++ b/pkg/build/nodeimage/buildcontext.go
@@ -284,6 +284,11 @@ func (c *buildContext) prePullImagesAndWriteManifests(bits kube.Bits, parsedVers
 			})
 		}
 	}
+	// Wait for containerd socket to be ready, which may take 1s when running under emulation
+	if err := importer.WaitForReady(); err != nil {
+		c.logger.Errorf("Image build failed, containerd did not become ready %v", err)
+		return nil, err
+	}
 	if err := errors.AggregateConcurrent(fns); err != nil {
 		return nil, err
 	}

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20241212-9f82dd49"
+const DefaultBaseImage = "docker.io/kindest/base:v20250117-f528b021"


### PR DESCRIPTION
contains the base image built from https://github.com/kubernetes-sigs/kind/pull/3828 in https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kind-push-base-image/1880330906284068864

TODO: node image (prow e2es will use this, github actions will use the default node image only, though I expect we are more likely to catch issues in the full kubernetes e2e tests anyhow for this particular change)