### PR TITLE
Be more clear on the expected format of --wait option

### DIFF
--- a/pkg/cmd/kind/create/cluster/createcluster.go
+++ b/pkg/cmd/kind/create/cluster/createcluster.go
@@ -83,7 +83,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		&flags.Wait,
 		"wait",
 		time.Duration(0),
-		"wait for control plane node to be ready (default 0s)",
+		"The length of time to wait for control plane node to be ready (default 0s). Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).",
 	)
 	cmd.Flags().StringVar(
 		&flags.Kubeconfig,


### PR DESCRIPTION
Follow up from #3418 and #3419.

`kind create cluster --help` does not explain what is the expected format of the `--wait` option. This is described in the quick start, but not in the command line help output. This change adds more a more verbose description to make it more clear.

Thanks for @radeksm for the original suggestion and work on this.