### PR TITLE
docs: mention podman local registry push option

### DIFF
--- a/site/content/docs/user/local-registry.md
+++ b/site/content/docs/user/local-registry.md
@@ -27,8 +27,13 @@ The registry can be used like this.
 3. Then we'll push it to the registry `docker push localhost:5001/hello-app:1.0`
 4. And now we can use the image `kubectl create deployment hello-server --image=localhost:5001/hello-app:1.0`
 
+> **NOTE**: The example commands above use Docker. If you are using Podman
+> and see `http: server gave HTTP response to HTTPS client` when pushing to
+> `localhost:5001`, configure Podman to treat the local registry as insecure,
+> or push with `podman push --tls-verify=false localhost:5001/hello-app:1.0`.
+
 If you build your own image and tag it like `localhost:5001/image:foo` and then use
-it in kubernetes as `localhost:5001/image:foo`. 
+it in kubernetes as `localhost:5001/image:foo`.
 
 If for some reason you have code running *inside* of a pod within the cluster that
 needs to use this registry directly (e.g. to build and push an image) then that


### PR DESCRIPTION
## Summary
Add a Podman-specific note to the local registry guide for localhost HTTP registry pushes.

## Reproduction
Following the local registry guide with Podman can fail when pushing to `localhost:5001` with `http: server gave HTTP response to HTTPS client`.

## Root cause
The guide uses Docker commands. Docker allows HTTP on loopback registries by default, while Podman can require explicit insecure registry configuration or `--tls-verify=false` for this local registry push.

## Changes
- Add a short note after the Docker push example explaining the Podman-specific push option.
- Keep the main local registry example Docker-focused.

## Tests
- `git diff --check`
- `make -C site build`

## Screenshots/Logs
N/A, docs-only change.

Fixes #3468