### PR TITLE
feat: add kind env command

### DIFF
--- a/pkg/cmd/kind/env/env.go
+++ b/pkg/cmd/kind/env/env.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package env implements the `env` command.
+package env
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kind/pkg/cmd"
+	"sigs.k8s.io/kind/pkg/log"
+)
+
+type environmentVariable struct {
+	Name        string
+	Description string
+}
+
+var environmentVariables = []environmentVariable{
+	{
+		Name:        "KIND_CLUSTER_NAME",
+		Description: "Default cluster name for create/delete commands",
+	},
+	{
+		Name:        "KIND_EXPERIMENTAL_PROVIDER",
+		Description: "Selects the runtime provider used for new clusters",
+	},
+	{
+		Name:        "KIND_EXPERIMENTAL_DOCKER_NETWORK",
+		Description: "Overrides the Docker network used for nodes",
+	},
+	{
+		Name:        "KIND_EXPERIMENTAL_PODMAN_NETWORK",
+		Description: "Overrides the Podman network used for nodes",
+	},
+	{
+		Name:        "KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER",
+		Description: "Passes a custom containerd snapshotter to nodes",
+	},
+	{
+		Name:        "KIND_DNS_SEARCH",
+		Description: "Provides DNS search domains for nodes",
+	},
+	{
+		Name:        "KUBECONFIG",
+		Description: "Overrides the kubeconfig path used by kind",
+	},
+}
+
+// NewCommand returns a new cobra.Command for env.
+func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
+	return &cobra.Command{
+		Use:   "env",
+		Short: "Prints the kind environment variables",
+		Long:  "Prints the kind environment variables and their current values",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return printEnv(streams.Out)
+		},
+	}
+}
+
+func printEnv(out io.Writer) error {
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	_, err := fmt.Fprintln(tw, "NAME\tVALUE\tDESCRIPTION")
+	if err != nil {
+		return err
+	}
+	for _, env := range environmentVariables {
+		value, ok := os.LookupEnv(env.Name)
+		if !ok {
+			value = "<unset>"
+		} else if value == "" {
+			value = "<empty>"
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", env.Name, value, env.Description); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}

--- a/pkg/cmd/kind/env/env_test.go
+++ b/pkg/cmd/kind/env/env_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package env
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPrintEnv(t *testing.T) {
+	t.Setenv("KIND_CLUSTER_NAME", "kind-dev")
+	t.Setenv("KIND_EXPERIMENTAL_PROVIDER", "podman")
+	t.Setenv("KUBECONFIG", "/tmp/kubeconfig")
+	t.Setenv("KIND_DNS_SEARCH", "")
+
+	var buf bytes.Buffer
+	if err := printEnv(&buf); err != nil {
+		t.Fatalf("printEnv() returned error: %v", err)
+	}
+	out := buf.String()
+
+	expected := []string{
+		"NAME",
+		"VALUE",
+		"DESCRIPTION",
+		"KIND_CLUSTER_NAME",
+		"kind-dev",
+		"KIND_EXPERIMENTAL_PROVIDER",
+		"podman",
+		"KUBECONFIG",
+		"/tmp/kubeconfig",
+		"KIND_DNS_SEARCH",
+		"<empty>",
+	}
+	for _, want := range expected {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output %q did not contain %q", out, want)
+		}
+	}
+
+	order := []string{
+		"KIND_CLUSTER_NAME",
+		"KIND_EXPERIMENTAL_PROVIDER",
+		"KIND_EXPERIMENTAL_DOCKER_NETWORK",
+		"KIND_EXPERIMENTAL_PODMAN_NETWORK",
+		"KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER",
+		"KIND_DNS_SEARCH",
+		"KUBECONFIG",
+	}
+	last := -1
+	for _, want := range order {
+		idx := strings.Index(out, want)
+		if idx < 0 {
+			t.Fatalf("output %q did not contain %q", out, want)
+		}
+		if idx < last {
+			t.Fatalf("env output order is wrong: %q appears before a previous entry", want)
+		}
+		last = idx
+	}
+}

--- a/pkg/cmd/kind/root.go
+++ b/pkg/cmd/kind/root.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cmd/kind/completion"
 	"sigs.k8s.io/kind/pkg/cmd/kind/create"
 	"sigs.k8s.io/kind/pkg/cmd/kind/delete"
+	"sigs.k8s.io/kind/pkg/cmd/kind/env"
 	"sigs.k8s.io/kind/pkg/cmd/kind/export"
 	"sigs.k8s.io/kind/pkg/cmd/kind/get"
 	"sigs.k8s.io/kind/pkg/cmd/kind/load"
@@ -75,6 +76,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	cmd.AddCommand(create.NewCommand(logger, streams))
 	cmd.AddCommand(delete.NewCommand(logger, streams))
 	cmd.AddCommand(export.NewCommand(logger, streams))
+	cmd.AddCommand(env.NewCommand(logger, streams))
 	cmd.AddCommand(get.NewCommand(logger, streams))
 	cmd.AddCommand(version.NewCommand(logger, streams))
 	cmd.AddCommand(load.NewCommand(logger, streams))

--- a/site/content/docs/user/auditing.md
+++ b/site/content/docs/user/auditing.md
@@ -40,7 +40,7 @@ EOF
 
 ### Create a `kind-config.yaml` file.
 
-To enable audit logging, use kind's [configuration file] to pass additional setup instructions. Kind uses `kubeadm` to provision the cluster and the configuration file has the ability to pass `kubeadmConfigPatches` for further customization.
+To enable audit logging, use kind's [configuration file] to pass additional configuration instructions. Kind uses `kubeadm` to provision the cluster and the configuration file has the ability to pass `kubeadmConfigPatches` for further customization.
 
 {{< codeFromInline lang="bash" >}}
 cat <<EOF > kind-config.yaml

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -161,7 +161,7 @@ kind can auto-detect the [docker], [podman], or [nerdctl] installed and choose t
 select the runtime.
 
 > **NOTE**: podman and nerdctl operate in [rootless mode](/docs/user/rootless) by default. Extra
-> setup is needed for KIND clusters to be fully functional.
+> configuration steps are needed for KIND clusters to be fully functional.
 
 ## Interacting With Your Cluster
 

--- a/site/content/docs/user/using-wsl2.md
+++ b/site/content/docs/user/using-wsl2.md
@@ -44,7 +44,7 @@ If you're using a physical machine, you can mount the ISO, copy the files to a F
 
 If you want the full details, see the [Installation Instructions for WSL2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install). This is the TL;DR version.
 
-Once your Windows machine is ready, you need to do a few more steps to set up WSL2
+Once your Windows machine is ready, you need to do a few more steps to set up WSL2.
 
 1. Open a PowerShell window as an admin, then run
 

--- a/site/content/docs/user/using-wsl2.md
+++ b/site/content/docs/user/using-wsl2.md
@@ -35,7 +35,7 @@ Now, start up the VM. Watch carefully for the "Press any key to continue install
 
 If you're using a physical machine, you can mount the ISO, copy the files to a FAT32 formatted USB disk, and boot from that instead. Be sure the machine is configured to boot using UEFI (not legacy BIOS), and has Intel VT or AMD-V enabled for the hypervisor.
 
-### Tips during setup
+### Tips during installation
 
 - You can skip the product key page
 - On the "Sign in with Microsoft" screen, look for the "offline account" button.


### PR DESCRIPTION
Add a new `kind env` command that prints the environment variables influencing cluster creation and the current value of each one. This makes it easier to discover provider, networking, and kubeconfig overrides from the CLI itself.\n\nTests cover unset, empty, and set values, and the root command now exposes the new subcommand.