### PR TITLE
upgrade to runc 1.3.4

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -140,9 +140,7 @@ RUN git clone --filter=tree:0 "${CONTAINERD_CLONE_URL}" /containerd \
 # stage for building runc
 FROM go-build AS build-runc
 ARG TARGETARCH GO_VERSION
-# TODO: upgrade to 1.3.x to match containerd after resolving:
-# https://github.com/kubernetes/kubernetes/issues/135214
-ARG RUNC_VERSION="v1.2.9"
+ARG RUNC_VERSION="v1.3.4"
 ARG RUNC_CLONE_URL="https://github.com/opencontainers/runc"
 RUN git clone --filter=tree:0 "${RUNC_CLONE_URL}" /runc \
     && cd /runc \


### PR DESCRIPTION
containerd 2.2.1 is not out yet but will use runc 1.3.4, we'll pickup 2.2.1 later

runc 1.4.0 is out yet, but I don't want to rush to the bleeding edge over the holidays after just getting 1.3.x unblocked