### PR TITLE
ci: fix rootless Docker permission issues

### DIFF
--- a/.github/workflows/vm.yaml
+++ b/.github/workflows/vm.yaml
@@ -75,8 +75,10 @@ jobs:
           limactl cp -r . default:/tmp/kind
           # Install packages
           lima sudo /tmp/kind/hack/ci/init-vm.sh
-          # Enable systemd lingering for rootless
-          lima sudo loginctl enable-linger "$USER"
+          # Enable systemd lingering for rootless. $USER on the host may differ
+          # from the Lima guest user (e.g. runner vs runner.guest), so derive
+          # the username inside the VM.
+          lima bash -c 'sudo loginctl enable-linger "$(id -un)"'
           # Install kind
           lima sudo git config --global --add safe.directory /tmp/kind
           lima sudo make -C /tmp/kind install INSTALL_DIR=/usr/bin
@@ -109,7 +111,9 @@ jobs:
       - name: Export logs
         if: always()
         run: |
-          "$HELPER" kind export logs /tmp/kind/logs
+          "$HELPER" mkdir -p /tmp/kind/logs
+          "$HELPER" kind export logs /tmp/kind/logs || true
+          "$HELPER" sh -c 'journalctl --no-pager --user --unit docker.service -n 50 > /tmp/kind/logs/docker-user-service.log 2>&1 || true'
           mkdir -p /tmp/kind/logs/lima
           cp -a ~/.lima/default/*.log /tmp/kind/logs/lima || true
           "$HELPER" tar cC /tmp/kind/logs . | tar xC /tmp/kind/logs

--- a/hack/ci/init-vm.sh
+++ b/hack/ci/init-vm.sh
@@ -40,6 +40,10 @@ GOARCH="$(uname -m | sed -e 's/aarch64/arm64/' -e 's/x86_64/amd64/')"
 curl -L -o /usr/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${GOARCH}/kubectl"
 chmod +x /usr/bin/kubectl
 
+# Disable SELinux enforcement in CI -- we're not testing SELinux policy and
+# enforcing mode causes permission denied errors with rootlesskit's detach-netns.
+setenforce 0 || true
+
 # Configuration for rootless: https://kind.sigs.k8s.io/docs/user/rootless/
 mkdir -p "/etc/systemd/system/user@.service.d"
 cat <<EOF >"/etc/systemd/system/user@.service.d/delegate.conf"


### PR DESCRIPTION
Something changed with containerd, the version of systemd on Fedora, or some other related package that has introduced a failure in setting up rootless docker, causing permission denied and other failures.

`loginctl enable-linger` was called with $USER from the host (runner), but the Lima guest user is runner.guest, so linger was never enabled for the user actually running rootless Docker. Fix by evaluating the username inside the VM with `id -un`.

Disables SELinux enforcement due to issues with the `--detach-ns` switch needed.

Also fix the Export logs step to not abort early when Docker is not running, and collect journalctl output for the docker user service so future failures are self-diagnosing.