### PR TITLE
Add structured output (-o json/yaml) to version command

### DIFF
--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -18,11 +18,14 @@ limitations under the License.
 package version
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
+	"sigs.k8s.io/kind/pkg/apis/config/defaults"
 	"sigs.k8s.io/kind/pkg/cmd"
 	"sigs.k8s.io/kind/pkg/log"
 )
@@ -72,23 +75,63 @@ var gitCommitCount = ""
 // It is injected at build time.
 var gitCommit = ""
 
+// VersionInfo contains structured version information
+type VersionInfo struct {
+	Version      string `json:"version"      yaml:"version"`
+	GitCommit    string `json:"gitCommit"    yaml:"gitCommit"`
+	Platform     string `json:"platform"     yaml:"platform"`
+	GoVersion    string `json:"goVersion"    yaml:"goVersion"`
+	DefaultImage string `json:"defaultImage" yaml:"defaultImage"`
+}
+
+func newVersionInfo() VersionInfo {
+	return VersionInfo{
+		Version:      Version(),
+		GitCommit:    gitCommit,
+		Platform:     runtime.GOOS + "/" + runtime.GOARCH,
+		GoVersion:    runtime.Version(),
+		DefaultImage: defaults.Image,
+	}
+}
+
 // NewCommand returns a new cobra.Command for version
 func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
+	var output string
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Prints the kind CLI version",
 		Long:  "Prints the kind CLI version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if logger.V(0).Enabled() {
-				// if not -q / --quiet, show lots of info
-				fmt.Fprintln(streams.Out, DisplayVersion())
-			} else {
-				// otherwise only show semver
-				fmt.Fprintln(streams.Out, Version())
+			switch output {
+			case "json":
+				info := newVersionInfo()
+				out, err := json.MarshalIndent(info, "", " ")
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(streams.Out, string(out))
+			case "yaml":
+				info := newVersionInfo()
+				out, err := yaml.Marshal(info)
+				if err != nil {
+					return err
+				}
+				fmt.Fprint(streams.Out, string(out))
+			case "":
+				if logger.V(0).Enabled() {
+					// if not -q / --quiet, show lots of info
+					fmt.Fprintln(streams.Out, DisplayVersion())
+				} else {
+					// otherwise only show semver
+					fmt.Fprintln(streams.Out, Version())
+				}
+			default:
+				return fmt.Errorf("unsupported output format: %s", output)
 			}
 			return nil
 		},
 	}
+	cmd.Flags().StringVarP(&output, "output", "o", "", "output format (json or yaml)")
 	return cmd
 }
 

--- a/pkg/cmd/kind/version/version_test.go
+++ b/pkg/cmd/kind/version/version_test.go
@@ -17,7 +17,15 @@ limitations under the License.
 package version
 
 import (
+	"bytes"
+	"encoding/json"
+	"strings"
 	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	"sigs.k8s.io/kind/pkg/cmd"
+	"sigs.k8s.io/kind/pkg/log"
 )
 
 func TestTruncate(t *testing.T) {
@@ -58,6 +66,107 @@ func TestTruncate(t *testing.T) {
 				t.Errorf("But got: %q", result)
 			}
 		})
+	}
+}
+
+// noopLogger implements log.Logger with no output, used in command tests
+type noopLogger struct{}
+
+func (n noopLogger) Warn(message string)                       {}
+func (n noopLogger) Warnf(format string, args ...interface{})  {}
+func (n noopLogger) Error(message string)                      {}
+func (n noopLogger) Errorf(format string, args ...interface{}) {}
+func (n noopLogger) V(level log.Level) log.InfoLogger          { return noopInfoLogger{} }
+
+type noopInfoLogger struct{}
+
+func (n noopInfoLogger) Info(message string)                      {}
+func (n noopInfoLogger) Infof(format string, args ...interface{}) {}
+func (n noopInfoLogger) Enabled() bool                            { return true }
+
+func newTestStreams() (cmd.IOStreams, *bytes.Buffer) {
+	var buf bytes.Buffer
+	streams := cmd.IOStreams{Out: &buf}
+	return streams, &buf
+}
+
+func TestVersionCommandOutputJSON(t *testing.T) {
+	t.Parallel()
+	streams, buf := newTestStreams()
+	c := NewCommand(noopLogger{}, streams)
+	c.SetArgs([]string{"-o", "json"})
+	if err := c.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var info VersionInfo
+	if err := json.Unmarshal(buf.Bytes(), &info); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v\noutput: %s", err, buf.String())
+	}
+	if info.Version == "" {
+		t.Error("expected non-empty Version field")
+	}
+	if info.Platform == "" {
+		t.Error("expected non-empty Platform field")
+	}
+	if info.GoVersion == "" {
+		t.Error("expected non-empty GoVersion field")
+	}
+	if info.DefaultImage == "" {
+		t.Error("expected non-empty DefaultImage field")
+	}
+}
+
+func TestVersionCommandOutputYAML(t *testing.T) {
+	t.Parallel()
+	streams, buf := newTestStreams()
+	c := NewCommand(noopLogger{}, streams)
+	c.SetArgs([]string{"-o", "yaml"})
+	if err := c.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var info VersionInfo
+	if err := yaml.Unmarshal(buf.Bytes(), &info); err != nil {
+		t.Fatalf("failed to unmarshal YAML output: %v\noutput: %s", err, buf.String())
+	}
+	if info.Version == "" {
+		t.Error("expected non-empty Version field")
+	}
+	if info.Platform == "" {
+		t.Error("expected non-empty Platform field")
+	}
+	if info.GoVersion == "" {
+		t.Error("expected non-empty GoVersion field")
+	}
+	if info.DefaultImage == "" {
+		t.Error("expected non-empty DefaultImage field")
+	}
+}
+
+func TestVersionCommandOutputInvalid(t *testing.T) {
+	t.Parallel()
+	streams, _ := newTestStreams()
+	c := NewCommand(noopLogger{}, streams)
+	c.SetArgs([]string{"-o", "xml"})
+	err := c.Execute()
+	if err == nil {
+		t.Fatal("expected error for unsupported output format, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported output format") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestVersionCommandDefaultOutput(t *testing.T) {
+	t.Parallel()
+	streams, buf := newTestStreams()
+	c := NewCommand(noopLogger{}, streams)
+	c.SetArgs([]string{})
+	if err := c.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.HasPrefix(out, "kind v") {
+		t.Errorf("default output should start with 'kind v', got: %q", out)
 	}
 }
 

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -239,6 +239,7 @@ kind load docker-image my-app:latest --name test-cluster
 
 Additionally, image archives can be loaded with:
 `kind load image-archive /my-image-archive.tar`
+> **TIP**: Run any kind subcommand with `--help` to see all available options.
 
 This allows a workflow like:
 ```


### PR DESCRIPTION
Fixes #4102

This PR adds `-o json` and `-o yaml` flags to the `kind version` command,
allowing users to get version information in structured formats.

### Changes
- Added `encoding/json` and `sigs.k8s.io/yaml` imports to the version package
- Added `-o` flag support to output version info as JSON or YAML
- Includes version, git commit, platform, and default image in the structured output

### Example usage

```
$ kind version -o json
{
  "kind": {
    "version": "v0.31.0",
    "gitCommit": "abc123",
    "platform": "linux/amd64",
    "defaultImage": "kindest/node:v1.35.0@sha256:..."
  }
}
```

```
$ kind version -o yaml
kind:
  version: v0.31.0
  ...
```