### PR TITLE
fix: set global arp_ignore param for kindnet

### DIFF
--- a/images/base/files/etc/sysctl.d/10-network-magic.conf
+++ b/images/base/files/etc/sysctl.d/10-network-magic.conf
@@ -9,3 +9,17 @@
 # Kubernetes mitigates the possible security issue caused by enabling this option.
 # ref: https://nvd.nist.gov/vuln/detail/CVE-2020-8558
 net.ipv4.conf.all.route_localnet=1
+
+# The global kernel parameter net.ipv4.conf.all.arp_ignore governs the
+# conditions under which ARP requests will be accepted or ignored. This global
+# setting will override any individual interface settings. Some host systems
+# might set this global parameter to a more restrictive setting of 2 (or
+# greater). Specifically, in mode 2, the system ignores ARP requests directed to
+# /32 addresses (this is what kindnet assigns to its veth interfaces) because
+# the request originates from a different subnet. This behavior breaks routing
+# for kindnet (specifically the ptp plugin), so we opinionatedly set this to 0
+# when kindnet is in use to ensure proper networking.
+#
+# For more information see:
+# https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html#arp_ignore
+net.ipv4.conf.all.arp_ignore=0


### PR DESCRIPTION
Resolves #3880

If we do decide to go this way, in my testing setting `1` appears to work properly, and since this is the first time we've been opinionated about it it seems like an opportunity to set it as restrictively as we can tolerate. However we went with a setting of `0` because that has been the historically anticipated setting.