### PR TITLE
loadbalancer/config: Parse resolv.conf for DNS

### DIFF
--- a/pkg/cluster/internal/loadbalancer/config.go
+++ b/pkg/cluster/internal/loadbalancer/config.go
@@ -40,7 +40,7 @@ global
   maxconn 100000
 
 resolvers docker
-  nameserver dns 127.0.0.11:53
+  parse-resolv-conf
 
 defaults
   log global


### PR DESCRIPTION
Control plane in HA setup doesn't currently work using Podman. This is because the haproxy DNS server is hard-coded to use 127.0.0.1:53, which is not available on Podman.

To get the actual NS address, /etc/resolv.conf must be consulted. So this patch adds parse-resolv-conf to the haproxy resolvers block, which makes HA control plane work on Podman instantly.

127.0.0.1:53 is retained as a nameserver still.

### Context

Let's use the following config:

```yaml
apiVersion: kind.x-k8s.io/v1alpha4
kind: Cluster
name: multinode
nodes:
  - role: control-plane
  - role: control-plane
  - role: control-plane
  - role: worker
```

Then let's run the following:

```
$ ./bin/kind create cluster --config kindconfig.yaml --retain
```

The output with some truncated parts:

```
enabling experimental podman provider
Creating cluster "multinode" ...
 ✓ Ensuring node image (kindest/node:v1.33.1) 🖼
 ✓ Preparing nodes 📦 📦 📦 📦  
 ✓ Configuring the external load balancer ⚖ 
 ✓ Writing configuration 📜 
 ✗ Starting control-plane 🕹 
ERROR: failed to create cluster: failed to init node with kubeadm: command "podman exec --privileged multinode-control-plane kubeadm init --config=/kind/kubeadm.conf --skip-token-print --v=6" failed with error: exit status 1

(...)

I0627 13:13:47.242628     171 round_trippers.go:632] "Response" verb="GET" url="https://multinode-external-load-balancer:6443/livez?timeout=10s" status="" milliseconds=1
I0627 13:13:48.243680     171 with_retry.go:234] "Got a Retry-After response" delay="1s" attempt=8 url="https://multinode-external-load-balancer:6443/livez?timeout=10s"
I0627 13:13:48.244978     171 round_trippers.go:632] "Response" verb="GET" url="https://multinode-external-load-balancer:6443/livez?timeout=10s" status="" milliseconds=1
I0627 13:13:49.245139     171 with_retry.go:234] "Got a Retry-After response" delay="1s" attempt=9 url="https://multinode-external-load-balancer:6443/livez?timeout=10s"
I0627 13:13:49.246500     171 round_trippers.go:632] "Response" verb="GET" url="https://multinode-external-load-balancer:6443/livez?timeout=10s" status="" milliseconds=1
[control-plane-check] kube-apiserver is not healthy after 4m0.000259768s
```

I then tried to `curl` the first control plane node to the the health status, everything was ok.
On the other hand, haproxy was showing

```
10.89.0.67:54516 [27/Jun/2025:13:10:07.229] control-plane kube-apiservers/<NOSRV> -1/-1/0 0 SC 1/1/0/0/0 0/0
10.89.0.67:58518 [27/Jun/2025:13:10:08.231] control-plane kube-apiservers/<NOSRV> -1/-1/0 0 SC 1/1/0/0/0 0/0
10.89.0.67:58528 [27/Jun/2025:13:10:09.232] control-plane kube-apiservers/<NOSRV> -1/-1/0 0 SC 1/1/0/0/0 0/0
10.89.0.67:58530 [27/Jun/2025:13:10:10.217] control-plane kube-apiservers/<NOSRV> -1/-1/0 0 SC 1/1/0/0/0 0/0
10.89.0.67:58538 [27/Jun/2025:13:10:11.218] control-plane kube-apiservers/<NOSRV> -1/-1/0 0 SC 1/1/0/0/0 0/0
10.89.0.67:58550 [27/Jun/2025:13:10:12.220] control-plane kube-apiservers/<NOSRV> -1/-1/0 0 SC 1/1/0/0/0 0/0
```

After much research I nailed it down to a DNS issue.
Applying this patch makes the cluster boot just fine.
haproxy was actually not logging any health check, which was confusing, but now:

```
[WARNING] 177/132752 (29) : Health check for server kube-apiservers/multinode-control-plane succeeded, reason: Layer7 check passed, code: 200, check duration: 5ms, status: 1/2 DOWN.
Server kube-apiservers/multinode-control-plane is UP. 1 active and 0 backup servers online. 0 sessions requeued, 0 total in queue.
```
