### PR TITLE
Promote stmcginnis to maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,7 @@ reviewers:
 approvers:
   - aojea
   - BenTheElder
+  - stmcginnis
 emeritus_approvers:
   - amwat
   - munnerz

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The maintainers of this project are reachable via:
 - [filing an issue] against this repo
 - The Kubernetes [SIG-Testing Mailing List]
 
-Current maintainers are [@aojea] and [@BenTheElder] - feel free to
+Current maintainers are [@aojea], [@BenTheElder], and [@stmcginnis] - feel free to
 reach out if you have any questions!
 
 Pull Requests are very welcome!
@@ -171,6 +171,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [@munnerz]: https://github.com/munnerz
 [@aojea]: https://github.com/aojea
 [@amwat]: https://github.com/amwat
+[@stmcginnis]: https://github.com/stmcginnis
 [contributor guide]: https://kind.sigs.k8s.io/docs/contributing/getting-started
 [releases]: https://github.com/kubernetes-sigs/kind/releases
 [install guide]: https://kind.sigs.k8s.io/docs/user/quick-start/#installation


### PR DESCRIPTION
Sean has been a long time contributor and reviewer now. Discussed with him and aojea at The KubeCon EU maintainer summit :-)

/assign @stmcginnis @aojea
/hold

We'll need to do some follow up administrivia, kubernetes/org and kubernetes/k8s.io have permissions to the repo and staging infra respectively, and we'll manually coordinate the dockerhub.