### PR TITLE
Add CONTROLLERS environment variable to e2e-k8s.sh

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -38,6 +38,9 @@ set -o errexit -o nounset -o xtrace
 #          JSON or YAML encoding of a string/string (!) map: {"apia.example.com/v1alpha1": "true", "apib.example.com/v1beta1": "false"}
 #          Enables API groups in the apiserver via --runtime-config.
 #          Cannot be used when GA_ONLY=true.
+# CONTROLLERS:
+#          Value for kube-controller-manager's "--controllers" argument.
+#          e.g. "-endpoints-controller,-endpointslice-mirroring-controller,*"
 
 # cleanup logic for cleanup on exit
 CLEANED_UP=false
@@ -129,6 +132,8 @@ create_cluster() {
   feature_gates="${FEATURE_GATES:-{\}}"
   # --runtime-config argument value passed to the API server, again as a map
   runtime_config="${RUNTIME_CONFIG:-{\}}"
+  # kube-controller-manager --controllers
+  controllers="${CONTROLLERS:-*}"
 
   case "${GA_ONLY:-false}" in
   false)
@@ -181,6 +186,7 @@ kubeadmConfigPatches:
 ${apiServer_extra_args}
   controllerManager:
     extraArgs:
+      controllers: "${controllers}"
 ${controllerManager_extra_args}
   scheduler:
     extraArgs:


### PR DESCRIPTION
This allows overriding kube-controller-manager's `--controllers` flag, which will be used by the new periodic e2e test for [KEP-4974](https://github.com/kubernetes/enhancements/issues/4974), which doesn't exist yet.

I thought about naming the variable `KCM_CONTROLLERS` or something instead, but having it be _just_ the name of the CLI arg was consistent with `FEATURE_GATES` and `RUNTIME_CONFIG`...