### PR TITLE
Handle tild (user home dir) when define a host path

### DIFF
--- a/pkg/cluster/internal/providers/podman/provision.go
+++ b/pkg/cluster/internal/providers/podman/provision.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/constants"
 	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/exec"
+	"sigs.k8s.io/kind/pkg/fs"
 
 	"sigs.k8s.io/kind/pkg/cluster/internal/loadbalancer"
 	"sigs.k8s.io/kind/pkg/cluster/internal/providers/common"
@@ -86,7 +87,7 @@ func planCreation(cfg *config.Cluster, networkName string) (createContainerFuncs
 		// fixup relative paths, podman can only handle absolute paths
 		for i := range node.ExtraMounts {
 			hostPath := node.ExtraMounts[i].HostPath
-			absHostPath, err := filepath.Abs(hostPath)
+			absHostPath, err := fs.Abs(hostPath)
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to resolve absolute path for hostPath: %q", hostPath)
 			}


### PR DESCRIPTION
Using kind on macos, I want to share my Podman auth file, but tild ~ is not working.

This PR:

- add utils fs function "Abs" that handle tild
- use this function for podman provider only

I can write tests if needed!

Relates:

- https://github.com/kubernetes-sigs/kind/issues/3642

Thanks you