### PR TITLE
docs: clarify auditing configuration wording

### DIFF
--- a/site/content/docs/user/auditing.md
+++ b/site/content/docs/user/auditing.md
@@ -40,7 +40,7 @@ EOF
 
 ### Create a `kind-config.yaml` file.
 
-To enable audit logging, use kind's [configuration file] to pass additional setup instructions. Kind uses `kubeadm` to provision the cluster and the configuration file has the ability to pass `kubeadmConfigPatches` for further customization.
+To enable audit logging, use kind's [configuration file] to pass additional configuration instructions. Kind uses `kubeadm` to provision the cluster and the configuration file has the ability to pass `kubeadmConfigPatches` for further customization.
 
 {{< codeFromInline lang="bash" >}}
 cat <<EOF > kind-config.yaml

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -161,7 +161,7 @@ kind can auto-detect the [docker], [podman], or [nerdctl] installed and choose t
 select the runtime.
 
 > **NOTE**: podman and nerdctl operate in [rootless mode](/docs/user/rootless) by default. Extra
-> setup is needed for KIND clusters to be fully functional.
+> configuration steps are needed for KIND clusters to be fully functional.
 
 ## Interacting With Your Cluster
 

--- a/site/content/docs/user/using-wsl2.md
+++ b/site/content/docs/user/using-wsl2.md
@@ -44,7 +44,7 @@ If you're using a physical machine, you can mount the ISO, copy the files to a F
 
 If you want the full details, see the [Installation Instructions for WSL2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install). This is the TL;DR version.
 
-Once your Windows machine is ready, you need to do a few more steps to set up WSL2
+Once your Windows machine is ready, you need to do a few more steps to set up WSL2.
 
 1. Open a PowerShell window as an admin, then run
 

--- a/site/content/docs/user/using-wsl2.md
+++ b/site/content/docs/user/using-wsl2.md
@@ -35,7 +35,7 @@ Now, start up the VM. Watch carefully for the "Press any key to continue install
 
 If you're using a physical machine, you can mount the ISO, copy the files to a FAT32 formatted USB disk, and boot from that instead. Be sure the machine is configured to boot using UEFI (not legacy BIOS), and has Intel VT or AMD-V enabled for the hypervisor.
 
-### Tips during setup
+### Tips during installation
 
 - You can skip the product key page
 - On the "Sign in with Microsoft" screen, look for the "offline account" button.


### PR DESCRIPTION
Small docs-only cleanup in the auditing guide. This improves the wording around configuration instructions without changing the example or the setup flow.