### PR TITLE
doc: runtimeConfig can be used to enable deprecated APIs

### DIFF
--- a/site/content/docs/user/configuration.md
+++ b/site/content/docs/user/configuration.md
@@ -86,13 +86,14 @@ featureGates:
 
 Kubernetes API server runtime-config can be toggled using the `runtimeConfig`
 key, which maps to the `--runtime-config` [kube-apiserver flag](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/).
-This may be used to e.g. disable beta / alpha APIs.
+This may be used to e.g. disable beta / alpha APIs, or even enable deprecated APIs.
 
 {{< codeFromInline lang="yaml" >}}
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 runtimeConfig:
   "api/alpha": "false"
+  "apps/v1beta2": "true"
 {{< /codeFromInline >}}
 
 ### Networking


### PR DESCRIPTION
Closes #1271.

This PR documents how to enable deprecated APIs via `runtimeConfig`. 

This ticket is a bit old, so I tested that this still works via kind v0.27.0, running images for v1.29.14.

```
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
  - role: control-plane
    image: kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29
  - role: worker
    image: kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29
runtimeConfig:
  "api/alpha": "true"
```

After creating the cluster I can see the `ValidatingAdmissionPolicy` is enabled at v1alpha1. In k8s v1.29, the v1alpha1 version of this resource was deprecated in favor of v1beta1 [(link)](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#validatingadmissionpolicy-v1beta1-admissionregistration-k8s-io).

```
$  k api-resources | grep admission
mutatingwebhookconfigurations                    admissionregistration.k8s.io/v1         false        MutatingWebhookConfiguration
validatingadmissionpolicies                      admissionregistration.k8s.io/v1alpha1   false        ValidatingAdmissionPolicy
validatingadmissionpolicybindings                admissionregistration.k8s.io/v1alpha1   false        ValidatingAdmissionPolicyBinding
validatingwebhookconfigurations                  admissionregistration.k8s.io/v1         false        ValidatingWebhookConfiguration
```

Creating a cluster without the `runtimeConfig` above results in no `ValidatingAdmissionPolicies` being shown.

````
$  k api-resources | grep admission
mutatingwebhookconfigurations                  admissionregistration.k8s.io/v1   false        MutatingWebhookConfiguration
validatingwebhookconfigurations                admissionregistration.k8s.io/v1   false        ValidatingWebhookConfiguration
```
