### PR TITLE
config: validate and default port mapping fields

### DIFF
--- a/pkg/internal/apis/config/default.go
+++ b/pkg/internal/apis/config/default.go
@@ -101,4 +101,10 @@ func SetDefaultsNode(obj *Node) {
 	if obj.Role == "" {
 		obj.Role = ControlPlaneRole
 	}
+
+	for i := range obj.ExtraPortMappings {
+		if obj.ExtraPortMappings[i].Protocol == "" {
+			obj.ExtraPortMappings[i].Protocol = PortMappingProtocolTCP
+		}
+	}
 }

--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -128,6 +128,16 @@ func (n *Node) Validate() error {
 		if err := validatePort(mapping.ContainerPort); err != nil {
 			errs = append(errs, errors.Wrapf(err, "invalid containerPort"))
 		}
+
+		switch mapping.Protocol {
+		case "", PortMappingProtocolTCP, PortMappingProtocolUDP, PortMappingProtocolSCTP:
+		default:
+			errs = append(errs, errors.Errorf("invalid protocol %q", mapping.Protocol))
+		}
+
+		if mapping.ListenAddress != "" && net.ParseIP(mapping.ListenAddress) == nil {
+			errs = append(errs, errors.Errorf("invalid listenAddress %q", mapping.ListenAddress))
+		}
 	}
 
 	if err := validatePortMappings(n.ExtraPortMappings); err != nil {

--- a/pkg/internal/apis/config/validate_test.go
+++ b/pkg/internal/apis/config/validate_test.go
@@ -401,6 +401,36 @@ func TestNodeValidate(t *testing.T) {
 			}(),
 			ExpectErrors: 0,
 		},
+		{
+			TestName: "Invalid protocol field",
+			Node: func() Node {
+				cfg := newDefaultedNode(ControlPlaneRole)
+				cfg.ExtraPortMappings = []PortMapping{
+					{
+						ContainerPort: 8080,
+						HostPort:      8080,
+						Protocol:      "ICMP",
+					},
+				}
+				return cfg
+			}(),
+			ExpectErrors: 1,
+		},
+		{
+			TestName: "Invalid listenAddress field",
+			Node: func() Node {
+				cfg := newDefaultedNode(ControlPlaneRole)
+				cfg.ExtraPortMappings = []PortMapping{
+					{
+						ContainerPort: 8080,
+						HostPort:      8080,
+						ListenAddress: "not-an-ip",
+					},
+				}
+				return cfg
+			}(),
+			ExpectErrors: 1,
+		},
 	}
 
 	for _, tc := range cases {
@@ -427,6 +457,23 @@ func TestNodeValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetDefaultsNode(t *testing.T) {
+	t.Parallel()
+
+	node := Node{
+		ExtraPortMappings: []PortMapping{
+			{
+				ContainerPort: 8080,
+				HostPort:      8080,
+			},
+		},
+	}
+
+	SetDefaultsNode(&node)
+
+	assert.StringEqual(t, string(PortMappingProtocolTCP), string(node.ExtraPortMappings[0].Protocol))
 }
 
 func TestPortValidate(t *testing.T) {

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -161,7 +161,7 @@ kind can auto-detect the [docker], [podman], or [nerdctl] installed and choose t
 select the runtime.
 
 > **NOTE**: podman and nerdctl operate in [rootless mode](/docs/user/rootless) by default. Extra
-> setup is needed for KIND clusters to be fully functional.
+> configuration is needed for KIND clusters to be fully functional.
 
 ## Interacting With Your Cluster
 


### PR DESCRIPTION
Improve node config validation by defaulting empty port mapping protocols to TCP and rejecting invalid listenAddress values early. Includes tests.