### PR TITLE
chore: bump base image to v20250506-ce37e374 with cni plugin 1.7.1

### DIFF
--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20250424-c9432c36"
+const DefaultBaseImage = "docker.io/kindest/base:v20250506-ce37e374"


### PR DESCRIPTION


```shell
$ docker pull kindest/base:v20250506-ce37e374
v20250506-ce37e374: Pulling from kindest/base
7caba30019f6: Pull complete
Digest: sha256:114ee9370555ef3bf86130f988a63eeecebb312ea7e6941dd513d0e02b8c7f07
Status: Downloaded newer image for kindest/base:v20250506-ce37e374
docker.io/kindest/base:v20250506-ce37e374
```

follow up: https://github.com/kubernetes-sigs/kind/pull/3925

/assign @BenTheElder