### PR TITLE
cli: align --name flag help and default

### DIFF
--- a/pkg/cmd/kind/create/cluster/createcluster.go
+++ b/pkg/cmd/kind/create/cluster/createcluster.go
@@ -19,6 +19,7 @@ package cluster
 
 import (
 	"io"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -50,16 +51,19 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Short: "Creates a local Kubernetes cluster",
 		Long:  "Creates a local Kubernetes cluster using Docker container 'nodes'",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.OverrideDefaultName(cmd.Flags())
 			return runE(logger, streams, flags)
 		},
+	}
+	defaultName := cluster.DefaultName
+	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
+		defaultName = name
 	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		"",
-		"cluster name, overrides KIND_CLUSTER_NAME, config (default kind)",
+		defaultName,
+		cli.NameFlagHelp,
 	)
 	cmd.Flags().StringVar(
 		&flags.Config,

--- a/pkg/cmd/kind/create/cluster/createcluster.go
+++ b/pkg/cmd/kind/create/cluster/createcluster.go
@@ -19,7 +19,6 @@ package cluster
 
 import (
 	"io"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -54,16 +53,12 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, streams, flags)
 		},
 	}
-	defaultName := cluster.DefaultName
-	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
-		defaultName = name
-	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		defaultName,
-		cli.NameFlagHelp,
+		cli.NameFromEnv(),
+		"cluster name, overrides KIND_CLUSTER_NAME and config name; defaults to KIND_CLUSTER_NAME if set, then config name, then kind",
 	)
 	cmd.Flags().StringVar(
 		&flags.Config,

--- a/pkg/cmd/kind/create/cluster/createcluster_test.go
+++ b/pkg/cmd/kind/create/cluster/createcluster_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	"sigs.k8s.io/kind/pkg/cmd"
+	"sigs.k8s.io/kind/pkg/internal/cli"
+	"sigs.k8s.io/kind/pkg/log"
+)
+
+func TestNameFlagDefaultPreservesConfigPrecedence(t *testing.T) {
+	t.Setenv(cli.ClusterNameEnv, "")
+
+	command := NewCommand(log.NoopLogger{}, cmd.IOStreams{})
+	flag := command.Flags().Lookup("name")
+	if flag == nil {
+		t.Fatal("expected --name flag")
+	}
+	if flag.DefValue != "" {
+		t.Fatalf("--name default = %q, want empty so config name can apply", flag.DefValue)
+	}
+	if got := flag.Value.String(); got != "" {
+		t.Fatalf("--name value = %q, want empty so config name can apply", got)
+	}
+}
+
+func TestNameFlagDefaultUsesEnv(t *testing.T) {
+	t.Setenv(cli.ClusterNameEnv, "env-cluster")
+
+	command := NewCommand(log.NoopLogger{}, cmd.IOStreams{})
+	flag := command.Flags().Lookup("name")
+	if flag == nil {
+		t.Fatal("expected --name flag")
+	}
+	if flag.DefValue != "env-cluster" {
+		t.Fatalf("--name default = %q, want %q", flag.DefValue, "env-cluster")
+	}
+	if got := flag.Value.String(); got != "env-cluster" {
+		t.Fatalf("--name value = %q, want %q", got, "env-cluster")
+	}
+
+	if err := command.Flags().Set("name", "flag-cluster"); err != nil {
+		t.Fatalf("setting --name: %v", err)
+	}
+	if got := flag.Value.String(); got != "flag-cluster" {
+		t.Fatalf("--name value after explicit set = %q, want %q", got, "flag-cluster")
+	}
+}

--- a/pkg/cmd/kind/delete/cluster/deletecluster.go
+++ b/pkg/cmd/kind/delete/cluster/deletecluster.go
@@ -18,6 +18,8 @@ limitations under the License.
 package cluster
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cluster"
@@ -50,16 +52,19 @@ if the cluster is already gone it will just return success.
 Errors will only occur if the cluster resources exist and are not able to be deleted.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.OverrideDefaultName(cmd.Flags())
 			return deleteCluster(logger, flags)
 		},
+	}
+	defaultName := cluster.DefaultName
+	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
+		defaultName = name
 	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		cluster.DefaultName,
-		"the cluster name",
+		defaultName,
+		cli.NameFlagHelp,
 	)
 	cmd.Flags().StringVar(
 		&flags.Kubeconfig,

--- a/pkg/cmd/kind/delete/cluster/deletecluster.go
+++ b/pkg/cmd/kind/delete/cluster/deletecluster.go
@@ -18,8 +18,6 @@ limitations under the License.
 package cluster
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cluster"
@@ -55,15 +53,11 @@ Errors will only occur if the cluster resources exist and are not able to be del
 			return deleteCluster(logger, flags)
 		},
 	}
-	defaultName := cluster.DefaultName
-	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
-		defaultName = name
-	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		defaultName,
+		cli.DefaultName(),
 		cli.NameFlagHelp,
 	)
 	cmd.Flags().StringVar(

--- a/pkg/cmd/kind/export/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kind/export/kubeconfig/kubeconfig.go
@@ -18,6 +18,8 @@ limitations under the License.
 package kubeconfig
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cluster"
@@ -43,16 +45,19 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Short: "Exports cluster kubeconfig",
 		Long:  "Exports cluster kubeconfig",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.OverrideDefaultName(cmd.Flags())
 			return runE(logger, flags)
 		},
+	}
+	defaultName := cluster.DefaultName
+	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
+		defaultName = name
 	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		cluster.DefaultName,
-		"the cluster context name",
+		defaultName,
+		cli.NameFlagHelp,
 	)
 	cmd.Flags().StringVar(
 		&flags.Kubeconfig,

--- a/pkg/cmd/kind/export/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kind/export/kubeconfig/kubeconfig.go
@@ -18,8 +18,6 @@ limitations under the License.
 package kubeconfig
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kind/pkg/cluster"
@@ -48,15 +46,11 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, flags)
 		},
 	}
-	defaultName := cluster.DefaultName
-	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
-		defaultName = name
-	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		defaultName,
+		cli.DefaultName(),
 		cli.NameFlagHelp,
 	)
 	cmd.Flags().StringVar(

--- a/pkg/cmd/kind/export/logs/logs.go
+++ b/pkg/cmd/kind/export/logs/logs.go
@@ -19,6 +19,7 @@ package logs
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -45,16 +46,19 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Short: "Exports logs to a tempdir or [output-dir] if specified",
 		Long:  "Exports logs to a tempdir or [output-dir] if specified",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.OverrideDefaultName(cmd.Flags())
 			return runE(logger, streams, flags, args)
 		},
+	}
+	defaultName := cluster.DefaultName
+	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
+		defaultName = name
 	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		cluster.DefaultName,
-		"the cluster context name",
+		defaultName,
+		cli.NameFlagHelp,
 	)
 	return cmd
 }

--- a/pkg/cmd/kind/export/logs/logs.go
+++ b/pkg/cmd/kind/export/logs/logs.go
@@ -19,7 +19,6 @@ package logs
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -49,15 +48,11 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, streams, flags, args)
 		},
 	}
-	defaultName := cluster.DefaultName
-	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
-		defaultName = name
-	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		defaultName,
+		cli.DefaultName(),
 		cli.NameFlagHelp,
 	)
 	return cmd

--- a/pkg/cmd/kind/get/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kind/get/kubeconfig/kubeconfig.go
@@ -19,6 +19,7 @@ package kubeconfig
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -44,16 +45,19 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Short: "Prints cluster kubeconfig",
 		Long:  "Prints cluster kubeconfig",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.OverrideDefaultName(cmd.Flags())
 			return runE(logger, streams, flags)
 		},
+	}
+	defaultName := cluster.DefaultName
+	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
+		defaultName = name
 	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		cluster.DefaultName,
-		"the cluster context name",
+		defaultName,
+		cli.NameFlagHelp,
 	)
 	cmd.Flags().BoolVar(
 		&flags.Internal,

--- a/pkg/cmd/kind/get/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kind/get/kubeconfig/kubeconfig.go
@@ -19,7 +19,6 @@ package kubeconfig
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -48,15 +47,11 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, streams, flags)
 		},
 	}
-	defaultName := cluster.DefaultName
-	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
-		defaultName = name
-	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		defaultName,
+		cli.DefaultName(),
 		cli.NameFlagHelp,
 	)
 	cmd.Flags().BoolVar(

--- a/pkg/cmd/kind/get/nodes/nodes.go
+++ b/pkg/cmd/kind/get/nodes/nodes.go
@@ -19,6 +19,7 @@ package nodes
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -45,16 +46,19 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Short: "Lists existing kind nodes by their name",
 		Long:  "Lists existing kind nodes by their name",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.OverrideDefaultName(cmd.Flags())
 			return runE(logger, streams, flags)
 		},
+	}
+	defaultName := cluster.DefaultName
+	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
+		defaultName = name
 	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		cluster.DefaultName,
-		"the cluster context name",
+		defaultName,
+		cli.NameFlagHelp,
 	)
 	cmd.Flags().BoolVarP(
 		&flags.AllClusters,

--- a/pkg/cmd/kind/get/nodes/nodes.go
+++ b/pkg/cmd/kind/get/nodes/nodes.go
@@ -19,7 +19,6 @@ package nodes
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -49,15 +48,11 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, streams, flags)
 		},
 	}
-	defaultName := cluster.DefaultName
-	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
-		defaultName = name
-	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		defaultName,
+		cli.DefaultName(),
 		cli.NameFlagHelp,
 	)
 	cmd.Flags().BoolVarP(

--- a/pkg/cmd/kind/load/docker-image/docker-image.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image.go
@@ -61,16 +61,19 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Short: "Loads docker images from host into nodes",
 		Long:  "Loads docker images from host into all or specified nodes by name",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.OverrideDefaultName(cmd.Flags())
 			return runE(logger, flags, args)
 		},
+	}
+	defaultName := cluster.DefaultName
+	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
+		defaultName = name
 	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		cluster.DefaultName,
-		"the cluster context name",
+		defaultName,
+		cli.NameFlagHelp,
 	)
 	cmd.Flags().StringSliceVar(
 		&flags.Nodes,

--- a/pkg/cmd/kind/load/docker-image/docker-image.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image.go
@@ -64,15 +64,11 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, flags, args)
 		},
 	}
-	defaultName := cluster.DefaultName
-	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
-		defaultName = name
-	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		defaultName,
+		cli.DefaultName(),
 		cli.NameFlagHelp,
 	)
 	cmd.Flags().StringSliceVar(

--- a/pkg/cmd/kind/load/image-archive/image-archive.go
+++ b/pkg/cmd/kind/load/image-archive/image-archive.go
@@ -58,16 +58,19 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Short: "Loads docker image from archive into nodes",
 		Long:  "Loads docker image from archive into all or specified nodes by name",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cli.OverrideDefaultName(cmd.Flags())
 			return runE(logger, flags, args)
 		},
+	}
+	defaultName := cluster.DefaultName
+	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
+		defaultName = name
 	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		cluster.DefaultName,
-		"the cluster context name",
+		defaultName,
+		cli.NameFlagHelp,
 	)
 	cmd.Flags().StringSliceVar(
 		&flags.Nodes,

--- a/pkg/cmd/kind/load/image-archive/image-archive.go
+++ b/pkg/cmd/kind/load/image-archive/image-archive.go
@@ -61,15 +61,11 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 			return runE(logger, flags, args)
 		},
 	}
-	defaultName := cluster.DefaultName
-	if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
-		defaultName = name
-	}
 	cmd.Flags().StringVarP(
 		&flags.Name,
 		"name",
 		"n",
-		defaultName,
+		cli.DefaultName(),
 		cli.NameFlagHelp,
 	)
 	cmd.Flags().StringSliceVar(

--- a/pkg/internal/cli/override.go
+++ b/pkg/internal/cli/override.go
@@ -1,18 +1,4 @@
 package cli
 
-import (
-	"os"
-
-	"github.com/spf13/pflag"
-)
-
-// OverrideDefaultName conditionally allows overriding the default cluster name
-// by setting the KIND_CLUSTER_NAME environment variable
-// only if --name wasn't set explicitly
-func OverrideDefaultName(fs *pflag.FlagSet) {
-	if !fs.Changed("name") {
-		if name := os.Getenv("KIND_CLUSTER_NAME"); name != "" {
-			_ = fs.Set("name", name)
-		}
-	}
-}
+// NameFlagHelp is the shared help text for the --name flag.
+const NameFlagHelp = "cluster name (or via KIND_CLUSTER_NAME)"

--- a/pkg/internal/cli/override.go
+++ b/pkg/internal/cli/override.go
@@ -1,4 +1,27 @@
 package cli
 
+import (
+	"os"
+
+	"sigs.k8s.io/kind/pkg/cluster/constants"
+)
+
+// ClusterNameEnv is the environment variable used to override the default
+// cluster name.
+const ClusterNameEnv = "KIND_CLUSTER_NAME"
+
 // NameFlagHelp is the shared help text for the --name flag.
 const NameFlagHelp = "cluster name (or via KIND_CLUSTER_NAME)"
+
+// NameFromEnv returns the cluster name from KIND_CLUSTER_NAME.
+func NameFromEnv() string {
+	return os.Getenv(ClusterNameEnv)
+}
+
+// DefaultName returns the effective default cluster name.
+func DefaultName() string {
+	if name := NameFromEnv(); name != "" {
+		return name
+	}
+	return constants.DefaultClusterName
+}

--- a/pkg/internal/cli/override_test.go
+++ b/pkg/internal/cli/override_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"testing"
+
+	"sigs.k8s.io/kind/pkg/cluster/constants"
+)
+
+func TestNameFromEnv(t *testing.T) {
+	t.Setenv(ClusterNameEnv, "env-cluster")
+
+	if got := NameFromEnv(); got != "env-cluster" {
+		t.Fatalf("NameFromEnv() = %q, want %q", got, "env-cluster")
+	}
+}
+
+func TestDefaultName(t *testing.T) {
+	t.Setenv(ClusterNameEnv, "")
+	if got := DefaultName(); got != constants.DefaultClusterName {
+		t.Fatalf("DefaultName() = %q, want %q", got, constants.DefaultClusterName)
+	}
+
+	t.Setenv(ClusterNameEnv, "env-cluster")
+	if got := DefaultName(); got != "env-cluster" {
+		t.Fatalf("DefaultName() = %q, want %q", got, "env-cluster")
+	}
+}


### PR DESCRIPTION
Standardize the --name/-n help text across commands and use cluster.DefaultName for create cluster so help output is consistent. Refs #4044