### PR TITLE
bump base image with statically linked plugins, improve new push-node.sh, adopt 1.32.2

### DIFF
--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.32.1@sha256:6afef2b7f69d627ea7bf27ee6696b6868d18e03bf98167c420df486da4662db6"
+const Image = "kindest/node:v1.32.2@sha256:ec2582d73b2982e0c515f6630a6d3af5a599f5f8a830d2f65f09e61600314b88"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20250117-f528b021"
+const DefaultBaseImage = "docker.io/kindest/base:v20250212-53ff1fb7"


### PR DESCRIPTION
picks up #3859

improves push-node.sh usability / logging (default to latest stable release if no version specified)

~~TEMP: testing new node image in staging~~ bumped node image