### PR TITLE
docs: mention kind load image-archive --help

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -240,6 +240,8 @@ kind load docker-image my-app:latest --name test-cluster
 Additionally, image archives can be loaded with:
 `kind load image-archive /my-image-archive.tar`
 
+For more options, see: `kind load image-archive --help`
+
 This allows a workflow like:
 ```
 docker build -t my-custom-image:unique-tag ./my-image-dir


### PR DESCRIPTION
Fixes #4051

Adds a short note in the quick start guide pointing readers to `kind load image-archive --help` for additional flags/options.