### PR TITLE
migrate off of gopkg.in/yaml.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
-	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -28,4 +27,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
+	// TODO: https://github.com/google/safetext/issues/9
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/apis/config/v1alpha4/yaml.go
+++ b/pkg/apis/config/v1alpha4/yaml.go
@@ -27,7 +27,7 @@ Custom YAML (de)serialization for these types
 */
 
 // UnmarshalYAML implements custom decoding YAML
-// https://godoc.org/gopkg.in/yaml.v3
+// https://godoc.org/sigs.k8s.io/yaml/goyaml.v3
 func (m *Mount) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// first unmarshal in the alias type (to avoid a recursion loop on unmarshal)
 	type MountAlias Mount
@@ -50,7 +50,7 @@ func (m *Mount) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML implements custom decoding YAML
-// https://godoc.org/gopkg.in/yaml.v3
+// https://godoc.org/sigs.k8s.io/yaml/goyaml.v3
 func (p *PortMapping) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// first unmarshal in the alias type (to avoid a recursion loop on unmarshal)
 	type PortMappingAlias PortMapping

--- a/pkg/cluster/internal/kubeconfig/internal/kubeconfig/encode.go
+++ b/pkg/cluster/internal/kubeconfig/internal/kubeconfig/encode.go
@@ -19,8 +19,8 @@ package kubeconfig
 import (
 	"bytes"
 
-	yaml "gopkg.in/yaml.v3"
 	kubeyaml "sigs.k8s.io/yaml"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	"sigs.k8s.io/kind/pkg/errors"
 )

--- a/pkg/cluster/internal/kubeconfig/internal/kubeconfig/read.go
+++ b/pkg/cluster/internal/kubeconfig/internal/kubeconfig/read.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"os"
 
-	yaml "gopkg.in/yaml.v3"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	"sigs.k8s.io/kind/pkg/errors"
 )

--- a/pkg/internal/apis/config/encoding/load.go
+++ b/pkg/internal/apis/config/encoding/load.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"os"
 
-	yaml "gopkg.in/yaml.v3"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	"sigs.k8s.io/kind/pkg/errors"

--- a/pkg/internal/patch/toml.go
+++ b/pkg/internal/patch/toml.go
@@ -23,7 +23,8 @@ import (
 	burntoml "github.com/BurntSushi/toml"
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	toml "github.com/pelletier/go-toml"
-	yaml "gopkg.in/yaml.v3"
+
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	"sigs.k8s.io/kind/pkg/errors"
 )


### PR DESCRIPTION
TODO: https://github.com/google/safetext/issues/9

(we still wind up with it in our dependency tree for now ...)