### PR TITLE
WIP: tag with git hash

### DIFF
--- a/images/Makefile.common.in
+++ b/images/Makefile.common.in
@@ -21,7 +21,7 @@ REGISTRY?=gcr.io/k8s-staging-kind
 # for appending build-meta like "_containerd-v1.7.1"
 TAG_SUFFIX?=
 # tag based on date-sha
-TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git describe --always --dirty)")
+TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git log --pretty=format:'%h' -n 1)")
 # the full image tag
 IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)$(TAG_SUFFIX)
 # Go version to use, respected by images that build go binaries


### PR DESCRIPTION
Something changed and our automatic image builds now have fancy git describe output instead of just the date+hash.

This would ensure we keep using date+hash.

I think that's probably the best move for now.