### PR TITLE
e2e-k8s.sh: don't manipulate SKIP when LABEL_FILTER is used

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -246,19 +246,31 @@ run_tests() {
   fi
 
   # ginkgo regexes and label filter
+  #
+  # Defaults for FOCUS and SKIP only get set when the job hasn't been converted
+  # to use LABEL_FILTER. This emulates the historic behavior while making
+  # updated jobs easier to read ("what you see is what you get").
+  #
+  # It also enables jobs where all tests (serial and parallel) run with
+  # parallel execution of the parallel tests, followed by sequential execution
+  # of the serial ones. This has been supported since Ginkgo v2 but not by
+  # this script because of the mandatory SKIP="\\[Serial\\]".
   SKIP="${SKIP:-}"
   FOCUS="${FOCUS:-}"
   LABEL_FILTER="${LABEL_FILTER:-}"
   if [ -z "${FOCUS}" ] && [ -z "${LABEL_FILTER}" ]; then
     FOCUS="\\[Conformance\\]"
   fi
-  # if we set PARALLEL=true, skip serial tests set --ginkgo-parallel
+  # If we have PARALLEL=true, set --ginkgo-parallel.
+  # Skip serial tests only if the job has not been converted to use LABEL_FILTER.
   if [ "${PARALLEL:-false}" = "true" ]; then
     export GINKGO_PARALLEL=y
-    if [ -z "${SKIP}" ]; then
-      SKIP="\\[Serial\\]"
-    else
-      SKIP="\\[Serial\\]|${SKIP}"
+    if [ -z "${LABEL_FILTER}" ]; then
+      if [ -z "${SKIP}" ]; then
+        SKIP="\\[Serial\\]"
+      else
+        SKIP="\\[Serial\\]|${SKIP}"
+      fi
     fi
   fi
 


### PR DESCRIPTION
It's unexpected when a job runs a different set of tests than specified by LABEL_FILTER. Not only that, at least for periodic jobs it would be desirable to have only one variant of the job which runs all tests (serial and parallel), with parallel execution of the parallel tests. Maintaining two variants is more work and makes the testgrid dashboards larger.

This change does not affect jobs that don't use LABEL_FILTER because the traditional behavior is preserved for those.

It does affect the following jobs (based on "grep 'name: LABEL_FILTER'"):

  - pull-kind-conformance-parallel-dual-stack-ipv4-ipv6
  - pull-kind-e2e-kubernetes
  - pull-kind-e2e-kubernetes-canary
  - ci-kubernetes-kube-network-policies-conformance-parallel
  - ci-kubernetes-kube-network-policies-conformance-parallel-ipv6
  - pull-kube-network-policies-nftables
  - pull-kube-network-policies-nftables-ipv6
  - pull-kubernetes-e2e-kind-dependencies (also for 1.34)
  - pull-kubernetes-e2e-kind-golang-tip (also for 1.34)
  - ci-kubernetes-e2e-kind-dependencies (also for 1.34)
  - ci-kubernetes-e2e-kind-golang-tip (also for 1.34)
  - ci-kubernetes-kind-e2e-json-logging (also in release branches)
  - ci-kubernetes-network-kind-alpha-beta-features
  - ci-kubernetes-e2e-kind (also for 1.34)
  - ci-kubernetes-e2e-kind-ipv6
  - ci-kubernetes-e2e-kind-beta-features
  - ci-kubernetes-e2e-kind-alpha-beta-features
  - pull-kubernetes-e2e-kind
  - pull-kubernetes-e2e-kind-canary
  - pull-kubernetes-e2e-kind-ipv6
  - pull-kubernetes-e2e-kind-ipv6-canary
  - pull-kubernetes-e2e-kind-beta-features
  - pull-kubernetes-e2e-kind-beta-enabled
  - pull-kubernetes-e2e-kind-beta-enabled-conformance
  - pull-kubernetes-e2e-kind-alpha-beta-features
  - pull-kubernetes-e2e-kind-alpha-beta-enabled
  - pull-kubernetes-e2e-kind-alpha-beta-enabled-conformance
  - pull-kubernetes-e2e-kind-alpha-beta-features-race
  - pull-kubernetes-e2e-kind-evented-pleg
  - pull-kubernetes-e2e-storage-kind-alpha-beta-features-slow

kube-network-policies already ran serial conformance tests (`|| Conformance`), but not normal serial tests.

Some other jobs using LABEL_FILTER already explicitly disabled serial tests and thus get the same behavior as before.

The first two are inconsistent at the moment: pull-kind-e2e-kubernetes is probably meant to run more than conformance tests and correctly does so by not setting FOCUS. pull-kind-conformance-parallel-dual-stack-ipv4-ipv6 is meant to be limited to conformance, but does not filter by that in LABEL_FILTER and thus runs also non-conformance tests because the FOCUS default already got disabled earlier when using LABEL_FILTER.

Other jobs may need an explicit `!Serial`, depending on the intention of the job owner, before the e2e-k8s.sh can be changed. https://github.com/kubernetes/test-infra/pull/35594 contains those changes. It needs to be merged first.