### PR TITLE
push-node: default to staging registry

### DIFF
--- a/hack/release/build/push-node.sh
+++ b/hack/release/build/push-node.sh
@@ -15,7 +15,7 @@
 
 set -o errexit -o nounset -o pipefail
 
-REGISTRY="${REGISTRY:-kindest}"
+REGISTRY="${REGISTRY:-gcr.io/k8s-staging-kind}"
 IMAGE_NAME="${IMAGE_NAME:-node}"
 
 # cd to the repo root


### PR DESCRIPTION
the newer script that uses pre-built binaries for 1.31+ already does this

/cc @stmcginnis 