### PR TITLE
fix: skip inaccessible kubeconfig entries when choosing merge target

### DIFF
--- a/pkg/cluster/internal/kubeconfig/internal/kubeconfig/paths.go
+++ b/pkg/cluster/internal/kubeconfig/internal/kubeconfig/paths.go
@@ -74,7 +74,7 @@ func pathForMerge(explicitPath string, getEnv func(string) string) string {
 
 func fileExists(filename string) bool {
 	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
 	return !info.IsDir()

--- a/pkg/cluster/internal/kubeconfig/internal/kubeconfig/paths_test.go
+++ b/pkg/cluster/internal/kubeconfig/internal/kubeconfig/paths_test.go
@@ -129,7 +129,11 @@ func TestPathForMerge(t *testing.T) {
 		if err := os.Mkdir(inaccessibleDir, 0o700); err != nil {
 			t.Fatalf("failed to create inaccessible dir: %v", err)
 		}
-		defer os.Chmod(inaccessibleDir, 0o700)
+		defer func() {
+			if err := os.Chmod(inaccessibleDir, 0o700); err != nil {
+				t.Fatalf("failed to restore dir permissions: %v", err)
+			}
+		}()
 		if err := os.Chmod(inaccessibleDir, 0); err != nil {
 			t.Fatalf("failed to chmod inaccessible dir: %v", err)
 		}

--- a/pkg/cluster/internal/kubeconfig/internal/kubeconfig/paths_test.go
+++ b/pkg/cluster/internal/kubeconfig/internal/kubeconfig/paths_test.go
@@ -124,6 +124,25 @@ func TestPathForMerge(t *testing.T) {
 		expected := "/bogus/path/two"
 		assert.StringEqual(t, expected, result)
 	})
+	t.Run("KUBECONFIG skips inaccessible entry", func(t *testing.T) {
+		inaccessibleDir := filepath.Join(dir, "inaccessible")
+		if err := os.Mkdir(inaccessibleDir, 0o700); err != nil {
+			t.Fatalf("failed to create inaccessible dir: %v", err)
+		}
+		defer os.Chmod(inaccessibleDir, 0o700)
+		if err := os.Chmod(inaccessibleDir, 0); err != nil {
+			t.Fatalf("failed to chmod inaccessible dir: %v", err)
+		}
+
+		inaccessibleFile := filepath.Join(inaccessibleDir, "config")
+		kubeconfigEnvValue := strings.Join([]string{inaccessibleFile, fakeKubeconfigs[1]}, string(filepath.ListSeparator))
+		result := pathForMerge("", func(s string) string {
+			return map[string]string{
+				"KUBECONFIG": kubeconfigEnvValue,
+			}[s]
+		})
+		assert.StringEqual(t, fakeKubeconfigs[1], result)
+	})
 }
 
 func TestHomeDir(t *testing.T) {


### PR DESCRIPTION
kind can panic here if `KUBECONFIG` starts with a path under a dir that can't be stat'd. Kinda nasty, and pretty easy to hit with a root owned dir or a busted mount.

This change treats any `os.Stat` error as not usable, then keeps going to the next path.

Repro
1. `tmp=$(mktemp -d)`
2. `mkdir "$tmp/locked" && touch "$tmp/fallback" && chmod 000 "$tmp/locked"`
3. `export KUBECONFIG="$tmp/locked/config:$tmp/fallback"`
4. Run a kubeconfig writing flow like `kind export kubeconfig` or `kind create cluster`
5. Before this fix, kind can blow up with a nil pointer panic
6. After this fix, it skips the bad entry and uses the fallback file
