### PR TITLE
Detect ip6tables failure without full ipv6 support

### DIFF
--- a/pkg/cluster/internal/providers/docker/network.go
+++ b/pkg/cluster/internal/providers/docker/network.go
@@ -271,7 +271,10 @@ func isIPv6UnavailableError(err error) bool {
 	// even on hosts that lack ip6tables setup.
 	// Preferably users would either have ip6tables setup properly or else disable ipv6 in docker
 	const dockerIPV6TablesError = "Error response from daemon: Failed to Setup IP tables: Unable to enable NAT rule:  (iptables failed: ip6tables"
-	return strings.HasPrefix(errorMessage, dockerIPV6DisabledError) || strings.HasPrefix(errorMessage, dockerIPV6TablesError)
+	// we get this error when ipv6 is missing in kernel
+	const dockerIPV6PolicyError = "Error response from daemon: setting default policy to DROP in FORWARD chain failed:  (iptables failed: ip6tables"
+
+	return strings.HasPrefix(errorMessage, dockerIPV6DisabledError) || strings.HasPrefix(errorMessage, dockerIPV6TablesError) || strings.HasPrefix(errorMessage, dockerIPV6PolicyError)
 }
 
 func isPoolOverlapError(err error) bool {


### PR DESCRIPTION
Error when running with kernel from Kata Containers:
```
    can't initialize ip6tables table `filter':
    Table does not exist (do you need to insmod?)
    Perhaps ip6tables or your kernel needs to be upgraded.
```

This happens also in Apple Containers. Fallback to ipv4 only.
The alternative is building a custom kernel, with full support.

This fixes the `kind create cluster` error that was encountered in:
* https://github.com/kubernetes-sigs/kind/issues/3958#issuecomment-3339348358

----

Assuming that user has redirected from nft to legacy, that is.

```
update-alternatives --set iptables /usr/sbin/iptables-legacy
update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
```

Got some other error, when trying to create with default iptables.

```console
# docker network create -d=bridge -o com.docker.network.bridge.enable_ip_masquerade=true -o com.docker.network.driver.mtu=1500 kind
Error response from daemon: Failed to Setup IP tables: Unable to enable NAT rule:  (iptables failed: iptables --wait -t nat -I POSTROUTING -s 172.18.0.0/16 ! -o br-b505b0155599 -j MASQUERADE: Warning: Extension MASQUERADE revision 0 not supported, missing kernel module?
iptables v1.8.10 (nf_tables): Could not fetch rule set generation id: Invalid argument
 (exit status 4))
```

* Container 0.4.1
* Linux 6.12.28

https://github.com/apple/container/blob/main/docs/tutorial.md

https://github.com/kata-containers/kata-containers/releases/tag/3.17.0

* Ubuntu 24.04.3 LTS
* Docker 28.4.0 CE

----

Here is the regular Ubuntu kernel, for reference:

```
CONFIG_IP_NF_IPTABLES=m
CONFIG_IP6_NF_IPTABLES=m

CONFIG_NF_NAT_MASQUERADE=y
CONFIG_NETFILTER_XT_TARGET_MASQUERADE=m
CONFIG_IP_NF_TARGET_MASQUERADE=m
CONFIG_IP6_NF_TARGET_MASQUERADE=m
```

And here is the Kata Containers kernel, no IPv6:

```
# zgrep IPTABLES /proc/config.gz
CONFIG_IP_NF_IPTABLES_LEGACY=y
CONFIG_IP_NF_IPTABLES=y
# CONFIG_IP6_NF_IPTABLES is not set

# zgrep MASQUERADE /proc/config.gz
CONFIG_NF_NAT_MASQUERADE=y
CONFIG_NETFILTER_XT_TARGET_MASQUERADE=y
CONFIG_IP_NF_TARGET_MASQUERADE=y
```