### PR TITLE
Skip /dev/mapper mount on rootless Docker

### DIFF
--- a/pkg/cluster/internal/providers/docker/util.go
+++ b/pkg/cluster/internal/providers/docker/util.go
@@ -49,8 +49,14 @@ func usernsRemap() bool {
 }
 
 // mountDevMapper checks if the Docker storage driver is Btrfs or ZFS
-// or if the backing filesystem is Btrfs
+// or if the backing filesystem is Btrfs.
+// Rootless Docker cannot create device nodes, so skip the mount.
 func mountDevMapper() bool {
+	i, err := info()
+	if err == nil && i != nil && i.Rootless {
+		return false
+	}
+
 	storage := ""
 	// check the docker storage driver
 	cmd := exec.Command("docker", "info", "-f", "{{.Driver}}")


### PR DESCRIPTION
Skip /dev/mapper mount on rootless Docker

Rootless Docker cannot create device nodes inside containers.
When the host backing filesystem is btrfs, zfs, or xfs, kind
unconditionally mounted /dev/mapper into the node container,
which failed with "permission denied" on rootless setups.

Add a rootless check to mountDevMapper() to skip this mount
when Docker is running rootless, matching the existing pattern
used by mountFuse().

Fixes #3963
Fixes #3972