### PR TITLE
docs: add note about vpn cidr clashes

### DIFF
--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -41,7 +41,7 @@ description: |-
 * [Docker Desktop for macOS and Windows](#docker-desktop-for-macos-and-windows)
 * [Older Linux Distributions](#older-linux-distributions)
 * [Failure to Create Cluster on WSL2](#failure-to-create-cluster-on-wsl2)
-*  [VPN CIDR clashes](#vpn-cidr-clashes)
+* [VPN CIDR clashes](#vpn-cidr-clashes)
 
 ## Troubleshooting Kind
 

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -41,7 +41,7 @@ description: |-
 * [Docker Desktop for macOS and Windows](#docker-desktop-for-macos-and-windows)
 * [Older Linux Distributions](#older-linux-distributions)
 * [Failure to Create Cluster on WSL2](#failure-to-create-cluster-on-wsl2)
-* [VPN CIDR clashes](#vpn-cidr-clashes)
+* [Local Subnet Clashes](#local-subnet-clashes)
 
 ## Troubleshooting Kind
 
@@ -417,11 +417,11 @@ the project relies on community support and feedback. It has been noted that the
 steps detailed in [https://github.com/spurin/wsl-cgroupsv2](https://github.com/spurin/wsl-cgroupsv2)
 have been necessary to resolve this issue.
 
-## VPN CIDR Clashes
+## Local Subnet Clashes
 
 KIND creates a separate docker network named `kind` that will be configured with default IPAM settings. If you are using the default IPAM configuration in your `daemon.json` you
-may have conflicts with existing VPNs that route the 172.17.x.x networks. To resolve this you can reconfigure the daemon-wide IPAM so that all networks will be created in subnets
-that do not have these conflicts.
+may have conflicts with existing networks (like VPNs, labs, etc) that route the 172.17.x.x networks. To resolve this you can reconfigure the daemon-wide IPAM so that all 
+networks will be created in subnets that do not have these conflicts.
 
 An example configuration that you can add to your `daemon.json` is below. This would configure `10.253.0.0/16` as the defauld CIDR with each individual network receiving a /24
 subnet to use for allocation.

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -41,6 +41,7 @@ description: |-
 * [Docker Desktop for macOS and Windows](#docker-desktop-for-macos-and-windows)
 * [Older Linux Distributions](#older-linux-distributions)
 * [Failure to Create Cluster on WSL2](#failure-to-create-cluster-on-wsl2)
+*  [VPN CIDR clashes](#vpn-cidr-clashes)
 
 ## Troubleshooting Kind
 
@@ -415,6 +416,25 @@ The KIND development team is not able to provide support with Windows and WSL, s
 the project relies on community support and feedback. It has been noted that the
 steps detailed in [https://github.com/spurin/wsl-cgroupsv2](https://github.com/spurin/wsl-cgroupsv2)
 have been necessary to resolve this issue.
+
+## VPN CIDR Clashes
+
+KIND creates a separate docker network named `kind` that will be configured with default IPAM settings. If your host's VPN configuration overlaps with this default range (172.17.x.x) you
+will be unable to access your KIND clusters from outside of the container. The network that is created persists even after the last KIND cluster is deleted, so you can resolve this
+by configuring the network manually before use. For example:
+
+```sh
+# stop your KIND cluster
+kind delete cluster
+
+# delete the docker network
+docker network rm kind
+
+# create a new network with a non-conflicting CIDR
+docker network create --subnet=10.253.0.0/22 kind
+```
+
+NOTE: You will need to configure/create the network again should you execute a `docker prune` or other operation that may lead to the network being deleted.
 
 [kind#156]: https://github.com/kubernetes-sigs/kind/issues/156
 [kind#229]: https://github.com/kubernetes-sigs/kind/issues/229

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -419,22 +419,23 @@ have been necessary to resolve this issue.
 
 ## VPN CIDR Clashes
 
-KIND creates a separate docker network named `kind` that will be configured with default IPAM settings. If your host's VPN configuration overlaps with this default range (172.17.x.x) you
-will be unable to access your KIND clusters from outside of the container. The network that is created persists even after the last KIND cluster is deleted, so you can resolve this
-by configuring the network manually before use. For example:
+KIND creates a separate docker network named `kind` that will be configured with default IPAM settings. If you are using the default IPAM configuration in your `daemon.json` you
+may have conflicts with existing VPNs that route the 172.17.x.x networks. To resolve this you can reconfigure the daemon-wide IPAM so that all networks will be created in subnets
+that do not have these conflicts.
 
-```sh
-# stop your KIND cluster
-kind delete cluster
+An example configuration that you can add to your `daemon.json` is below. This would configure `10.253.0.0/16` as the defauld CIDR with each individual network receiving a /24
+subnet to use for allocation.
 
-# delete the docker network
-docker network rm kind
-
-# create a new network with a non-conflicting CIDR
-docker network create --subnet=10.253.0.0/22 kind
+```json
+"default-address-pools": [
+  {
+    "base": "10.253.0.0/16",
+    "size": 24
+  }
+]
 ```
 
-NOTE: You will need to configure/create the network again should you execute a `docker prune` or other operation that may lead to the network being deleted.
+For more information on the Docker Engine config file check out [these docs](https://docs.docker.com/engine/daemon/).
 
 [kind#156]: https://github.com/kubernetes-sigs/kind/issues/156
 [kind#229]: https://github.com/kubernetes-sigs/kind/issues/229


### PR DESCRIPTION
This PR is a quick note about clashing VPN CIDRs with the KIND docker network that is created by default.

I ran into this issue as the default 172.17.x.x network overlaps with some internal corporate VPN networks. I was able to resolve it by creating the network manually with a CIDR that did not conflict. This fix will persist as long as the network is not removed.