### PR TITLE
pin new actions to commit.

### DIFF
--- a/.github/workflows/vm.yaml
+++ b/.github/workflows/vm.yaml
@@ -44,11 +44,11 @@ jobs:
           check-latest: true
 
       - name: "Install Lima"
-        uses: lima-vm/lima-actions/setup@v1
+        uses: lima-vm/lima-actions/setup@be564a1408f84557d067b099a475652288074b2e # v1
         id: lima-actions-setup
 
       - name: "Cache ~/.cache/lima"
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/lima
           key: lima-${{ steps.lima-actions-setup.outputs.version }}


### PR DESCRIPTION
all previous actions already pinned.

limits exposure to something like https://arstechnica.com/information-technology/2025/03/supply-chain-attack-exposing-credentials-affects-23k-users-of-tj-actions/

to explicit actions update PRs

we regressed in https://github.com/kubernetes-sigs/kind/pull/3889, though this is just "best practice" here, we have NONE with write permission, and actions CI results are already untrustworthy due to running with the config in the PR branch rather than the config of the target branch anyhow