### PR TITLE
Statically link CNI plugins

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -176,7 +176,7 @@ RUN git clone --filter=tree:0 "${CNI_PLUGINS_CLONE_URL}" /cni-plugins \
     && eval "$(gimme "${GO_VERSION}")" \
     && export GOTOOLCHAIN="go${GO_VERSION}" \
     && mkdir ./bin \
-    && export GOARCH=$TARGETARCH && export CC=$(target-cc) && export CGO_ENABLED=1 \
+    && export GOARCH=$TARGETARCH && export CC=$(target-cc) && export CGO_ENABLED=0 \
     && go build -o ./bin/host-local -mod=vendor ./plugins/ipam/host-local \
     && go build -o ./bin/loopback -mod=vendor ./plugins/main/loopback \
     && go build -o ./bin/ptp -mod=vendor ./plugins/main/ptp \


### PR DESCRIPTION
Picking a release of cni plugins and inspecting the binaries shows that they are statically linked. So we should do the same.

Following up to a multus-cni testing issue: 
- https://github.com/k8snetworkplumbingwg/multus-cni/pull/1213#issuecomment-2626094985
- https://github.com/k8snetworkplumbingwg/multus-cni/pull/1213#issuecomment-2635853338

```
$ find . -type f | xargs file | grep executable | cut -f 1-4 -d ','
./vrf:                                   ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./host-device:                           ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./vlan:                                  ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./portmap:                               ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./dhcp:                                  ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./sbr:                                   ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./firewall:                              ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./tuning:                                ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./host-local:                            ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./tap:                                   ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./bridge:                                ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./macvlan:                               ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./bandwidth:                             ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./ptp:                                   ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./ipvlan:                                ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./static:                                ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./loopback:                              ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./dummy:                                 ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
```