### PR TITLE
bump base image to v20250228-c27ae4d9 with runc 1.2.4

### DIFF
--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20250214-acbabc1a"
+const DefaultBaseImage = "docker.io/kindest/base:v20250228-c27ae4d9"


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kind-push-base-image/1895426829129355264 / https://github.com/kubernetes-sigs/kind/pull/3877