### PR TITLE
docs: add note referencing `kind load image-archive --help`

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -131,6 +131,17 @@ On Windows via Winget (https://github.com/microsoft/winget-pkgs/tree/master/mani
 winget install Kubernetes.kind
 {{< /codeFromInline >}}
 
+## Discovering Additional Command Options
+
+kind provides built-in help for all commands and subcommands.  
+You can explore available flags and usage details by running:
+
+kind help
+kind <command> --help
+kind <command> <subcommand> --help
+
+This applies to commands such as `kind load image-archive`
+
 ## Creating a Cluster
 
 Creating a Kubernetes cluster is as simple as `kind create cluster`.
@@ -226,23 +237,8 @@ Docker images can be loaded into your cluster nodes with:
 > cluster you wish to load the images into:
 > `kind load docker-image my-custom-image-0 my-custom-image-1 --name kind-2`
 
-
 Additionally, image archives can be loaded with:
 `kind load image-archive /my-image-archive.tar`
-
-
-## Discovering Additional Command Options
-
-kind provides built-in help for all commands and subcommands.  
-You can explore available flags and usage details by running:
-
-```
-kind help
-kind <command> --help
-kind <command> <subcommand> --help
-```
-
-This applies to commands such as `kind load image-archive` and others.
 
 This allows a workflow like:
 

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -229,6 +229,10 @@ Docker images can be loaded into your cluster nodes with:
 Additionally, image archives can be loaded with:
 `kind load image-archive /my-image-archive.tar`
 
+For additional usage details and available flags, you can run:
+
+  kind load image-archive --help
+
 This allows a workflow like:
 ```
 docker build -t my-custom-image:unique-tag ./my-image-dir

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -226,16 +226,26 @@ Docker images can be loaded into your cluster nodes with:
 > cluster you wish to load the images into:
 > `kind load docker-image my-custom-image-0 my-custom-image-1 --name kind-2`
 
+
 Additionally, image archives can be loaded with:
 `kind load image-archive /my-image-archive.tar`
 
-For additional usage details and available flags, you can run:
 
-```sh
-kind load image-archive --help
+## Discovering Additional Command Options
+
+kind provides built-in help for all commands and subcommands.  
+You can explore available flags and usage details by running:
+
+```
+kind help
+kind <command> --help
+kind <command> <subcommand> --help
 ```
 
+This applies to commands such as `kind load image-archive` and others.
+
 This allows a workflow like:
+
 ```
 docker build -t my-custom-image:unique-tag ./my-image-dir
 kind load docker-image my-custom-image:unique-tag

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -231,7 +231,8 @@ Additionally, image archives can be loaded with:
 
 For additional usage details and available flags, you can run:
 
-  kind load image-archive --help
+```sh
+kind load image-archive --help
 
 This allows a workflow like:
 ```

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -233,6 +233,7 @@ For additional usage details and available flags, you can run:
 
 ```sh
 kind load image-archive --help
+```
 
 This allows a workflow like:
 ```


### PR DESCRIPTION
Adds a short note pointing users to the CLI help output for additional flags, as suggested in issue #4051.