### PR TITLE
docs(rootless): fix `/etc/systctl.d` -> `/etc/sysctl.d` typo

### DIFF
--- a/site/content/docs/user/rootless.md
+++ b/site/content/docs/user/rootless.md
@@ -156,7 +156,7 @@ are particularly susceptible to this issue.
 
 To increase the inotify limits, do the following:
 
-1. As root, create a `.conf` file in `/etc/systctl.d` that increases the `fs.inotify` max user settings:
+1. As root, create a `.conf` file in `/etc/sysctl.d` that increases the `fs.inotify` max user settings:
 
    ```
    fs.inotify.max_user_watches = 524288
@@ -199,7 +199,7 @@ appropriate port number. In the example above, HTTP requests must use `localhost
 
 To allow a KIND node to bind to ports 80 and/or 443 on the host, do the following:
 
-1. As root, create a `.conf` file in `/etc/systctl.d` that lowers the privileged port start number:
+1. As root, create a `.conf` file in `/etc/sysctl.d` that lowers the privileged port start number:
 
    ```
    # Allow unprivileged binding to HTTP port 80


### PR DESCRIPTION
Closes #4132.

The [rootless guide](https://kind.sigs.k8s.io/docs/user/rootless/#increase-inotify-limits) told users to drop a \`.conf\` file in \`/etc/systctl.d\` in two places (the inotify-limits section and the unprivileged-port-range section). That path doesn't exist — the real one is \`/etc/sysctl.d\` (\`man sysctl.d\` / \`systemd-sysctl\`), which is also what the follow-up \`sudo sysctl --system\` lines right below each step already invoke. Anyone pasting the snippet verbatim ends up with a file systemd never reads.

One-character fix, same replacement in both places.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>