### PR TITLE
docs: fix 'systctl.d' typo to 'sysctl.d' in rootless guide

### DIFF
--- a/site/content/docs/user/rootless.md
+++ b/site/content/docs/user/rootless.md
@@ -156,7 +156,7 @@ are particularly susceptible to this issue.
 
 To increase the inotify limits, do the following:
 
-1. As root, create a `.conf` file in `/etc/systctl.d` that increases the `fs.inotify` max user settings:
+1. As root, create a `.conf` file in `/etc/sysctl.d` that increases the `fs.inotify` max user settings:
 
    ```
    fs.inotify.max_user_watches = 524288
@@ -199,7 +199,7 @@ appropriate port number. In the example above, HTTP requests must use `localhost
 
 To allow a KIND node to bind to ports 80 and/or 443 on the host, do the following:
 
-1. As root, create a `.conf` file in `/etc/systctl.d` that lowers the privileged port start number:
+1. As root, create a `.conf` file in `/etc/sysctl.d` that lowers the privileged port start number:
 
    ```
    # Allow unprivileged binding to HTTP port 80


### PR DESCRIPTION
Fixes #4132

The rootless mode documentation referenced `/etc/systctl.d` in two places (inotify limits and privileged port binding). That directory does not exist; the correct path is `/etc/sysctl.d`, which matches the adjacent `sudo sysctl --system` reload steps.

## Changes

Two single-character fixes in `site/content/docs/user/rootless.md`:

- Line 159: `/etc/systctl.d` → `/etc/sysctl.d` (inotify limits section)
- Line 202: `/etc/systctl.d` → `/etc/sysctl.d` (privileged ports section)

## Verification

```
$ grep -n 'systctl' site/content/docs/user/rootless.md
# no matches
$ grep -n 'sysctl' site/content/docs/user/rootless.md
169:   sudo sysctl --system
213:   sudo sysctl --system
265:- To enable OOM watching, allow `dmesg` by running `sysctl -w kernel.dmesg_re...
```

Confirmed by @aojea in [the issue](https://github.com/kubernetes-sigs/kind/issues/4132#issuecomment-3456099057).

/kind documentation
/sig cluster-lifecycle