### PR TITLE
Update nginx controller from 1.12.0-beta.0 to 1.12.1

### DIFF
--- a/site/static/examples/ingress/deploy-ingress-nginx.yaml
+++ b/site/static/examples/ingress/deploy-ingress-nginx.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx
   namespace: ingress-nginx
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -130,7 +130,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -149,7 +149,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -231,7 +231,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -270,7 +270,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -289,7 +289,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -308,7 +308,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -328,7 +328,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -340,7 +340,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -372,7 +372,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -395,7 +395,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -417,7 +417,7 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.12.0-beta.0
+        app.kubernetes.io/version: 1.12.1
     spec:
       containers:
       - args:
@@ -442,7 +442,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
-        image: registry.k8s.io/ingress-nginx/controller:v1.12.0-beta.0@sha256:9724476b928967173d501040631b23ba07f47073999e80e34b120e8db5f234d5
+        image: registry.k8s.io/ingress-nginx/controller:v1.12.1@sha256:9724476b928967173d501040631b23ba07f47073999e80e34b120e8db5f234d5
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -528,7 +528,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -539,7 +539,7 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.12.0-beta.0
+        app.kubernetes.io/version: 1.12.1
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -580,7 +580,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -591,7 +591,7 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.12.0-beta.0
+        app.kubernetes.io/version: 1.12.1
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -634,7 +634,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -647,7 +647,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.0-beta.0
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
​This pull request updates the NGINX Ingress Controller from version 1.12.0-beta.0 to 1.12.1, addressing several critical security vulnerabilities and improving the stability of ingress resources
**Security Enhancements:**
* IngressNightmare Vulnerabilities: The previous version was susceptible to multiple vulnerabilities collectively known as "IngressNightmare." These included issues like configuration injection via unsanitized annotations and a critical remote code execution vulnerability in the admission controller component (CVE-2025-1974). Upgrading to version 1.12.1 mitigates these vulnerabilities. 