### PR TITLE
docs: fix stale go install minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 kind is a tool for running local Kubernetes clusters using Docker container "nodes".
 kind was primarily designed for testing Kubernetes itself, but may be used for local development or CI.
 
-If you have [go] 1.16+ and [docker], [podman] or [nerdctl] installed `go install sigs.k8s.io/kind@v0.32.0 && kind create cluster` is all you need!
+If you have [go] and [docker], [podman] or [nerdctl] installed `go install sigs.k8s.io/kind@v0.32.0 && kind create cluster` is all you need!
 
 ![](site/static/images/kind-create-cluster.png)
 

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -84,7 +84,7 @@ use it as `kind` from the command line.
 
 #### Installing with `go install`
 
-When installing with [Go](https://golang.org/) please use the latest stable Go release. At least go1.16 or greater is required.
+When installing with [Go](https://golang.org/) please use the latest stable Go release.
 
 To install use: `go install sigs.k8s.io/kind@{{< stableVersion >}}`.
 


### PR DESCRIPTION
Summary

Tiny docs fix. `go install` with Go 1.16 or 1.17 is a no-go now, current deps need Go 1.18+. This updates the README and quick start so folks dont hit that wall.

Repro

1. `docker run --rm -v "$PWD":/src -w /src golang:1.17.13 /usr/local/go/bin/go install ./...`
2. It fails with `undefined: any` and `note: module requires Go 1.18`
3. `docker run --rm -v "$PWD":/src -w /src golang:1.18.10 /usr/local/go/bin/go install ./...`
4. That passes.

Validation

- `make -C site build`
