### PR TITLE
add name for kind cluster

### DIFF
--- a/site/content/docs/user/kind-example-config.yaml
+++ b/site/content/docs/user/kind-example-config.yaml
@@ -2,6 +2,7 @@
 # NOTE: this is not a particularly useful config file
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+name: multinode
 # patch the generated kubeadm config with some extra settings
 kubeadmConfigPatches:
 - |


### PR DESCRIPTION
This multi node cluster need a name to override default in order to not conflict with previous simple node.

```
$ kind create cluster
```
create a Kubernetes cluster with name kind by default.
we need to change kind config file to prevent name conflict.

So beginner user can follow quick start guide without interruption.

