### PR TITLE
update default base, node image

### DIFF
--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f"
+const Image = "kindest/node:v1.32.2@sha256:142f543559cc55d64e1ab9341df08e5ced84bd2e893736da8f51320f26f5950b"

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20250228-c27ae4d9"
+const DefaultBaseImage = "docker.io/kindest/base:v20250305-2d7b9fe8"


### PR DESCRIPTION
"promoted" (crane cp) from https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kind-push-base-image/1897268305459154944

TODO: node image