### PR TITLE
feat(cli): add short description to bash completion

### DIFF
--- a/pkg/cmd/kind/completion/bash/bash.go
+++ b/pkg/cmd/kind/completion/bash/bash.go
@@ -31,7 +31,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		Use:   "bash",
 		Short: "Output shell completions for bash",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Parent().Parent().GenBashCompletion(streams.Out)
+			return cmd.Parent().Parent().GenBashCompletionV2(streams.Out, true)
 		},
 	}
 	return cmd


### PR DESCRIPTION
The completion for bash now displays the short description for the subcommands and flags, similar to the bash completion in tools like `kubectl` and `helm`.

The short descriptions provide better UX with improved discoverability. It will also allow us to add usage examples to the short descriptions in follow-ups.

### Current bash completion:

```
$ kind
build       completion  create      delete      export      get         help        load        version

$ kind export
kubeconfig  logs

$ kind export kubeconfig --
--internal     --kubeconfig   --kubeconfig=  --name         --name=        --quiet        --verbosity    --verbosity=
```

### Bash Completion V2:

```
$ kind
build       (Build one of [node-image])
completion  (Output shell completion code for the specified shell (bash, zsh or fish))
create      (Creates one of [cluster])
delete      (Deletes one of [cluster])
export      (Exports one of [kubeconfig, logs])
get         (Gets one of [clusters, nodes, kubeconfig])
help        (Help about any command)
load        (Loads images into nodes)
version     (Prints the kind CLI version)

$ kind export
kubeconfig  (Exports cluster kubeconfig)                              logs        (Exports logs to a tempdir or [output-dir] if specified)

$ kind export kubeconfig --
--help        (help for kubeconfig)
--internal    (use internal address instead of external)
--kubeconfig  (sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config)
--name        (the cluster context name)
--quiet       (silence all stderr output)
--verbosity   (info log verbosity, higher value produces more output)
```