### PR TITLE
cli: add read-only kind env command

### DIFF
--- a/pkg/cmd/kind/env/env.go
+++ b/pkg/cmd/kind/env/env.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package env implements the `env` command.
+package env
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kind/pkg/cmd"
+	"sigs.k8s.io/kind/pkg/log"
+)
+
+type envVar struct {
+	Name        string
+	Description string
+}
+
+var envVariables = []envVar{
+	{
+		Name:        "KIND_EXPERIMENTAL_PROVIDER",
+		Description: "Override provider auto-detection (docker, podman, nerdctl).",
+	},
+	{
+		Name:        "KIND_CLUSTER_NAME",
+		Description: "Default cluster name used by commands (default \"kind\").",
+	},
+	{
+		Name:        "KUBECONFIG",
+		Description: "Path to the kubeconfig file(s) for cluster access.",
+	},
+	{
+		Name:        "KIND_EXPERIMENTAL_DOCKER_NETWORK",
+		Description: "Docker network to attach cluster nodes to.",
+	},
+	{
+		Name:        "KIND_EXPERIMENTAL_PODMAN_NETWORK",
+		Description: "Podman network to attach cluster nodes to.",
+	},
+	{
+		Name:        "KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER",
+		Description: "Containerd snapshotter inside nodes (e.g. overlayfs, fuse-overlayfs).",
+	},
+}
+
+// NewCommand returns a new cobra.Command for env.
+func NewCommand(_ log.Logger, streams cmd.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "env",
+		Short: "Prints key environment variables used by kind",
+		Long:  "Prints key environment variables used by kind along with their current values.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, variable := range envVariables {
+				value := os.Getenv(variable.Name)
+				if _, err := fmt.Fprintf(streams.Out, "%s=%q\t%s\n", variable.Name, value, variable.Description); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/kind/env/env_test.go
+++ b/pkg/cmd/kind/env/env_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package env
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/kind/pkg/cmd"
+	"sigs.k8s.io/kind/pkg/log"
+)
+
+func TestEnvCommandOutputsVariables(t *testing.T) {
+	testValues := map[string]string{
+		"KIND_EXPERIMENTAL_PROVIDER":               "podman",
+		"KIND_CLUSTER_NAME":                        "test-cluster",
+		"KUBECONFIG":                               "/tmp/kubeconfig",
+		"KIND_EXPERIMENTAL_DOCKER_NETWORK":         "kind-network",
+		"KIND_EXPERIMENTAL_PODMAN_NETWORK":         "podman-network",
+		"KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER": "fuse-overlayfs",
+	}
+	for key, value := range testValues {
+		t.Setenv(key, value)
+	}
+
+	out := &bytes.Buffer{}
+	streams := cmd.IOStreams{
+		Out:    out,
+		ErrOut: io.Discard,
+	}
+	command := NewCommand(log.NoopLogger{}, streams)
+	command.SetArgs([]string{})
+
+	if err := command.Execute(); err != nil {
+		t.Fatalf("env command returned error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != len(envVariables) {
+		t.Fatalf("expected %d environment variables, got %d", len(envVariables), len(lines))
+	}
+
+	for i, variable := range envVariables {
+		parts := strings.SplitN(lines[i], "\t", 2)
+		if len(parts) != 2 {
+			t.Fatalf("line %d not formatted correctly: %q", i, lines[i])
+		}
+
+		value := testValues[variable.Name]
+		expectedPrefix := fmt.Sprintf("%s=%q", variable.Name, value)
+		if parts[0] != expectedPrefix {
+			t.Errorf("expected %q, got %q", expectedPrefix, parts[0])
+		}
+		if parts[1] != variable.Description {
+			t.Errorf("expected description %q, got %q", variable.Description, parts[1])
+		}
+	}
+}

--- a/pkg/cmd/kind/root.go
+++ b/pkg/cmd/kind/root.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cmd/kind/completion"
 	"sigs.k8s.io/kind/pkg/cmd/kind/create"
 	"sigs.k8s.io/kind/pkg/cmd/kind/delete"
+	"sigs.k8s.io/kind/pkg/cmd/kind/env"
 	"sigs.k8s.io/kind/pkg/cmd/kind/export"
 	"sigs.k8s.io/kind/pkg/cmd/kind/get"
 	"sigs.k8s.io/kind/pkg/cmd/kind/load"
@@ -74,6 +75,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd.AddCommand(completion.NewCommand(logger, streams))
 	cmd.AddCommand(create.NewCommand(logger, streams))
 	cmd.AddCommand(delete.NewCommand(logger, streams))
+	cmd.AddCommand(env.NewCommand(logger, streams))
 	cmd.AddCommand(export.NewCommand(logger, streams))
 	cmd.AddCommand(get.NewCommand(logger, streams))
 	cmd.AddCommand(version.NewCommand(logger, streams))


### PR DESCRIPTION
Adds a read-only `kind env` subcommand to surface key environment variables and their current values.
No behavior changes.

Refs #4044
