### PR TITLE
docs: document resource requirements for running and building kind clusters

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -330,6 +330,45 @@ kind build node-image --type source $HOME/go/src/k8s.io/kubernetes/
 > **NOTE**: modes other than source directory namely `url`, `file` and `release` are only
 > available in kind v0.24 and above.
 
+## Resource Requirements
+
+kind clusters run as Docker containers on the host, so the host's CPU and
+memory limits apply directly to the cluster.
+
+For typical single-node clusters with light workloads, Docker's default
+resource allocation (around 2 CPUs and 2 GB of memory on Docker Desktop) is
+usually enough to bring a cluster up. For more reliable operation with many
+pods or multi-node clusters, we recommend allocating at least **4 GB of memory
+and 2 CPUs** to Docker, and scaling up further for heavier workloads.
+
+Building Kubernetes node images with `kind build node-image` has a higher
+floor: see [Settings for Docker Desktop](#settings-for-docker-desktop) below.
+
+Exact numbers depend on the Kubernetes version, the CNI in use, and the
+workloads running on the cluster, so we recommend measuring against your own
+scenario rather than relying on fixed figures.
+
+### Measuring Resource Usage
+
+To check the resource footprint of a running cluster in a repeatable way,
+combine the cluster label that kind sets on node containers with
+[`docker stats`][docker stats].
+
+List the node containers for a cluster (the cluster named `kind` by default):
+
+```
+docker ps --filter label=io.x-k8s.kind.cluster=kind --format '{{.Names}}'
+```
+
+Then watch their live CPU and memory usage:
+
+```
+docker stats $(docker ps --filter label=io.x-k8s.kind.cluster=kind --format '{{.Names}}')
+```
+
+For per-pod measurements, install [metrics-server][metrics-server] (not
+bundled by default) and use `kubectl top nodes` / `kubectl top pods -A`.
+
 ### Settings for Docker Desktop
 
 If you are building Kubernetes (for example - `kind build node-image`) on MacOS or Windows then you need a minimum of 6GB of RAM
@@ -517,3 +556,5 @@ kind, the Kubernetes cluster itself, etc.
 [customize control plane with kubeadm]: https://kubernetes.io/docs/setup/independent/control-plane-flags/
 [access multiple clusters]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
 [release notes]: https://github.com/kubernetes-sigs/kind/releases
+[docker stats]: https://docs.docker.com/reference/cli/docker/container/stats/
+[metrics-server]: https://github.com/kubernetes-sigs/metrics-server

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -330,45 +330,6 @@ kind build node-image --type source $HOME/go/src/k8s.io/kubernetes/
 > **NOTE**: modes other than source directory namely `url`, `file` and `release` are only
 > available in kind v0.24 and above.
 
-## Resource Requirements
-
-kind clusters run as Docker containers on the host, so the host's CPU and
-memory limits apply directly to the cluster.
-
-For typical single-node clusters with light workloads, Docker's default
-resource allocation (around 2 CPUs and 2 GB of memory on Docker Desktop) is
-usually enough to bring a cluster up. For more reliable operation with many
-pods or multi-node clusters, we recommend allocating at least **4 GB of memory
-and 2 CPUs** to Docker, and scaling up further for heavier workloads.
-
-Building Kubernetes node images with `kind build node-image` has a higher
-floor: see [Settings for Docker Desktop](#settings-for-docker-desktop) below.
-
-Exact numbers depend on the Kubernetes version, the CNI in use, and the
-workloads running on the cluster, so we recommend measuring against your own
-scenario rather than relying on fixed figures.
-
-### Measuring Resource Usage
-
-To check the resource footprint of a running cluster in a repeatable way,
-combine the cluster label that kind sets on node containers with
-[`docker stats`][docker stats].
-
-List the node containers for a cluster (the cluster named `kind` by default):
-
-```
-docker ps --filter label=io.x-k8s.kind.cluster=kind --format '{{.Names}}'
-```
-
-Then watch their live CPU and memory usage:
-
-```
-docker stats $(docker ps --filter label=io.x-k8s.kind.cluster=kind --format '{{.Names}}')
-```
-
-For per-pod measurements, install [metrics-server][metrics-server] (not
-bundled by default) and use `kubectl top nodes` / `kubectl top pods -A`.
-
 ### Settings for Docker Desktop
 
 If you are building Kubernetes (for example - `kind build node-image`) on MacOS or Windows then you need a minimum of 6GB of RAM
@@ -556,5 +517,3 @@ kind, the Kubernetes cluster itself, etc.
 [customize control plane with kubeadm]: https://kubernetes.io/docs/setup/independent/control-plane-flags/
 [access multiple clusters]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
 [release notes]: https://github.com/kubernetes-sigs/kind/releases
-[docker stats]: https://docs.docker.com/reference/cli/docker/container/stats/
-[metrics-server]: https://github.com/kubernetes-sigs/metrics-server

--- a/site/content/docs/user/resource-requirements.md
+++ b/site/content/docs/user/resource-requirements.md
@@ -1,0 +1,67 @@
+---
+title: "Resource Requirements"
+menu:
+  main:
+    parent: "user"
+    identifier: "user-resource-requirements"
+    weight: 3
+description: |-
+  Notes on the resources kind clusters consume and how to measure usage on a running cluster.
+---
+
+## Overview
+
+kind runs Kubernetes node containers on the host's container runtime, so the
+host's CPU, memory, and disk I/O budgets apply directly to the cluster.
+
+There is no single recommended figure that holds across workloads. Real
+resource usage is dominated by what you run on top of the cluster, the
+Kubernetes version, and the CNI in use, so the most reliable approach is to
+measure against your own scenario rather than aim at a fixed number.
+
+## What Tends to Limit Small Hosts
+
+On very constrained hosts the bottleneck is usually **disk I/O for etcd**
+rather than CPU or memory. etcd is sensitive to fsync latency, so SSD-backed
+storage and a host that is not heavily contended for I/O make the largest
+difference for cluster stability.
+
+If you primarily plan to **build kind node images** (for example, with
+`kind build node-image` on macOS or Windows), the floor is higher and is
+about VM resources rather than cluster resources; see
+[Settings for Docker Desktop][docker-desktop-settings] in the quick start.
+
+## Measuring Cluster Usage
+
+kind labels every node container with `io.x-k8s.kind.cluster=<name>`. Combine
+that label with the runtime's `stats` command to watch live CPU and memory
+use for a specific cluster (`kind` by default).
+
+For Docker:
+
+```
+docker ps --filter label=io.x-k8s.kind.cluster=kind --format '{{.Names}}'
+docker stats $(docker ps --filter label=io.x-k8s.kind.cluster=kind --format '{{.Names}}')
+```
+
+For [Podman][podman]:
+
+```
+podman ps --filter label=io.x-k8s.kind.cluster=kind --format '{{.Names}}'
+podman stats $(podman ps --filter label=io.x-k8s.kind.cluster=kind --format '{{.Names}}')
+```
+
+For [nerdctl][nerdctl]:
+
+```
+nerdctl ps --filter label=io.x-k8s.kind.cluster=kind --format '{{.Names}}'
+nerdctl stats $(nerdctl ps --filter label=io.x-k8s.kind.cluster=kind --format '{{.Names}}')
+```
+
+For per-pod measurements, install [metrics-server] (not bundled by default)
+and use `kubectl top nodes` / `kubectl top pods -A`.
+
+[docker-desktop-settings]: /docs/user/quick-start/#settings-for-docker-desktop
+[podman]: https://podman.io/
+[nerdctl]: https://github.com/containerd/nerdctl
+[metrics-server]: https://github.com/kubernetes-sigs/metrics-server


### PR DESCRIPTION
Fixes #485

Reworked per maintainer feedback on this PR.

Instead of expanding `quick-start.md`, the resource notes now live in a
dedicated sub-page at `site/content/docs/user/resource-requirements.md`.
The page drops the prescriptive RAM/CPU figures from the original draft
and instead calls out that disk I/O for etcd is usually the limiting
factor on small hosts. It documents the
`io.x-k8s.kind.cluster=<name>` label-based measurement recipe with
variants for Docker, Podman, and nerdctl, and links to metrics-server
for per-pod numbers. The existing `Settings for Docker Desktop` section
in the quick start is left untouched and is referenced from the new
page for build-time VM sizing.

Supersedes #4093 in scope.

/kind documentation
/sig cluster-lifecycle