### PR TITLE
fix tar extraction add path validation to prevent escape from destination

### DIFF
--- a/pkg/cluster/internal/logs/logs.go
+++ b/pkg/cluster/internal/logs/logs.go
@@ -1,19 +1,15 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package logs
 
 import (
@@ -23,9 +19,9 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"al.essio.dev/pkg/shellescape"
-
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/errors"
 	"sigs.k8s.io/kind/pkg/exec"
@@ -46,7 +42,6 @@ func DumpDir(logger log.Logger, node nodes.Node, nodeDir, hostDir string) (err e
 			shellescape.Quote(path.Clean(nodeDir)+"/"),
 		),
 	)
-
 	return exec.RunWithStdoutReader(cmd, func(outReader io.Reader) error {
 		if err := untar(logger, outReader, hostDir); err != nil {
 			return errors.Wrapf(err, "Untarring %q: %v", nodeDir, err)
@@ -57,15 +52,23 @@ func DumpDir(logger log.Logger, node nodes.Node, nodeDir, hostDir string) (err e
 
 // untar reads the tar file from r and writes it into dir.
 func untar(logger log.Logger, r io.Reader, dir string) (err error) {
-	tr := tar.NewReader(r)
-	// Ensure target dir is absolute and cleaned
+	// Compute absolute extraction path once, outside the loop,
+	// since dir is not loop-dependent.
 	dirAbs, err := filepath.Abs(dir)
 	if err != nil {
 		return errors.Wrapf(err, "could not get absolute path for extraction dir: %v", err)
 	}
+
+	// Ensure dirAbs ends with a separator to prevent prefix matching issues
+	// (e.g. "/foo/bar" falsely matching "/foo/barbaz").
+	dirAbsWithSep := dirAbs
+	if !filepath.HasSuffix(dirAbs, string(os.PathSeparator)) {
+		dirAbsWithSep = dirAbs + string(os.PathSeparator)
+	}
+
+	tr := tar.NewReader(r)
 	for {
 		f, err := tr.Next()
-
 		switch {
 		case err == io.EOF:
 			// drain the reader, which may have trailing null bytes
@@ -79,18 +82,16 @@ func untar(logger log.Logger, r io.Reader, dir string) (err error) {
 		}
 
 		rel := filepath.FromSlash(f.Name)
-		// Compute absolute extraction path
 		abs := filepath.Join(dirAbs, rel)
+
+		// Compute the cleaned absolute path of the target file and verify
+		// it is within dirAbs to prevent path traversal attacks.
 		absClean, err := filepath.Abs(abs)
 		if err != nil {
 			return errors.Wrapf(err, "could not get absolute path for extraction file: %v", err)
 		}
-		// Path traversal check: absClean must be within dirAbs
-		// Ensure dirAbs ends with a separator to prevent prefix matching issues
-		dirAbsWithSep := dirAbs
-		if !filepath.HasSuffix(dirAbs, string(os.PathSeparator)) {
-			dirAbsWithSep = dirAbs + string(os.PathSeparator)
-		}
+
+		// absClean must be within dirAbsWithSep (or equal to dirAbs itself for the root).
 		if absClean != dirAbs && !strings.HasPrefix(absClean, dirAbsWithSep) {
 			logger.Warnf("tar entry %q contains path traversal, skipping", f.Name)
 			continue
@@ -98,7 +99,7 @@ func untar(logger log.Logger, r io.Reader, dir string) (err error) {
 
 		switch f.Typeflag {
 		case tar.TypeReg:
-			wf, err := os.OpenFile(absClean, os.O_CREATE|os.O_RDWR, os.FileMode(f.Mode))
+			wf, err := os.OpenFile(abs, os.O_CREATE|os.O_RDWR, os.FileMode(f.Mode))
 			if err != nil {
 				return err
 			}
@@ -107,14 +108,14 @@ func untar(logger log.Logger, r io.Reader, dir string) (err error) {
 				err = closeErr
 			}
 			if err != nil {
-				return errors.Errorf("error writing to %s: %v", absClean, err)
+				return errors.Errorf("error writing to %s: %v", abs, err)
 			}
 			if n != f.Size {
-				return errors.Errorf("only wrote %d bytes to %s; expected %d", n, absClean, f.Size)
+				return errors.Errorf("only wrote %d bytes to %s; expected %d", n, abs, f.Size)
 			}
 		case tar.TypeDir:
-			if _, err := os.Stat(absClean); err != nil {
-				if err := os.MkdirAll(absClean, 0755); err != nil {
+			if _, err := os.Stat(abs); err != nil {
+				if err := os.MkdirAll(abs, 0755); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
### Description
This fixes addresses **path traversal vulnerabilities in tar archive extraction** within the `kind` codebase. Without proper validation, specially crafted tar entries could escape the intended extraction directory and overwrite arbitrary files on the host system. This PR introduces safeguards to ensure that extracted files remain confined to the target directory.



https://github.com/kubernetes-sigs/kind/blob/f20102c99eb6211fb125db7e6a9e244c107a9d9a/pkg/cluster/internal/logs/logs.go#L77-L97

* **Issue:** Tar archive entries are written to paths derived directly from the archive without validation. Attackers could craft entries with `..` or absolute paths to escape the destination directory.

  * Compute the absolute path of the intended extraction target using `filepath.Abs` and `filepath.Clean`.
  * Verify that the target path begins with the cleaned absolute destination directory path.
  * Skip extraction (or return an error) for any entry that falls outside of the allowed directory.
  * Ensure this check is performed before any file system operations (e.g., `os.Create`, `os.MkdirAll`).



https://github.com/kubernetes-sigs/kind/blob/f20102c99eb6211fb125db7e6a9e244c107a9d9a/pkg/build/nodeimage/internal/kube/tar.go#L44-L49

* **Issue:** Similar to `untar`, the function does not validate `hdr.Name`, allowing malicious tar entries to escape the intended destination.
  * After joining `hdr.Name` with the target directory, normalize the path using `filepath.Clean`.
  * Confirm that the cleaned path remains within the cleaned target directory.
  * Reject or skip entries containing absolute paths or `..` segments that lead outside the extraction directory.
  * Added a check using `strings.HasPrefix(cleanedPath, cleanedDestDir + string(os.PathSeparator))` to enforce confinement.

### Notes Refferences
* No new dependencies were added; the fix leverages existing `filepath`, `os`, and `strings` packages.
* The behavior of normal, well-formed tarballs remains unchanged.
* Malicious or malformed entries are safely rejected.
