### PR TITLE
Add priority class to kindnet daemonset

### DIFF
--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -104,6 +104,7 @@ spec:
         kubernetes.io/os: linux
       tolerations:
       - operator: Exists
+      priorityClassName: system-node-critical
       serviceAccountName: kindnet
       containers:
       - name: kindnet-cni


### PR DESCRIPTION
This PR adds the priority class `system-node-critical` to the kindnet daemonset to avoid preemption.