### PR TITLE
Add warning when using cgroupv1

### DIFF
--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -68,7 +68,7 @@ type ClusterOptions struct {
 // Cluster creates a cluster
 func Cluster(logger log.Logger, p providers.Provider, opts *ClusterOptions) error {
 	// validate provider first
-	if err := validateProvider(p); err != nil {
+	if err := validateProvider(logger, p); err != nil {
 		return err
 	}
 
@@ -241,7 +241,7 @@ func fixupOptions(opts *ClusterOptions) error {
 	return nil
 }
 
-func validateProvider(p providers.Provider) error {
+func validateProvider(logger log.Logger, p providers.Provider) error {
 	info, err := p.Info()
 	if err != nil {
 		return err
@@ -253,6 +253,8 @@ func validateProvider(p providers.Provider) error {
 		if !info.SupportsMemoryLimit || !info.SupportsPidsLimit || !info.SupportsCPUShares {
 			return errors.New("running kind with rootless provider requires setting systemd property \"Delegate=yes\", see https://kind.sigs.k8s.io/docs/user/rootless/")
 		}
+	} else if !info.Cgroup2 {
+		logger.Warn("cgroup v1 is deprecated in Kubernetes and will not be supported in a future kind release, please upgrade to cgroup v2")
 	}
 	return nil
 }


### PR DESCRIPTION
To help prepare for the eventually removal of cgroup v1 support, this adds a check and warning if we are running on a system that does not support cgroup v2.

Related-to: #3915 