### PR TITLE
bump containerd back to 2.2.3 due to 2.3.0 regression, bump runc to 1…

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -124,7 +124,7 @@ RUN eval "$(gimme "${GO_VERSION}")" \
 # stage for building containerd
 FROM go-build AS build-containerd
 ARG TARGETARCH GO_VERSION
-ARG CONTAINERD_VERSION="v2.3.0"
+ARG CONTAINERD_VERSION="v2.2.3"
 ARG CONTAINERD_CLONE_URL="https://github.com/containerd/containerd"
 # we don't build with optional snapshotters, we never select any of these
 # they're not ideal inside kind anyhow, and we save some disk space
@@ -142,7 +142,7 @@ RUN git clone --filter=tree:0 "${CONTAINERD_CLONE_URL}" /containerd \
 # stage for building runc
 FROM go-build AS build-runc
 ARG TARGETARCH GO_VERSION
-ARG RUNC_VERSION="v1.4.2"
+ARG RUNC_VERSION="v1.3.5"
 ARG RUNC_CLONE_URL="https://github.com/opencontainers/runc"
 RUN git clone --filter=tree:0 "${RUNC_CLONE_URL}" /runc \
     && cd /runc \


### PR DESCRIPTION
….3.5 to match

https://github.com/kubernetes-sigs/kind/pull/4149#discussion_r3215259815