### PR TITLE
Upgrade to haproxy 3.2.x

### DIFF
--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -15,7 +15,7 @@
 # This image is a haproxy image + minimal config so the container will not exit
 # while we rewrite the config at runtime and signal haproxy to reload.
 
-ARG BASE="registry.k8s.io/build-image/debian-base:bullseye-v1.4.3"
+ARG BASE="registry.k8s.io/build-image/debian-base:bookworm-v1.0.5"
 FROM ${BASE} AS build
 
 # NOTE: copyrights.tar.gz is a quirk of Kubernetes's debian-base image
@@ -27,8 +27,19 @@ RUN [ ! -f /usr/share/copyrights.tar.gz ] || tar -C / -xzvf /usr/share/copyright
 # - haproxy (see: https://haproxy.debian.net/)
 # - bash (ldd is a bash script and debian-base removes bash)
 # - procps (for `kill` which kind needs)
+# install curl and ca-certificates to enable dedcate repositories
 RUN apt update && \
-    apt install -y --no-install-recommends haproxy=2.2.\* \
+    apt install -y --no-install-recommends curl
+RUN apt update && apt install -y ca-certificates
+# enable dedicated repositories to install latest haproxy (see: https://haproxy.debian.net/#distribution=Debian&release=bookworm&version=3.2) 
+RUN curl https://haproxy.debian.net/haproxy-archive-keyring.gpg \
+    --create-dirs --output /etc/apt/keyrings/haproxy-archive-keyring.gpg
+RUN echo deb "[signed-by=/etc/apt/keyrings/haproxy-archive-keyring.gpg]" \
+      https://haproxy.debian.net bookworm-backports-3.2 main \
+      > /etc/apt/sources.list.d/haproxy.list
+# install the latest stable haproxy version compatible with bookworm
+RUN apt update && \
+    apt install -y --no-install-recommends haproxy=3.2.\* \
       procps bash
 
 # copy in script for staging distro provided binary to distroless
@@ -50,7 +61,7 @@ RUN mkdir -p "${STAGE_DIR}" && \
 
 # See: https://github.com/GoogleContainerTools/distroless/tree/main/base
 # This has /etc/passwd, tzdata, cacerts
-FROM "gcr.io/distroless/static-debian11"
+FROM "gcr.io/distroless/static-debian12"
 
 ARG STAGE_DIR="/opt/stage"
 

--- a/images/haproxy/stage-binary-and-deps.sh
+++ b/images/haproxy/stage-binary-and-deps.sh
@@ -30,7 +30,7 @@ file_to_package() {
     # `dpkg-query --search $file-pattern` outputs lines with the format: "$package: $file-path"
     # where $file-path belongs to $package
     # https://manpages.debian.org/jessie/dpkg/dpkg-query.1.en.html
-    dpkg-query --search "$(realpath "${1}")" | cut -d':' -f1
+    dpkg-query --search "$(realpath "${1}" | sed 's|/usr|*|')" | cut -d':' -f1
 }
 
 # package_to_copyright gives the path to the copyright file for the package $1

--- a/images/local-path-helper/Dockerfile
+++ b/images/local-path-helper/Dockerfile
@@ -15,7 +15,7 @@
 # This image is contains the binaries needed for the local-path-provisioner
 # helper pod. Currently that means: sh, rm, mkdir
 
-ARG BASE="registry.k8s.io/build-image/debian-base:bullseye-v1.4.3"
+ARG BASE="registry.k8s.io/build-image/debian-base:bookworm-v1.0.5"
 FROM ${BASE} AS build
 
 # NOTE: copyrights.tar.gz is a quirk of Kubernetes's debian-base image
@@ -42,6 +42,6 @@ RUN mkdir -p "${STAGE_DIR}" && \
     find "${STAGE_DIR}"
 
 # copy staged binary + deps + copyright into distroless
-FROM "gcr.io/distroless/static-debian11"
+FROM "gcr.io/distroless/static-debian12"
 ARG STAGE_DIR="/opt/stage"
 COPY --from=build "${STAGE_DIR}/" /

--- a/images/local-path-helper/stage-binary-and-deps.sh
+++ b/images/local-path-helper/stage-binary-and-deps.sh
@@ -30,7 +30,8 @@ file_to_package() {
     # `dpkg-query --search $file-pattern` outputs lines with the format: "$package: $file-path"
     # where $file-path belongs to $package
     # https://manpages.debian.org/jessie/dpkg/dpkg-query.1.en.html
-    dpkg-query --search "$(realpath "${1}")" | cut -d':' -f1
+    # Match bash path in dpkg regardless of /usr merge
+    dpkg-query --search "$(realpath "${1}" | sed 's|/usr|*|')" | cut -d':' -f1
 }
 
 # package_to_copyright gives the path to the copyright file for the package $1

--- a/images/local-path-provisioner/Dockerfile
+++ b/images/local-path-provisioner/Dockerfile
@@ -29,7 +29,7 @@ RUN eval "$(gimme "${GO_VERSION}")" \
     && GOBIN=/usr/local/bin go install github.com/google/go-licenses@latest \
     && GOARCH=$TARGETARCH go-licenses save --save_path=/_LICENSES .
 
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base-debian12
 COPY --from=0 /usr/local/bin/local-path-provisioner /usr/local/bin/local-path-provisioner
 COPY --from=0 /_LICENSES/* /LICENSES/
 COPY --chmod=0644 files/LICENSES/* /LICENSES/*


### PR DESCRIPTION
There was an attempt to upgrade to bookworm before #3294 (see: comments)
But was switched back to bullseye (#3350, #3351)

This PR upgrades the haproxy to latest stable 3.2.x , which is compatible with bookworm.

Raised another PR just for bumping the debian-base image from bullseye to bookworm #4003 .This PR has redundant changes as #4003 ;will clean it up later.