### PR TITLE
docs: mention Docker-Mac-Net-Connect for LoadBalancer

### DIFF
--- a/site/content/docs/user/loadbalancer.md
+++ b/site/content/docs/user/loadbalancer.md
@@ -50,9 +50,16 @@ Now verify that the loadbalancer works by sending traffic to it's external IP an
 LB_IP=$(kubectl get svc/foo-service -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
 {{< /codeFromInline >}}
 
+> **NOTE**: If you are using Docker Desktop on macOS and cannot reach the
+> assigned LoadBalancer IP directly, the Docker network may not be routed from
+> the host. Community tools such as [Docker-Mac-Net-Connect] can make Docker
+> container networks reachable from macOS.
+
 ```bash
 # should output foo and bar on separate lines 
 for _ in {1..10}; do
   curl ${LB_IP}:5678
 done
 ```
+
+[Docker-Mac-Net-Connect]: https://github.com/chipmk/docker-mac-net-connect


### PR DESCRIPTION
## Summary
- Add a LoadBalancer documentation note for Docker Desktop on macOS users who cannot reach the assigned LoadBalancer IP directly.
- Link Docker-Mac-Net-Connect as a community routing helper for making Docker container networks reachable from macOS.

## Reproduction
- Follow the LoadBalancer guide on Docker Desktop for macOS.
- Cloud Provider KIND assigns a LoadBalancer IP from the Docker network.
- The existing verification step asks users to curl that IP directly from the host, which may fail if the Docker network is not routed from macOS.

## Root cause
Docker Desktop on macOS does not expose Docker container networks to the host by default, but the LoadBalancer guide did not mention this platform-specific networking limitation or a possible routing helper.

## Changes
- Add a concise note beside the LoadBalancer verification command.
- Keep the guidance scoped to macOS and describe Docker-Mac-Net-Connect as a community tool rather than an official requirement.

## Tests
- `git diff --check`
- `make -C site build` (passes; Hugo reports existing deprecation warnings from the site config)

## Screenshots/Logs
Not applicable; documentation-only change.

Fixes #3448.
