### PR TITLE
docs: remove reference to archived blixt repository

### DIFF
--- a/site/content/docs/user/ingress.md
+++ b/site/content/docs/user/ingress.md
@@ -20,8 +20,6 @@ Ingress exposes HTTP and HTTPS routes from outside the cluster to services withi
 
 > **NOTE**: You may also want to consider using [Gateway API](https://gateway-api.sigs.k8s.io/) instead of Ingress.
 > Gateway API has an [Ingress migration guide](https://gateway-api.sigs.k8s.io/guides/migrating-from-ingress/).
->
-> You can use blixt to test Gateway API with kind https://github.com/kubernetes-sigs/blixt#usage
 
 ### Create Cluster
 


### PR DESCRIPTION
On the 8th of September the [`blixt`](https://github.com/kubernetes-retired/blixt/commit/02feed6d6a373c6db2ad3746b1c013db2be1a22f) repository was marked as archived and isn't actively maintained anymore.