### PR TITLE
docs: clarify resource requirement scope in quick start

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -323,7 +323,7 @@ kind build node-image --type source $HOME/go/src/k8s.io/kubernetes/
 If you are building Kubernetes (for example - `kind build node-image`) on MacOS or Windows then you need a minimum of 6GB of RAM
 dedicated to the virtual machine (VM) running the Docker engine. 8GB is recommended.
 
-> Note: Resource requirements vary depending on usage.
+> **Note**: Resource requirements vary depending on usage.
 > The values listed here are minimums for basic clusters.
 > Workloads such as building node images, multi-node clusters,
 > or running additional components may require more CPU and memory.

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -323,6 +323,11 @@ kind build node-image --type source $HOME/go/src/k8s.io/kubernetes/
 If you are building Kubernetes (for example - `kind build node-image`) on MacOS or Windows then you need a minimum of 6GB of RAM
 dedicated to the virtual machine (VM) running the Docker engine. 8GB is recommended.
 
+> Note: Resource requirements vary depending on usage.
+> The values listed here are minimums for basic clusters.
+> Workloads such as building node images, multi-node clusters,
+> or running additional components may require more CPU and memory.
+
 To change the resource limits for the Docker on Mac, you'll need to open the
 **Preferences** menu.
 


### PR DESCRIPTION
This PR clarifies that the resource values mentioned in the quick start
are minimums for basic clusters and may vary depending on workload
(e.g., building node images or multi-node clusters).

Closes: #485.
