### PR TITLE
eliminate yaml.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	al.essio.dev/pkg/shellescape v1.5.1
 	github.com/BurntSushi/toml v1.4.0
 	github.com/evanphx/json-patch/v5 v5.6.0
-	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2
 	github.com/mattn/go-isatty v0.0.20
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
@@ -23,10 +22,14 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
+// test-only transitive deps, these are used by sigs.k8s.io/yaml's tests
+require (
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
+)
+
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	// TODO: https://github.com/google/safetext/issues/9
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJ
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 h1:SJ+NtwL6QaZ21U+IrK7d0gGgpjGGvd2kz+FzTHVzdqI=
-github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2/go.mod h1:Tv1PlzqC9t8wNnpPdctvtSUOPUUg4SHeE6vR1Ir2hmg=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -38,7 +36,6 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/pkg/cluster/internal/create/actions/installcni/cni.go
+++ b/pkg/cluster/internal/create/actions/installcni/cni.go
@@ -20,8 +20,7 @@ package installcni
 import (
 	"bytes"
 	"strings"
-
-	"github.com/google/safetext/yamltemplate"
+	"text/template"
 
 	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/internal/apis/config"
@@ -70,7 +69,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 	// their own, or use the default. The internal templating mechanism is
 	// not intended for external usage and is unstable.
 	if strings.Contains(manifest, "would you kindly template this file") {
-		t, err := yamltemplate.New("cni-manifest").Parse(manifest)
+		t, err := template.New("cni-manifest").Parse(manifest)
 		if err != nil {
 			return errors.Wrap(err, "failed to parse CNI manifest template")
 		}

--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -21,8 +21,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-
-	"github.com/google/safetext/yamltemplate"
+	"text/template"
 
 	"sigs.k8s.io/kind/pkg/errors"
 
@@ -192,7 +191,7 @@ kubernetesVersion: {{.KubernetesVersion}}
 clusterName: "{{.ClusterName}}"
 {{ if .KubeadmFeatureGates}}featureGates:
 {{ range $key, $value := .KubeadmFeatureGates }}
-  "{{ (StructuralData $key) }}": {{ $value }}
+  "{{ $key }}": {{ $value }}
 {{end}}{{end}}
 controlPlaneEndpoint: "{{ .ControlPlaneEndpoint }}"
 # on docker for mac we have to expose the api server via port forward,
@@ -292,7 +291,7 @@ evictionHard:
   imagefs.available: "0%"
 {{if .FeatureGates}}featureGates:
 {{ range $index, $gate := .SortedFeatureGates }}
-  "{{ (StructuralData $gate.Name) }}": {{ $gate.Value }}
+  "{{ $gate.Name }}": {{ $gate.Value }}
 {{end}}{{end}}
 {{if ne .KubeProxyMode "none"}}
 ---
@@ -303,7 +302,7 @@ metadata:
 mode: "{{ .KubeProxyMode }}"
 {{if .FeatureGates}}featureGates:
 {{ range $index, $gate := .SortedFeatureGates }}
-  "{{ (StructuralData $gate.Name) }}": {{ $gate.Value }}
+  "{{ $gate.Name }}": {{ $gate.Value }}
 {{end}}{{end}}
 iptables:
   minSyncPeriod: 1s
@@ -335,7 +334,7 @@ kubernetesVersion: {{.KubernetesVersion}}
 clusterName: "{{.ClusterName}}"
 {{ if .KubeadmFeatureGates}}featureGates:
 {{ range $key, $value := .KubeadmFeatureGates }}
-  "{{ (StructuralData $key) }}": {{ $value }}
+  "{{ $key }}": {{ $value }}
 {{end}}{{end}}
 controlPlaneEndpoint: "{{ .ControlPlaneEndpoint }}"
 # on docker for mac we have to expose the api server via port forward,
@@ -447,7 +446,7 @@ evictionHard:
   imagefs.available: "0%"
 {{if .FeatureGates}}featureGates:
 {{ range $index, $gate := .SortedFeatureGates }}
-  "{{ (StructuralData $gate.Name) }}": {{ $gate.Value }}
+  "{{ $gate.Name }}": {{ $gate.Value }}
 {{end}}{{end}}
 {{if ne .KubeProxyMode "none"}}
 ---
@@ -458,7 +457,7 @@ metadata:
 mode: "{{ .KubeProxyMode }}"
 {{if .FeatureGates}}featureGates:
 {{ range $index, $gate := .SortedFeatureGates }}
-  "{{ (StructuralData $gate.Name) }}": {{ $gate.Value }}
+  "{{ $gate.Name }}": {{ $gate.Value }}
 {{end}}{{end}}
 iptables:
   minSyncPeriod: 1s
@@ -508,7 +507,7 @@ func Config(data ConfigData) (config string, err error) {
 		templateSource = ConfigTemplateBetaV2
 	}
 
-	t, err := yamltemplate.New("kubeadm-config").Parse(templateSource)
+	t, err := template.New("kubeadm-config").Parse(templateSource)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse config template")
 	}


### PR DESCRIPTION
not convinced these were necessary, users can patch arbitrary yaml in anyhow, I don't think there's a realistic threat model resolved by safetext/yamltemplate

further, the safetext repo doesn't seem to be responsively maintained, last commit 9 months ago, and the small number of issues are going unresponded (4 open, 0 closed, some multiple years old)