### PR TITLE
Use YAMLToJSONStrict instead of YAMLToJSON when loading patches

### DIFF
--- a/pkg/cluster/internal/create/actions/installcni/cni.go
+++ b/pkg/cluster/internal/create/actions/installcni/cni.go
@@ -110,7 +110,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			Patch:   patchValue,
 		}
 
-		patchedConfig, err := patch.KubeYAML(manifest, nil, []config.PatchJSON6902{controlPlanePatch6902})
+		patchedConfig, err := patch.KubeYAML(manifest, nil, []config.PatchJSON6902{controlPlanePatch6902}, ctx.Logger)
 		if err != nil {
 			return err
 		}

--- a/pkg/internal/patch/kubeyaml.go
+++ b/pkg/internal/patch/kubeyaml.go
@@ -17,12 +17,11 @@ limitations under the License.
 package patch
 
 import (
-	"sigs.k8s.io/kind/pkg/log"
 	"strings"
 
 	"sigs.k8s.io/kind/pkg/errors"
-
 	"sigs.k8s.io/kind/pkg/internal/apis/config"
+	"sigs.k8s.io/kind/pkg/log"
 )
 
 // KubeYAML takes a Kubernetes object YAML document stream to patch,

--- a/pkg/internal/patch/kubeyaml.go
+++ b/pkg/internal/patch/kubeyaml.go
@@ -17,6 +17,7 @@ limitations under the License.
 package patch
 
 import (
+	"sigs.k8s.io/kind/pkg/log"
 	"strings"
 
 	"sigs.k8s.io/kind/pkg/errors"
@@ -34,13 +35,13 @@ import (
 //
 // Patches match if their kind and apiVersion match a document, with the exception
 // that if the patch does not set apiVersion it will be ignored.
-func KubeYAML(toPatch string, patches []string, patches6902 []config.PatchJSON6902) (string, error) {
+func KubeYAML(toPatch string, patches []string, patches6902 []config.PatchJSON6902, logger log.Logger) (string, error) {
 	// pre-process, including splitting up documents etc.
 	resources, err := parseResources(toPatch)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse yaml to patch")
 	}
-	mergePatches, err := parseMergePatches(patches)
+	mergePatches, err := parseMergePatches(patches, logger)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse patches")
 	}

--- a/pkg/internal/patch/kubeyaml_test.go
+++ b/pkg/internal/patch/kubeyaml_test.go
@@ -61,6 +61,12 @@ func TestKubeYAML(t *testing.T) {
 			ExpectError:     false,
 			ExpectOutput:    normalKubeadmConfigTrivialPatchedAnd6902Patched,
 		},
+		{
+			Name:        "kubeadm config one merge-patch with malformed yaml (duplicate key)",
+			ToPatch:     normalKubeadmConfig,
+			Patches:     []string{malformedPatchWithDuplicateKey},
+			ExpectError: true,
+		},
 	}
 	for _, tc := range cases {
 		tc := tc // capture test case
@@ -401,4 +407,19 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 metadata:
   name: config
+`
+const malformedPatchWithDuplicateKey = `
+kind: ClusterConfiguration
+apiVersion: kubeadm.k8s.io/v1beta2
+
+scheduler:
+  extraArgs:
+   some-extra-arg: the-arg
+   some-extra-arg: the-arg
+----
+kind: InitConfiguration
+nodeRegistration:
+  kubeletExtraArgs:
+    "v": "4"
+    "logging-format": "json"
 `

--- a/pkg/internal/patch/kubeyaml_test.go
+++ b/pkg/internal/patch/kubeyaml_test.go
@@ -62,10 +62,11 @@ func TestKubeYAML(t *testing.T) {
 			ExpectOutput:    normalKubeadmConfigTrivialPatchedAnd6902Patched,
 		},
 		{
-			Name:        "kubeadm config one merge-patch with malformed yaml (duplicate key)",
-			ToPatch:     normalKubeadmConfig,
-			Patches:     []string{malformedPatchWithDuplicateKey},
-			ExpectError: true,
+			Name:         "kubeadm config one merge-patch with malformed yaml (duplicate key)",
+			ToPatch:      normalKubeadmConfig,
+			Patches:      []string{malformedPatchWithDuplicateKey},
+			ExpectOutput: malformedPatchWithDuplicateKeyKustomized,
+			ExpectError:  false,
 		},
 	}
 	for _, tc := range cases {
@@ -414,12 +415,77 @@ apiVersion: kubeadm.k8s.io/v1beta2
 
 scheduler:
   extraArgs:
-   some-extra-arg: the-arg
-   some-extra-arg: the-arg
-----
+   some-duplicate-key: value1
+   some-duplicate-key: value2
+`
+
+const malformedPatchWithDuplicateKeyKustomized = `apiServer:
+  certSANs:
+  - localhost
+  - 127.0.0.1
+apiVersion: kubeadm.k8s.io/v1beta2
+clusterName: kind
+controlPlaneEndpoint: 192.168.9.3:6443
+controllerManager:
+  extraArgs:
+    enable-hostpath-provisioner: "true"
+kind: ClusterConfiguration
+kubernetesVersion: v1.15.3
+metadata:
+  name: config
+networking:
+  podSubnet: 10.244.0.0/16
+  serviceSubnet: 10.96.0.0/12
+scheduler:
+  extraArgs:
+    some-duplicate-key: value2
+---
+apiVersion: kubeadm.k8s.io/v1beta2
+bootstrapTokens:
+- token: abcdef.0123456789abcdef
 kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 192.168.9.6
+  bindPort: 6443
+metadata:
+  name: config
 nodeRegistration:
+  criSocket: /run/containerd/containerd.sock
   kubeletExtraArgs:
-    "v": "4"
-    "logging-format": "json"
+    fail-swap-on: "false"
+    node-ip: 192.168.9.6
+---
+apiVersion: kubeadm.k8s.io/v1beta2
+controlPlane:
+  localAPIEndpoint:
+    advertiseAddress: 192.168.9.6
+    bindPort: 6443
+discovery:
+  bootstrapToken:
+    apiServerEndpoint: 192.168.9.3:6443
+    token: abcdef.0123456789abcdef
+    unsafeSkipCAVerification: true
+kind: JoinConfiguration
+metadata:
+  name: config
+nodeRegistration:
+  criSocket: /run/containerd/containerd.sock
+  kubeletExtraArgs:
+    fail-swap-on: "false"
+    node-ip: 192.168.9.6
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+evictionHard:
+  imagefs.available: 0%
+  nodefs.available: 0%
+  nodefs.inodesFree: 0%
+imageGCHighThresholdPercent: 100
+kind: KubeletConfiguration
+metadata:
+  name: config
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metadata:
+  name: config
 `

--- a/pkg/internal/patch/kubeyaml_test.go
+++ b/pkg/internal/patch/kubeyaml_test.go
@@ -21,6 +21,7 @@ import (
 
 	"sigs.k8s.io/kind/pkg/internal/apis/config"
 	"sigs.k8s.io/kind/pkg/internal/assert"
+	"sigs.k8s.io/kind/pkg/log"
 )
 
 func TestKubeYAML(t *testing.T) {
@@ -73,7 +74,7 @@ func TestKubeYAML(t *testing.T) {
 		tc := tc // capture test case
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			out, err := KubeYAML(tc.ToPatch, tc.Patches, tc.PatchesJSON6902)
+			out, err := KubeYAML(tc.ToPatch, tc.Patches, tc.PatchesJSON6902, log.NoopLogger{})
 			assert.ExpectError(t, tc.ExpectError, err)
 			if err == nil {
 				assert.StringEqual(t, tc.ExpectOutput, out)

--- a/pkg/internal/patch/mergepatch.go
+++ b/pkg/internal/patch/mergepatch.go
@@ -44,7 +44,7 @@ func parseMergePatches(rawPatches []string) ([]mergePatch, error) {
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
-		json, err := yaml.YAMLToJSON([]byte(raw))
+		json, err := yaml.YAMLToJSONStrict([]byte(raw))
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/pkg/internal/patch/mergepatch.go
+++ b/pkg/internal/patch/mergepatch.go
@@ -17,9 +17,10 @@ limitations under the License.
 package patch
 
 import (
+	"sigs.k8s.io/yaml"
+
 	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/log"
-	"sigs.k8s.io/yaml"
 )
 
 type mergePatch struct {

--- a/pkg/internal/patch/mergepatch.go
+++ b/pkg/internal/patch/mergepatch.go
@@ -17,11 +17,9 @@ limitations under the License.
 package patch
 
 import (
-	"fmt"
-	"os"
-	"sigs.k8s.io/yaml"
-
 	"sigs.k8s.io/kind/pkg/errors"
+	"sigs.k8s.io/kind/pkg/log"
+	"sigs.k8s.io/yaml"
 )
 
 type mergePatch struct {
@@ -30,7 +28,7 @@ type mergePatch struct {
 	matchInfo matchInfo // for matching resources
 }
 
-func parseMergePatches(rawPatches []string) ([]mergePatch, error) {
+func parseMergePatches(rawPatches []string, logger log.Logger) ([]mergePatch, error) {
 	patches := []mergePatch{}
 	// split document streams before trying to parse them
 	splitRawPatches := make([]string, 0, len(rawPatches))
@@ -48,10 +46,8 @@ func parseMergePatches(rawPatches []string) ([]mergePatch, error) {
 		}
 		json, err := yaml.YAMLToJSONStrict([]byte(raw))
 		if err != nil {
-			fmt.Fprintf(
-				os.Stderr,
-				"\033[33m\nWARN: Error converting patch of kind %s to json: \"%v\". "+
-					"Trying more permissive conversion.\033[0m\n",
+			logger.Warnf("Failed to strictly convert patch of kind %s to json: \"%v\". "+
+				"Trying more permissive conversion.",
 				matchInfo.Kind,
 				err,
 			)

--- a/pkg/internal/patch/mergepatch.go
+++ b/pkg/internal/patch/mergepatch.go
@@ -17,6 +17,8 @@ limitations under the License.
 package patch
 
 import (
+	"fmt"
+	"os"
 	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/kind/pkg/errors"
@@ -46,7 +48,17 @@ func parseMergePatches(rawPatches []string) ([]mergePatch, error) {
 		}
 		json, err := yaml.YAMLToJSONStrict([]byte(raw))
 		if err != nil {
-			return nil, errors.WithStack(err)
+			fmt.Fprintf(
+				os.Stderr,
+				"\033[33m\nWARN: Error converting patch of kind %s to json: \"%v\". "+
+					"Trying more permissive conversion.\033[0m\n",
+				matchInfo.Kind,
+				err,
+			)
+			json, err = yaml.YAMLToJSON([]byte(raw))
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
 		}
 		patches = append(patches, mergePatch{
 			raw:       raw,


### PR DESCRIPTION
Currently when yamls with duplicate key entries are used for config patches, neither a warning nor an error message is displayed. For example using this malformed patch (See duplicate key in the last line) :
```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
kubeadmConfigPatches:
- |
  kind: InitConfiguration
  nodeRegistration:
    kubeletExtraArgs:
      anonymous-auth: "true"
      anonymous-auth: "false"
``` 
with `kind create cluster --config ./kind-config.yaml -v=9` will result in the following `kubeadm.config` (only relavant lines are shown):
```bash
  kubeletExtraArgs:
    anonymous-auth: "false"
``` 
This PR contains a change to use `YAMLToJSONStrict` instead of the more relaxed `YAMLToJSON`. I also added a test case for an example with a duplicate key.