### PR TITLE
Fix: Permission error when creating pod with hostUsers: false

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -70,7 +70,7 @@ COPY --chmod=0644 files/etc/systemd/system/kubelet.service.d/* /etc/systemd/syst
 # Finally we adjust tempfiles cleanup to be 1 minute after "boot" instead of 15m
 # This is plenty after we've done initial setup for a node, but before we are
 # likely to try to export logs etc.
-RUN chmod 755 /kind/bin && \
+RUN chmod 755 /kind /kind/bin && \
     echo "Installing Packages ..." \
     && DEBIAN_FRONTEND=noninteractive clean-install \
       systemd \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -28,7 +28,7 @@ FROM $BASE_IMAGE AS base
 # all non-scripts are 0644 (rw- r-- r--)
 COPY --chmod=0755 files/usr/local/bin/* /usr/local/bin/
 
-COPY --chmod=0644 files/kind/ /kind/
+COPY --chmod=0755 files/kind/ /kind/
 # COPY only applies to files, not the directory itself, so the permissions are
 # fixed in RUN below with a chmod.
 COPY --chmod=0755 files/kind/bin/ /kind/bin/

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -28,7 +28,7 @@ FROM $BASE_IMAGE AS base
 # all non-scripts are 0644 (rw- r-- r--)
 COPY --chmod=0755 files/usr/local/bin/* /usr/local/bin/
 
-COPY --chmod=0755 files/kind/ /kind/
+COPY --chmod=0644 files/kind/ /kind/
 # COPY only applies to files, not the directory itself, so the permissions are
 # fixed in RUN below with a chmod.
 COPY --chmod=0755 files/kind/bin/ /kind/bin/


### PR DESCRIPTION
fix https://github.com/kubernetes-sigs/kind/issues/4178

## Testing
1. Build the kind base image with the changes in the PR
```bash
REGISTRY='docker.io/yesdeepakverma' IMAGE_NAME=my-kind TAG=0.1 make quick
```
2. Build a kind node image
```bash
K8S_TAG=v1.36.1
kind build node-image $K8S_TAG --base-image docker.io/yesdeepakverma/my-kind:0.1 --image my-kind-nodeset:0.1
```
3. Create a kind cluster with new kind node image
```bash
kind create cluster --name my-kind-cluster --image my-kind-nodeset:0.1
```
4. Exec into the kind node to verify the permission
```bash
root@my-kind-cluster-control-plane:/# ls -lah /kind
total 40K
**drwxr-xr-x 1 root root 4.0K May 30 19:51 .**
drwxr-xr-x 1 root root 4.0K May 30 19:51 ..
-rw-r--r-- 1 root root  187 May 30 04:55 README.txt
drwxr-xr-x 2 root root 4.0K May 30 04:55 bin
-rw------- 1 root root 1.8K May 30 19:51 kubeadm.conf
drwxr-xr-x 2 root root 4.0K May 30 19:50 manifests
-rw-r--r-- 1 root root   10 May 30 19:51 old-ipv4
-rw-r--r-- 1 root root   21 May 30 19:51 old-ipv6
-rw-r--r-- 1 root root   37 May 30 19:51 product_uuid
-rw------- 1 root root    7 May 30 19:50 version
```
5. Now create a pod with hostUsers: false flag
```bash
root@ubuntu:/code# echo "                                         
apiVersion: v1
kind: Pod
metadata:
  name: my-pod-hostusers-false
spec:
  hostUsers: false
  containers:
  - name: shell
    command: ["sleep", "infinity"]
    image: debian
" | kubectl apply -f -
pod/my-pod-hostusers-false created
root@ubuntu:/code# echo "
apiVersion: v1
kind: Pod
metadata:
  name: my-pod-without-hostusers
spec:
  containers:
  - name: shell
    command: ["sleep", "infinity"]
    image: debian
" | kubectl apply -f -
pod/my-pod-without-hostusers created
root@ubuntu:/code# kubectl get pods
NAME                       READY   STATUS    RESTARTS   AGE
my-pod-hostusers-false     1/1     Running   0          20s
my-pod-without-hostusers   1/1     Running   0          3s
```