### PR TITLE
bump actions runners to ubuntu 22.04, as 20.04 is deprecated

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   docker:
     name: Docker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   podman:
     name: Podman
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/11101

the others were already on 22.04