### PR TITLE
update registry docs for containerd 2.x

### DIFF
--- a/site/content/docs/user/private-registries.md
+++ b/site/content/docs/user/private-registries.md
@@ -104,9 +104,10 @@ nodes:
     extraMounts:
       - containerPath: /etc/docker/certs.d/registry.dev.example.com
         hostPath: /etc/docker/certs.d/registry.dev.example.com
+# NOTE: the following patch is not necessary with images from kind v0.27.0+
+# It may enable some older images to work similarly
 containerdConfigPatches:
-  - |-
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.dev.example.com".tls]
-      cert_file = "/etc/docker/certs.d/registry.dev.example.com/ba_client.cert"
-      key_file  = "/etc/docker/certs.d/registry.dev.example.com/ba_client.key"
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"
 {{< /codeFromInline >}}

--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -11,8 +11,10 @@ if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true
 fi
 
 # 2. Create kind cluster with containerd registry config dir enabled
-# TODO: kind will eventually enable this by default and this patch will
-# be unnecessary.
+#
+# NOTE: the containerd config patch is not necessary with images from kind v0.27.0+
+# It may enable some older images to work similarly.
+# If you're only supporting newer relases, you can just use `kind create cluster` here.
 #
 # See:
 # https://github.com/kubernetes-sigs/kind/issues/2875


### PR DESCRIPTION
see: https://github.com/kubernetes-sigs/kind/issues/3884

note: private registry is untested, but consistent with the upstream docs