### PR TITLE
add support for building node images from Kubernetes CI artifacts

### DIFF
--- a/pkg/build/nodeimage/build.go
+++ b/pkg/build/nodeimage/build.go
@@ -18,9 +18,13 @@ package nodeimage
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"runtime"
+	"strings"
+	"time"
 
 	"sigs.k8s.io/kind/pkg/build/nodeimage/internal/kube"
 	"sigs.k8s.io/kind/pkg/errors"
@@ -94,6 +98,31 @@ func Build(options ...Option) error {
 		}
 	}
 
+	if ctx.buildType == "ci" {
+		ctx.logger.V(0).Infof("Building using CI %q artifacts", ctx.kubeParam)
+		marker := ctx.kubeParam
+		if marker == "" {
+			marker = "latest"
+		}
+		if !strings.HasPrefix(marker, "ci/") {
+			marker = "ci/" + marker
+		}
+		if !strings.HasSuffix(marker, ".txt") {
+			marker = marker + ".txt"
+		}
+		markerURL := "https://dl.k8s.io/" + marker
+		resolvedVersion, err := fetchURL(ctx.logger, markerURL)
+		if err != nil {
+			return errors.Wrapf(err, "error resolving CI version from %s", markerURL)
+		}
+		ctx.logger.V(0).Infof("Resolved CI version: %s", resolvedVersion)
+		builder, err := kube.NewCIBuilder(ctx.logger, resolvedVersion, ctx.arch)
+		if err != nil {
+			return err
+		}
+		ctx.builder = builder
+	}
+
 	if ctx.builder == nil {
 		// locate sources if no kubernetes source was specified
 		if ctx.kubeParam == "" {
@@ -121,6 +150,7 @@ func Build(options ...Option) error {
 // url: if the param is a valid http or https url
 // file: if the param refers to an existing regular file
 // source: if the param refers to an existing directory
+// ci: if the param starts with "ci/" (indicates a CI build version marker)
 // release: if the param is a semantic version expression (does this require the v preprended?
 func detectBuildType(param string) string {
 	u, err := url.ParseRequestURI(param)
@@ -136,6 +166,9 @@ func detectBuildType(param string) string {
 		if info.Mode().IsDir() {
 			return "source"
 		}
+	}
+	if strings.HasPrefix(param, "ci/") {
+		return "ci"
 	}
 	_, err = version.ParseSemantic(param)
 	if err == nil {
@@ -153,4 +186,27 @@ func supportedArch(arch string) bool {
 	case "arm64":
 	}
 	return true
+}
+
+func fetchURL(logger log.Logger, url string) (string, error) {
+	logger.V(0).Infof("Fetching %q", url)
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
+	}
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("error status: %s", resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(body)), nil
 }

--- a/pkg/build/nodeimage/build_test.go
+++ b/pkg/build/nodeimage/build_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeimage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectBuildType(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "kind-build-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tmpFile := filepath.Join(tmpDir, "some-file")
+	if err := os.WriteFile(tmpFile, []byte("content"), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		param    string
+		expected string
+	}{
+		{
+			name:     "valid http url",
+			param:    "http://example.com/foo",
+			expected: "url",
+		},
+		{
+			name:     "valid https url",
+			param:    "https://example.com/foo",
+			expected: "url",
+		},
+		{
+			name:     "existing file",
+			param:    tmpFile,
+			expected: "file",
+		},
+		{
+			name:     "existing directory",
+			param:    tmpDir,
+			expected: "source",
+		},
+		{
+			name:     "ci/latest build type",
+			param:    "ci/latest",
+			expected: "ci",
+		},
+		{
+			name:     "ci/latest-1.30 build type",
+			param:    "ci/latest-1.30",
+			expected: "ci",
+		},
+		{
+			name:     "valid semantic release",
+			param:    "v1.30.0",
+			expected: "release",
+		},
+		{
+			name:     "valid semantic release without v prefix",
+			param:    "1.30.0",
+			expected: "release",
+		},
+		{
+			name:     "invalid / fallback",
+			param:    "invalid-input",
+			expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actual := detectBuildType(tc.param)
+			if actual != tc.expected {
+				t.Errorf("detectBuildType(%q) = %q, expected %q", tc.param, actual, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/build/nodeimage/internal/kube/builder_remote.go
+++ b/pkg/build/nodeimage/internal/kube/builder_remote.go
@@ -58,6 +58,16 @@ func NewReleaseBuilder(logger log.Logger, version, arch string) (Builder, error)
 	}, nil
 }
 
+// NewCIBuilder used to specify a CI semver and constructs a url to CI artifacts
+func NewCIBuilder(logger log.Logger, version, arch string) (Builder, error) {
+	url := "https://dl.k8s.io/ci/" + version + "/kubernetes-server-linux-" + arch + ".tar.gz"
+	return &remoteBuilder{
+		version: version,
+		logger:  logger,
+		url:     url,
+	}, nil
+}
+
 // Build implements Bits.Build
 func (b *remoteBuilder) Build() (Bits, error) {
 

--- a/pkg/cmd/kind/build/nodeimage/nodeimage.go
+++ b/pkg/cmd/kind/build/nodeimage/nodeimage.go
@@ -38,11 +38,18 @@ type flagpole struct {
 func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 	flags := &flagpole{}
 	cmd := &cobra.Command{
-		Args: cobra.MaximumNArgs(1),
-		// TODO(bentheelder): more detailed usage
+		Args:  cobra.MaximumNArgs(1),
 		Use:   "node-image [kubernetes-source]",
 		Short: "Build the node image",
-		Long:  "Build the node image which contains Kubernetes build artifacts and other kind requirements",
+		Long: `Build the node image which contains Kubernetes build artifacts and other kind requirements.
+By default, this will build from a local Kubernetes source directory (auto-detected if omitted).
+
+You can also build from:
+- A local Kubernetes source directory path (e.g., /path/to/kubernetes/source)
+- A local Kubernetes release tarball path (e.g., /path/to/kubernetes-server-linux-amd64.tar.gz)
+- A URL to a Kubernetes release tarball (e.g., https://dl.k8s.io/v1.30.0/kubernetes-server-linux-amd64.tar.gz)
+- A release version (e.g., v1.36.1)
+- A Kubernetes CI build version marker prefixed with 'ci/' (e.g., ci/latest, ci/latest-1.36)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(logger, flags, args)
 		},
@@ -51,7 +58,7 @@ func NewCommand(logger log.Logger, streams cmd.IOStreams) *cobra.Command {
 		&flags.BuildType,
 		"type",
 		"",
-		"optionally specify one of 'url', 'file', 'release' or 'source' as the type of build",
+		"optionally specify one of 'url', 'file', 'release', 'ci' or 'source' as the type of build",
 	)
 	cmd.Flags().StringVar(
 		&flags.Image,


### PR DESCRIPTION
So you can do like `kind build node-image ci/latest`, `kind build node-image ci/latest-1.36` in addition to the release markers

FYI @kannon92 @dims @pohly 

/hold