### PR TITLE
Bump image from bullseye to bookworm for local-path-helper

### DIFF
--- a/images/local-path-helper/Dockerfile
+++ b/images/local-path-helper/Dockerfile
@@ -15,7 +15,7 @@
 # This image is contains the binaries needed for the local-path-provisioner
 # helper pod. Currently that means: sh, rm, mkdir
 
-ARG BASE="registry.k8s.io/build-image/debian-base:bullseye-v1.4.3"
+ARG BASE="registry.k8s.io/build-image/debian-base:bookworm-v1.0.5"
 FROM ${BASE} AS build
 
 # NOTE: copyrights.tar.gz is a quirk of Kubernetes's debian-base image
@@ -42,6 +42,6 @@ RUN mkdir -p "${STAGE_DIR}" && \
     find "${STAGE_DIR}"
 
 # copy staged binary + deps + copyright into distroless
-FROM "gcr.io/distroless/static-debian11"
+FROM "gcr.io/distroless/static-debian12"
 ARG STAGE_DIR="/opt/stage"
 COPY --from=build "${STAGE_DIR}/" /

--- a/images/local-path-helper/stage-binary-and-deps.sh
+++ b/images/local-path-helper/stage-binary-and-deps.sh
@@ -30,7 +30,8 @@ file_to_package() {
     # `dpkg-query --search $file-pattern` outputs lines with the format: "$package: $file-path"
     # where $file-path belongs to $package
     # https://manpages.debian.org/jessie/dpkg/dpkg-query.1.en.html
-    dpkg-query --search "$(realpath "${1}")" | cut -d':' -f1
+    # Match bash path in dpkg regardless of /usr merge
+    dpkg-query --search "$(realpath "${1}" | sed 's|/usr|*|')" | cut -d':' -f1
 }
 
 # package_to_copyright gives the path to the copyright file for the package $1

--- a/images/local-path-provisioner/Dockerfile
+++ b/images/local-path-provisioner/Dockerfile
@@ -29,7 +29,7 @@ RUN eval "$(gimme "${GO_VERSION}")" \
     && GOBIN=/usr/local/bin go install github.com/google/go-licenses@latest \
     && GOARCH=$TARGETARCH go-licenses save --save_path=/_LICENSES .
 
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base-debian12
 COPY --from=0 /usr/local/bin/local-path-provisioner /usr/local/bin/local-path-provisioner
 COPY --from=0 /_LICENSES/* /LICENSES/
 COPY --chmod=0644 files/LICENSES/* /LICENSES/*


### PR DESCRIPTION
### Changes:
1. Bumped base image from Debian Bullseye to Bookworm

2. Fixed dpkg-query failure due to path mismatch
   **Root cause:** The build script uses `which bash`, resolving to /usr/bin/bash. On systems with merged /usr layout, this path is valid, but dpkg-query only matches exact paths recorded in the package database—typically /bin/bash. (_mismatch occurs because dpkg-query doesn’t follow symlinks or filesystem structure; it relies solely on the original install path recorded by the package_)
   **Fix:** Used wildcard match — `dpkg-query -S '*/bin/bash'`

### **Testing:**
- Image built successfully using Podman
- Verification pending via Makefile-based tests