### PR TITLE
e2e-k8s.sh: support e2e.test parameters

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -15,7 +15,11 @@
 
 # hack script for running a kind e2e
 # must be run with a kubernetes checkout in $PWD (IE from the checkout)
-# Usage: SKIP="ginkgo skip regex" FOCUS="ginkgo focus regex" kind-e2e.sh
+# Usage: SKIP="ginkgo skip regex" FOCUS="ginkgo focus regex" kind-e2e.sh [args]
+#
+# <args> are additional command line arguments for e2e.test. They get
+# passed through to k/k/hack/ginkgo-e2e.sh, which in turn passes
+# them on to e2e.test.
 
 set -o errexit -o nounset -o xtrace
 
@@ -267,7 +271,8 @@ run_tests() {
   ./hack/ginkgo-e2e.sh \
     '--provider=skeleton' "--num-nodes=${NUM_NODES}" \
     "--ginkgo.focus=${FOCUS}" "--ginkgo.skip=${SKIP}" "--ginkgo.label-filter=${LABEL_FILTER}" \
-    "--report-dir=${ARTIFACTS}" '--disable-log-dump=true' &
+    "--report-dir=${ARTIFACTS}" '--disable-log-dump=true' \
+    "${@}" &
   GINKGO_PID=$!
   wait "$GINKGO_PID"
 }
@@ -299,9 +304,9 @@ main() {
   # create the cluster and run tests
   res=0
   create_cluster || res=$?
-  run_tests || res=$?
+  run_tests "${@}" || res=$?
   cleanup || res=$?
   exit $res
 }
 
-main
+main "${@}"


### PR DESCRIPTION
This is useful as an escape hatch for special kind-based jobs which need to control aspect of the e2e.test which are not covered by dedicated env variables.

The specific needs is for kubernetes-e2e-kind-alpha-beta-features-race: it needs to enable race detection via command line flags (https://github.com/kubernetes/kubernetes/pull/133844).

That PR currently uses an env variable for that, but a generic env variable is harder to use correctly than this PR (word splitting is ambiguous) and adding a dedicated env variable doesn't scale - that way leads to replicating more and more command line flags as env variables.

