### PR TITLE
Update example local registry tag from 2 to 3

### DIFF
--- a/site/static/examples/kind-with-registry.sh
+++ b/site/static/examples/kind-with-registry.sh
@@ -7,7 +7,7 @@ reg_port='5001'
 if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
   docker run \
     -d --restart=always -p "127.0.0.1:${reg_port}:5000" --network bridge --name "${reg_name}" \
-    registry:2
+    registry:3
 fi
 
 # 2. Create kind cluster with containerd registry config dir enabled


### PR DESCRIPTION
Raises the registry version from 2 to 3 to get up to date.

---

```
$ ./site/static/examples/kind-with-registry.sh
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.35.0) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
configmap/local-registry-hosting created
```

```
$ docker pull gcr.io/google-samples/hello-app:1.0
1.0: Pulling from google-samples/hello-app
7c12895b777b: Pull complete
3214acf345c0: Pull complete
069d1e267530: Pull complete
b839dfae01f6: Pull complete
990a9c434e5e: Pull complete
2780920e5dbf: Pull complete
86869ae6f192: Pull complete
dd64bf2dd177: Pull complete
ef49c20a7b35: Pull complete
52630fc75a18: Pull complete
dcaa5a89b0cc: Pull complete
526604835308: Pull complete
bf7a4185f015: Pull complete
Digest: sha256:649188051906c9df7f87fb2ef04a21acbdb009c0877fa67b3132b83230411f6e
Status: Downloaded newer image for gcr.io/google-samples/hello-app:1.0
gcr.io/google-samples/hello-app:1.0
```

```
$ docker tag gcr.io/google-samples/hello-app:1.0 localhost:5001/hello-app:1.0
$ docker push localhost:5001/hello-app:1.0
The push refers to repository [localhost:5001/hello-app]
526604835308: Pushed
bf7a4185f015: Pushed
86869ae6f192: Pushed
990a9c434e5e: Pushed
52630fc75a18: Pushed
7c12895b777b: Pushed
b839dfae01f6: Pushed
3214acf345c0: Pushed
ef49c20a7b35: Pushed
069d1e267530: Pushed
dcaa5a89b0cc: Pushed
2780920e5dbf: Pushed
dd64bf2dd177: Pushed
1.0: digest: sha256:649188051906c9df7f87fb2ef04a21acbdb009c0877fa67b3132b83230411f6e size: 3022
```

```
$ kubectl create deployment hello-server --image=localhost:5001/hello-app:1.0
deployment.apps/hello-server created
```

```
$ k get pod
NAME                            READY   STATUS    RESTARTS   AGE
hello-server-867664d94b-ljrxh   1/1     Running   0          7s
```

---

Related to https://github.com/kubernetes-sigs/kind/issues/1213#issuecomment-4414859240