### PR TITLE
e2e: Stop force-skipping Serial tests in parallel mode

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -25,9 +25,14 @@ set -o errexit -o nounset -o xtrace
 # LABEL_FILTER: ginkgo label query for selecting tests (see "Spec Labels" in https://onsi.github.io/ginkgo/#filtering-specs)
 #
 # The default is to focus on conformance tests when FOCUS is unset. To run all
-# tests (no focus filter), explicitly set FOCUS="". Serial tests get skipped when
-# parallel testing is enabled. Using LABEL_FILTER instead of combining SKIP and
-# FOCUS is recommended (more expressive, easier to read than regexp).
+# tests (no focus filter), explicitly set FOCUS="". Using LABEL_FILTER instead
+# of combining SKIP and FOCUS is recommended (more expressive, easier to read
+# than regexp).
+#
+# Note: Serial tests are handled automatically by Ginkgo v2. When running in
+# parallel mode, Ginkgo runs parallel specs first across all processes, then
+# runs Serial specs on process #1 after all other processes have exited.
+# See: https://onsi.github.io/ginkgo/#serial-specs
 #
 # FEATURE_GATES:
 #          JSON or YAML encoding of a string/bool map: {"FeatureGateA": true, "FeatureGateB": false}
@@ -250,14 +255,11 @@ run_tests() {
       FOCUS=""
     fi
   fi
-  # if we set PARALLEL=true, skip serial tests set --ginkgo-parallel
+  # if we set PARALLEL=true, enable ginkgo parallel mode
+  # Note: Ginkgo v2 automatically handles Serial specs - they run on process #1
+  # after all parallel specs complete. No need to skip them explicitly.
   if [ "${PARALLEL:-false}" = "true" ]; then
     export GINKGO_PARALLEL=y
-    if [ -z "${SKIP}" ]; then
-      SKIP="\\[Serial\\]"
-    else
-      SKIP="\\[Serial\\]|${SKIP}"
-    fi
   fi
 
   # setting this env prevents ginkgo e2e from trying to run provider setup


### PR DESCRIPTION
Ginkgo v2 natively handles Serial specs when running in parallel mode. According to the Ginkgo documentation [1], when parallel testing is enabled, Serial-decorated specs are automatically deferred until after parallel execution completes:

  "When it detects the presence of Serial specs, process #1 will wait
   for all other processes to exit before running the Serial specs."

The previous behavior of adding [Serial] to the SKIP regex was necessary for Ginkgo v1 but is no longer required. Removing this allows Serial tests to run automatically after parallel tests complete, which improves test coverage without requiring manual skip management.

This change enables CI jobs that use PARALLEL=true to get coverage of Serial tests (such as DaemonSet, PriorityClass, and Namespace tests) without needing separate test runs.

[1] https://onsi.github.io/ginkgo/#serial-specs