### PR TITLE
switch image builds to gcb-docker-gcloud

### DIFF
--- a/images/base/cloudbuild.yaml
+++ b/images/base/cloudbuild.yaml
@@ -3,6 +3,6 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_32
 steps:
-- name: gcr.io/k8s-staging-test-infra/krte:latest-master
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest-master
   entrypoint: make
   args: ['-C', 'images/base', 'push']

--- a/images/haproxy/cloudbuild.yaml
+++ b/images/haproxy/cloudbuild.yaml
@@ -3,6 +3,6 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_8
 steps:
-- name: gcr.io/k8s-staging-test-infra/krte:latest-master
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest-master
   entrypoint: make
   args: ['-C', 'images/haproxy', 'push']

--- a/images/kindnetd/cloudbuild.yaml
+++ b/images/kindnetd/cloudbuild.yaml
@@ -3,6 +3,6 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_32
 steps:
-- name: gcr.io/k8s-staging-test-infra/krte:latest-master
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest-master
   entrypoint: make
   args: ['-C', 'images/kindnetd', 'push']

--- a/images/local-path-helper/cloudbuild.yaml
+++ b/images/local-path-helper/cloudbuild.yaml
@@ -3,6 +3,6 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_8
 steps:
-- name: gcr.io/k8s-staging-test-infra/krte:latest-master
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest-master
   entrypoint: make
   args: ['-C', 'images/local-path-helper', 'push']

--- a/images/local-path-provisioner/cloudbuild.yaml
+++ b/images/local-path-provisioner/cloudbuild.yaml
@@ -3,6 +3,6 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_8
 steps:
-- name: gcr.io/k8s-staging-test-infra/krte:latest-master
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest-master
   entrypoint: make
   args: ['-C', 'images/local-path-provisioner', 'push']


### PR DESCRIPTION
https://github.com/kubernetes-sigs/kind/pull/4056#issuecomment-3639085183

TODO: determine if we should also switch https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kind-push-binaries/1998850601328316416 which is currently still working fine (Doesn't use docker)