### PR TITLE
update runc and containerd to latest stable

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -122,7 +122,7 @@ RUN eval "$(gimme "${GO_VERSION}")" \
 # stage for building containerd
 FROM go-build AS build-containerd
 ARG TARGETARCH GO_VERSION
-ARG CONTAINERD_VERSION="v2.0.2"
+ARG CONTAINERD_VERSION="v2.0.3"
 ARG CONTAINERD_CLONE_URL="https://github.com/containerd/containerd"
 # we don't build with optional snapshotters, we never select any of these
 # they're not ideal inside kind anyhow, and we save some disk space
@@ -140,7 +140,7 @@ RUN git clone --filter=tree:0 "${CONTAINERD_CLONE_URL}" /containerd \
 # stage for building runc
 FROM go-build AS build-runc
 ARG TARGETARCH GO_VERSION
-ARG RUNC_VERSION="v1.2.4"
+ARG RUNC_VERSION="v1.2.5"
 ARG RUNC_CLONE_URL="https://github.com/opencontainers/runc"
 RUN git clone --filter=tree:0 "${RUNC_CLONE_URL}" /runc \
     && cd /runc \


### PR DESCRIPTION
note: containerd 2.0.3 ships with runc 1.2.5 upstream

https://github.com/containerd/containerd/releases/tag/v2.0.3