### PR TITLE
kindnetd: validate noMasqueradeCIDRs before creating IPMasqAgent

### DIFF
--- a/images/kindnetd/cmd/kindnetd/masq.go
+++ b/images/kindnetd/cmd/kindnetd/masq.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"strings"
 	"time"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -27,6 +29,11 @@ import (
 
 // NewIPMasqAgent returns a new IPMasqAgent
 func NewIPMasqAgent(ipv6 bool, noMasqueradeCIDRs []string) (*IPMasqAgent, error) {
+	validatedCIDRs, err := validateNoMasqueradeCIDRs(ipv6, noMasqueradeCIDRs)
+	if err != nil {
+		return nil, err
+	}
+
 	protocol := iptables.ProtocolIPv4
 	if ipv6 {
 		protocol = iptables.ProtocolIPv6
@@ -36,12 +43,31 @@ func NewIPMasqAgent(ipv6 bool, noMasqueradeCIDRs []string) (*IPMasqAgent, error)
 		return nil, err
 	}
 
-	// TODO: validate cidrs
 	return &IPMasqAgent{
 		iptables:          ipt,
 		masqChain:         masqChainName,
-		noMasqueradeCIDRs: noMasqueradeCIDRs,
+		noMasqueradeCIDRs: validatedCIDRs,
 	}, nil
+}
+
+func validateNoMasqueradeCIDRs(ipv6 bool, noMasqueradeCIDRs []string) ([]string, error) {
+	validatedCIDRs := make([]string, 0, len(noMasqueradeCIDRs))
+	for _, cidr := range noMasqueradeCIDRs {
+		cidr = strings.TrimSpace(cidr)
+		ip, _, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid noMasqueradeCIDR %q: %w", cidr, err)
+		}
+		if ipv6 {
+			if ip.To4() != nil {
+				return nil, fmt.Errorf("invalid noMasqueradeCIDR %q: expected IPv6 CIDR", cidr)
+			}
+		} else if ip.To4() == nil {
+			return nil, fmt.Errorf("invalid noMasqueradeCIDR %q: expected IPv4 CIDR", cidr)
+		}
+		validatedCIDRs = append(validatedCIDRs, cidr)
+	}
+	return validatedCIDRs, nil
 }
 
 // IPMasqAgent is based on https://github.com/kubernetes-incubator/ip-masq-agent

--- a/images/kindnetd/cmd/kindnetd/masq_test.go
+++ b/images/kindnetd/cmd/kindnetd/masq_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValidateNoMasqueradeCIDRs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ipv6    bool
+		cidrs   []string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:  "valid ipv4 cidrs",
+			cidrs: []string{"10.244.0.0/16", "10.96.0.0/12"},
+			want:  []string{"10.244.0.0/16", "10.96.0.0/12"},
+		},
+		{
+			name:  "trim whitespace",
+			cidrs: []string{" 10.244.0.0/16 ", "\t10.96.0.0/12\n"},
+			want:  []string{"10.244.0.0/16", "10.96.0.0/12"},
+		},
+		{
+			name:  "valid ipv6 cidrs",
+			ipv6:  true,
+			cidrs: []string{"fd00:10:244::/56", "fd00:10:96::/112"},
+			want:  []string{"fd00:10:244::/56", "fd00:10:96::/112"},
+		},
+		{
+			name:    "invalid cidr",
+			cidrs:   []string{"not-a-cidr"},
+			wantErr: true,
+		},
+		{
+			name:    "ipv4 agent rejects ipv6 cidr",
+			cidrs:   []string{"fd00:10:244::/56"},
+			wantErr: true,
+		},
+		{
+			name:    "ipv6 agent rejects ipv4 cidr",
+			ipv6:    true,
+			cidrs:   []string{"10.244.0.0/16"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := validateNoMasqueradeCIDRs(tt.ipv6, tt.cidrs)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("validateNoMasqueradeCIDRs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
To reject invalid or wrong-family noMasqueradeCIDRs early and add focused unit tests.