### PR TITLE
fix: handle registry ports in image normalization

### DIFF
--- a/pkg/cluster/internal/providers/podman/images.go
+++ b/pkg/cluster/internal/providers/podman/images.go
@@ -92,9 +92,9 @@ func sanitizeImage(image string) (friendlyImageName, pullImageName string) {
 	var remainder string
 
 	if strings.Contains(image, "@sha256:") {
-		splits := strings.Split(image, "@sha256:")
+		splits := strings.SplitN(image, "@sha256:", 2)
 		friendlyImageName = splits[0]
-		remainder = strings.Split(splits[0], ":")[0] + "@sha256:" + splits[1]
+		remainder = stripTag(splits[0]) + "@sha256:" + splits[1]
 	} else {
 		friendlyImageName = image
 		remainder = image
@@ -112,4 +112,13 @@ func sanitizeImage(image string) (friendlyImageName, pullImageName string) {
 	}
 
 	return
+}
+
+func stripTag(image string) string {
+	lastSlash := strings.LastIndex(image, "/")
+	lastColon := strings.LastIndex(image, ":")
+	if lastColon > lastSlash {
+		return image[:lastColon]
+	}
+	return image
 }

--- a/pkg/cluster/internal/providers/podman/images_test.go
+++ b/pkg/cluster/internal/providers/podman/images_test.go
@@ -73,6 +73,11 @@ func Test_sanitizeImage(t *testing.T) {
 			pullImageName:     "foo.bar/baz@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6",
 		},
 		{
+			image:             "localhost:5000/kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6",
+			friendlyImageName: "localhost:5000/kindest/node:v1.21.1",
+			pullImageName:     "localhost:5000/kindest/node@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6",
+		},
+		{
 			image:             "baz:quux@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6",
 			friendlyImageName: "baz:quux",
 			pullImageName:     "docker.io/library/baz@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6",

--- a/pkg/cmd/kind/load/docker-image/docker-image.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image.go
@@ -275,10 +275,15 @@ func sanitizeImage(image string) (sanitizedName string) {
 		sanitizedName = defaultDomain + sanitizedName
 	}
 
-	i = strings.IndexRune(sanitizedName, ':')
-	if i == -1 {
+	if !hasTag(sanitizedName) && !strings.ContainsRune(sanitizedName, '@') {
 		sanitizedName += ":latest"
 	}
 
 	return
+}
+
+func hasTag(image string) bool {
+	lastSlash := strings.LastIndex(image, "/")
+	lastColon := strings.LastIndex(image, ":")
+	return lastColon > lastSlash
 }

--- a/pkg/cmd/kind/load/docker-image/docker-image_test.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image_test.go
@@ -94,6 +94,14 @@ func Test_sanitizeImage(t *testing.T) {
 			image:          "other-registry/baz",
 			sanitizedImage: "docker.io/other-registry/baz:latest",
 		},
+		{
+			image:          "localhost:5000/baz",
+			sanitizedImage: "localhost:5000/baz:latest",
+		},
+		{
+			image:          "localhost:5000/baz:quux",
+			sanitizedImage: "localhost:5000/baz:quux",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Tiny papercut in image ref normalization.

Registries with ports are valid refs, e.g. `localhost:5001/foo:tag`; kind local registry docs use this shape too. Some helpers treated the registry port colon like an image tag separator.

Repro, before this patch:

```sh
go test ./pkg/cluster/internal/providers/podman -run Test_sanitizeImage -count=1
go test ./pkg/cmd/kind/load/docker-image -run Test_sanitizeImage -count=1
```

The podman path turned `localhost:5000/kindest/node:v1.21.1@sha256:...` into `library/localhost@sha256:...`, yikes. `kind load docker-image localhost:5000/baz` also missed the implicit `:latest` tag.

This keeps colons before the last slash as part of the registry, and only strips/detects tags after the image path starts.

Verified:

```sh
go test ./pkg/... ./cmd/...
make unit
make verify
```

Related: #1213
