### PR TITLE
docs: clarify rootless quick-start note

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -161,7 +161,7 @@ kind can auto-detect the [docker], [podman], or [nerdctl] installed and choose t
 select the runtime.
 
 > **NOTE**: podman and nerdctl operate in [rootless mode](/docs/user/rootless) by default. Extra
-> setup is needed for KIND clusters to be fully functional.
+> configuration steps are needed for KIND clusters to be fully functional.
 
 ## Interacting With Your Cluster
 

--- a/site/content/docs/user/using-wsl2.md
+++ b/site/content/docs/user/using-wsl2.md
@@ -44,7 +44,7 @@ If you're using a physical machine, you can mount the ISO, copy the files to a F
 
 If you want the full details, see the [Installation Instructions for WSL2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install). This is the TL;DR version.
 
-Once your Windows machine is ready, you need to do a few more steps to set up WSL2
+Once your Windows machine is ready, you need to do a few more steps to set up WSL2.
 
 1. Open a PowerShell window as an admin, then run
 


### PR DESCRIPTION
Small docs-only wording cleanup in the quick-start guide. This keeps the note accurate while reading more naturally for users following the rootless provider paths.