### PR TITLE
fix: handle empty port mapping listen addresses

### DIFF
--- a/pkg/internal/apis/config/validate.go
+++ b/pkg/internal/apis/config/validate.go
@@ -163,6 +163,12 @@ func validatePortMappings(portMappings []PortMapping) error {
 		}
 
 		addr := net.ParseIP(portMapping.ListenAddress)
+		if portMapping.ListenAddress == "" {
+			addr = wildcardAddrIPv4
+		}
+		if addr == nil {
+			return fmt.Errorf("invalid listen address: %s", portMapping.ListenAddress)
+		}
 		addrString := addr.String()
 
 		portProtocol := formatPortProtocol(portMapping.HostPort, portMapping.Protocol)

--- a/pkg/internal/apis/config/validate_test.go
+++ b/pkg/internal/apis/config/validate_test.go
@@ -578,6 +578,28 @@ func TestValidatePortMappings(t *testing.T) {
 			// error expected: port mapping is already defined for wildcard interface - ::
 			expectErr: fmt.Sprintf("%s: [::1]:80/SCTP", errMsg),
 		},
+		{
+			testName: "empty listen address defaults to wildcard",
+			portMappings: []PortMapping{
+				newPortMapping("", 80, "TCP"),
+			},
+			expectErr: "",
+		},
+		{
+			testName: "empty listen address conflicts as wildcard",
+			portMappings: []PortMapping{
+				newPortMapping("", 80, "TCP"),
+				newPortMapping("127.0.0.1", 80, "TCP"),
+			},
+			expectErr: fmt.Sprintf("%s: 127.0.0.1:80/TCP", errMsg),
+		},
+		{
+			testName: "invalid listen address",
+			portMappings: []PortMapping{
+				newPortMapping("not-an-ip", 80, "TCP"),
+			},
+			expectErr: "invalid listen address: not-an-ip",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes a panic when `extraPortMappings` omits `listenAddress`. Docs say it is optional, and providers already default it to wildcard, so validation should treat it that way too. tiny footgun tbh.

Repro:
```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  extraPortMappings:
  - containerPort: 80
    hostPort: 8080
```

Run:
```bash
kind create cluster --config config.yaml
```

Before: validation can panic in `validatePortMappings` on `addr.String()`.
After: empty `listenAddress` is checked as `0.0.0.0`; bad values get a normal validation error, no boom.

Checked:
- `go test ./pkg/internal/apis/config`
- `make unit`
- `make verify` got through lints/generated, then shellcheck hit local Docker socket perms here.

Related: #4133