### PR TITLE
test: upgrade nerdctl to v2

### DIFF
--- a/.github/workflows/nerdctl.yaml
+++ b/.github/workflows/nerdctl.yaml
@@ -26,7 +26,7 @@ jobs:
     env:
       JOB_NAME: "nerdctl-${{ matrix.deployment }}-${{ matrix.ipFamily }}"
       IP_FAMILY: ${{ matrix.ipFamily }}
-      NERDCTL_VERSION: "1.7.4"
+      NERDCTL_VERSION: "2.0.2"
       KIND_EXPERIMENTAL_PROVIDER: "nerdctl"
     steps:
       - name: Check out code into the Go module directory
@@ -91,7 +91,7 @@ jobs:
       - name: Export logs
         if: always()
         run: |
-          sudo cat /etc/cni/net.d/* 
+          sudo find /etc/cni/net.d/ -type f -exec sh -c 'echo "{}" && cat "{}"' \;
           sudo mkdir -p /tmp/kind/logs
           sudo /usr/local/bin/kind export logs /tmp/kind/logs
           sudo chown -R $USER:$USER /tmp/kind/logs


### PR DESCRIPTION
> This release of nerdctl is expected to be used with containerd v1.6, v1.7, or v2.0.
> https://github.com/containerd/nerdctl/releases/tag/v2.0.2

The nerdctl v2.x is also expected to be compatible with containerd v2. 

This pull request includes updates to version numbers for dependencies in the `nerdctl` GitHub workflow and the default base image in the `nodeimage` package.

Version updates:

* [`.github/workflows/nerdctl.yaml`](diffhunk://#diff-4e2320dfb704eab40a465b6a57332f8c4b000bc4dd27248ac3a7f64b8b0c766eL29-R29): Updated `NERDCTL_VERSION` from "1.7.4" to "2.0.2".
~* [`pkg/build/nodeimage/defaults.go`](diffhunk://#diff-4283c324e37748a6ec55fe240d2d06561a180ca2b170d684b30edd2d9564e743L25-R25): Updated `DefaultBaseImage` from "docker.io/kindest/base:v20241212-9f82dd49" to "docker.io/kindest/base:v20250117-f528b021".~

