### PR TITLE
fix: respect Docker client proxy config for docker nodes

### DIFF
--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -291,6 +292,9 @@ func runArgsForLoadBalancer(cfg *config.Cluster, name string, args []string) ([]
 
 func getProxyEnv(cfg *config.Cluster, networkName string, nodeNames []string) (map[string]string, error) {
 	envs := common.GetProxyEnvs(cfg)
+	if !kindProxyEnvOverridesDockerConfig(os.Getenv) {
+		envs = mergeProxyEnvWithDockerConfig(cfg, envs, dockerConfigProxyEnvs(os.Getenv, os.ReadFile, inspectDockerContextHost))
+	}
 	// Specifically add the docker network subnets to NO_PROXY if we are using a proxy
 	if len(envs) > 0 {
 		subnets, err := getSubnets(networkName)
@@ -311,6 +315,28 @@ func getProxyEnv(cfg *config.Cluster, networkName string, nodeNames []string) (m
 		envs[strings.ToLower(common.NOProxy)] = noProxyJoined
 	}
 	return envs, nil
+}
+
+func mergeProxyEnvWithDockerConfig(cfg *config.Cluster, envs, dockerEnv map[string]string) map[string]string {
+	if len(envs) == 0 && len(dockerEnv) > 0 {
+		envs = dockerEnv
+		noProxy := envs[common.NOProxy]
+		if noProxy != "" {
+			noProxy += ","
+		}
+		noProxy += cfg.Networking.ServiceSubnet + "," + cfg.Networking.PodSubnet
+		envs[common.NOProxy] = noProxy
+		envs[strings.ToLower(common.NOProxy)] = noProxy
+		return envs
+	}
+
+	for _, name := range []string{common.HTTPProxy, common.HTTPSProxy, common.NOProxy} {
+		if envs[name] == "" && dockerEnv[name] != "" {
+			envs[name] = dockerEnv[name]
+			envs[strings.ToLower(name)] = dockerEnv[name]
+		}
+	}
+	return envs
 }
 
 func getSubnets(networkName string) ([]string, error) {

--- a/pkg/cluster/internal/providers/docker/proxyconfig.go
+++ b/pkg/cluster/internal/providers/docker/proxyconfig.go
@@ -1,0 +1,155 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/kind/pkg/cluster/internal/providers/common"
+	"sigs.k8s.io/kind/pkg/exec"
+)
+
+const (
+	dockerConfigEnv  = "DOCKER_CONFIG"
+	dockerContextEnv = "DOCKER_CONTEXT"
+	dockerHostEnv    = "DOCKER_HOST"
+)
+
+type dockerConfigFile struct {
+	CurrentContext string                       `json:"currentContext"`
+	Proxies        map[string]dockerProxyConfig `json:"proxies"`
+}
+
+type dockerProxyConfig struct {
+	HTTPProxy  string `json:"httpProxy"`
+	HTTPSProxy string `json:"httpsProxy"`
+	NOProxy    string `json:"noProxy"`
+}
+
+func dockerConfigProxyEnvs(
+	getEnv func(string) string,
+	readFile func(string) ([]byte, error),
+	inspectContextHost func(string) (string, error),
+) map[string]string {
+	configPath := dockerConfigPath(getEnv)
+	if configPath == "" {
+		return map[string]string{}
+	}
+
+	rawConfig, err := readFile(configPath)
+	if err != nil {
+		return map[string]string{}
+	}
+
+	cfg := dockerConfigFile{}
+	if err := json.Unmarshal(rawConfig, &cfg); err != nil {
+		return map[string]string{}
+	}
+
+	proxyCfg, ok := dockerProxySettings(cfg.Proxies, dockerHostForProxyLookup(getEnv, cfg, inspectContextHost))
+	if !ok {
+		return map[string]string{}
+	}
+
+	envs := map[string]string{}
+	setProxyEnv(envs, common.HTTPProxy, proxyCfg.HTTPProxy)
+	setProxyEnv(envs, common.HTTPSProxy, proxyCfg.HTTPSProxy)
+	setProxyEnv(envs, common.NOProxy, proxyCfg.NOProxy)
+	return envs
+}
+
+func dockerConfigPath(getEnv func(string) string) string {
+	// Docker CLI config defaults to ~/.docker/config.json and can be overridden
+	// with DOCKER_CONFIG. The same config file also stores the current context.
+	// See https://docs.docker.com/reference/cli/docker/
+	if dockerConfigDir := getEnv(dockerConfigEnv); dockerConfigDir != "" {
+		return filepath.Join(dockerConfigDir, "config.json")
+	}
+	if homeDir := getEnv("HOME"); homeDir != "" {
+		return filepath.Join(homeDir, ".docker", "config.json")
+	}
+	return ""
+}
+
+func dockerHostForProxyLookup(
+	getEnv func(string) string,
+	cfg dockerConfigFile,
+	inspectContextHost func(string) (string, error),
+) string {
+	if dockerHost := getEnv(dockerHostEnv); dockerHost != "" {
+		return dockerHost
+	}
+
+	contextName := getEnv(dockerContextEnv)
+	if contextName == "" {
+		contextName = cfg.CurrentContext
+	}
+	if contextName == "" {
+		contextName = "default"
+	}
+
+	host, err := inspectContextHost(contextName)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(host)
+}
+
+func dockerProxySettings(proxies map[string]dockerProxyConfig, dockerHost string) (dockerProxyConfig, bool) {
+	if len(proxies) == 0 {
+		return dockerProxyConfig{}, false
+	}
+	// Docker's proxies config supports a "default" entry plus per-daemon entries
+	// keyed by the daemon host string, for example
+	// "https://manager1.mycorp.example.com:2377".
+	// See https://docs.docker.com/reference/cli/docker/
+	if dockerHost != "" {
+		if proxyCfg, ok := proxies[dockerHost]; ok {
+			return proxyCfg, true
+		}
+	}
+	proxyCfg, ok := proxies["default"]
+	return proxyCfg, ok
+}
+
+func setProxyEnv(envs map[string]string, name, value string) {
+	if value == "" {
+		return
+	}
+	envs[name] = value
+	envs[strings.ToLower(name)] = value
+}
+
+func kindProxyEnvOverridesDockerConfig(getEnv func(string) string) bool {
+	for _, name := range []string{common.HTTPProxy, common.HTTPSProxy} {
+		if getEnv(name) != "" || getEnv(strings.ToLower(name)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func inspectDockerContextHost(contextName string) (string, error) {
+	format := `{{ (index .Endpoints "docker").Host }}`
+	lines, err := exec.OutputLines(exec.Command("docker", "context", "inspect", "--format", format, contextName))
+	if err != nil || len(lines) == 0 {
+		return "", err
+	}
+	return lines[0], nil
+}

--- a/pkg/cluster/internal/providers/docker/proxyconfig_test.go
+++ b/pkg/cluster/internal/providers/docker/proxyconfig_test.go
@@ -1,0 +1,331 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"path/filepath"
+	"testing"
+
+	"sigs.k8s.io/kind/pkg/cluster/internal/providers/common"
+	"sigs.k8s.io/kind/pkg/internal/apis/config"
+	"sigs.k8s.io/kind/pkg/internal/assert"
+)
+
+func TestDockerConfigProxyEnvs(t *testing.T) {
+	t.Parallel()
+
+	const configJSON = `{
+		"proxies": {
+			"default": {
+				"httpProxy": "http://proxy.default:3128",
+				"httpsProxy": "https://proxy.default:3129",
+				"noProxy": "default.internal"
+			},
+			"tcp://remote.example.com:2376": {
+				"httpProxy": "http://proxy.remote:4128",
+				"httpsProxy": "https://proxy.remote:4129",
+				"noProxy": "remote.internal"
+			}
+		}
+	}`
+
+	cases := []struct {
+		name string
+		env  map[string]string
+		want map[string]string
+	}{
+		{
+			name: "uses default docker config",
+			env: map[string]string{
+				"DOCKER_CONFIG": "/tmp/docker-config",
+			},
+			want: map[string]string{
+				common.HTTPProxy:  "http://proxy.default:3128",
+				"http_proxy":      "http://proxy.default:3128",
+				common.HTTPSProxy: "https://proxy.default:3129",
+				"https_proxy":     "https://proxy.default:3129",
+				common.NOProxy:    "default.internal",
+				"no_proxy":        "default.internal",
+			},
+		},
+		{
+			name: "uses host specific docker config when DOCKER_HOST matches",
+			env: map[string]string{
+				"DOCKER_CONFIG": "/tmp/docker-config",
+				"DOCKER_HOST":   "tcp://remote.example.com:2376",
+			},
+			want: map[string]string{
+				common.HTTPProxy:  "http://proxy.remote:4128",
+				"http_proxy":      "http://proxy.remote:4128",
+				common.HTTPSProxy: "https://proxy.remote:4129",
+				"https_proxy":     "https://proxy.remote:4129",
+				common.NOProxy:    "remote.internal",
+				"no_proxy":        "remote.internal",
+			},
+		},
+		{
+			name: "uses host specific docker config when DOCKER_CONTEXT matches a remote host",
+			env: map[string]string{
+				"DOCKER_CONFIG":  "/tmp/docker-config",
+				"DOCKER_CONTEXT": "remote-context",
+			},
+			want: map[string]string{
+				common.HTTPProxy:  "http://proxy.remote:4128",
+				"http_proxy":      "http://proxy.remote:4128",
+				common.HTTPSProxy: "https://proxy.remote:4129",
+				"https_proxy":     "https://proxy.remote:4129",
+				common.NOProxy:    "remote.internal",
+				"no_proxy":        "remote.internal",
+			},
+		},
+		{
+			name: "uses host specific docker config when currentContext matches a remote host",
+			env: map[string]string{
+				"DOCKER_CONFIG": "/tmp/docker-config",
+			},
+			want: map[string]string{
+				common.HTTPProxy:  "http://proxy.remote:4128",
+				"http_proxy":      "http://proxy.remote:4128",
+				common.HTTPSProxy: "https://proxy.remote:4129",
+				"https_proxy":     "https://proxy.remote:4129",
+				common.NOProxy:    "remote.internal",
+				"no_proxy":        "remote.internal",
+			},
+		},
+		{
+			name: "falls back to HOME docker config path",
+			env: map[string]string{
+				"HOME": "/home/tester",
+			},
+			want: map[string]string{
+				common.HTTPProxy:  "http://proxy.default:3128",
+				"http_proxy":      "http://proxy.default:3128",
+				common.HTTPSProxy: "https://proxy.default:3129",
+				"https_proxy":     "https://proxy.default:3129",
+				common.NOProxy:    "default.internal",
+				"no_proxy":        "default.internal",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfgJSON := configJSON
+			if tc.name == "uses host specific docker config when currentContext matches a remote host" {
+				cfgJSON = `{
+		"currentContext": "remote-context",
+		"proxies": {
+			"default": {
+				"httpProxy": "http://proxy.default:3128",
+				"httpsProxy": "https://proxy.default:3129",
+				"noProxy": "default.internal"
+			},
+			"tcp://remote.example.com:2376": {
+				"httpProxy": "http://proxy.remote:4128",
+				"httpsProxy": "https://proxy.remote:4129",
+				"noProxy": "remote.internal"
+			}
+		}
+	}`
+			}
+
+			result := dockerConfigProxyEnvs(func(key string) string {
+				return tc.env[key]
+			}, func(name string) ([]byte, error) {
+				switch name {
+				case filepath.Join("/tmp/docker-config", "config.json"), filepath.Join("/home/tester", ".docker", "config.json"):
+					return []byte(cfgJSON), nil
+				default:
+					t.Fatalf("unexpected config path %q", name)
+					return nil, nil
+				}
+			}, func(contextName string) (string, error) {
+				switch contextName {
+				case "default":
+					return "unix:///var/run/docker.sock", nil
+				case "remote-context":
+					return "tcp://remote.example.com:2376", nil
+				default:
+					t.Fatalf("unexpected context %q", contextName)
+					return "", nil
+				}
+			})
+
+			assert.DeepEqual(t, tc.want, result)
+		})
+	}
+}
+
+func TestDockerConfigProxyEnvsIgnoresInvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	result := dockerConfigProxyEnvs(func(key string) string {
+		if key == "DOCKER_CONFIG" {
+			return "/tmp/docker-config"
+		}
+		return ""
+	}, func(name string) ([]byte, error) {
+		return []byte("{not-json"), nil
+	}, func(string) (string, error) {
+		t.Fatal("context inspection should not be called for invalid config")
+		return "", nil
+	})
+
+	assert.DeepEqual(t, map[string]string{}, result)
+}
+
+func TestKindProxyEnvOverridesDockerConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{
+			name: "http proxy set",
+			env: map[string]string{
+				common.HTTPProxy: "http://proxy.example.com:3128",
+			},
+			want: true,
+		},
+		{
+			name: "https proxy set in lower case",
+			env: map[string]string{
+				"https_proxy": "https://proxy.example.com:3129",
+			},
+			want: true,
+		},
+		{
+			name: "only no proxy set",
+			env: map[string]string{
+				common.NOProxy: "example.internal",
+			},
+			want: false,
+		},
+		{
+			name: "no proxy env set",
+			env:  map[string]string{},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := kindProxyEnvOverridesDockerConfig(func(key string) string {
+				return tc.env[key]
+			})
+			assert.BoolEqual(t, tc.want, result)
+		})
+	}
+}
+
+func TestMergeProxyEnvWithDockerConfig(t *testing.T) {
+	t.Parallel()
+
+	cluster := &config.Cluster{}
+	cluster.Networking.ServiceSubnet = "10.96.0.0/16"
+	cluster.Networking.PodSubnet = "10.244.0.0/16"
+
+	const configJSON = `{
+		"proxies": {
+			"default": {
+				"httpProxy": "http://proxy.default:3128",
+				"httpsProxy": "https://proxy.default:3129",
+				"noProxy": "default.internal"
+			}
+		}
+	}`
+
+	cases := []struct {
+		name string
+		env  map[string]string
+		want map[string]string
+	}{
+		{
+			name: "uses docker config when shell proxy env is unset",
+			env: map[string]string{
+				"DOCKER_CONFIG": "/tmp/docker-config",
+			},
+			want: map[string]string{
+				common.HTTPProxy:  "http://proxy.default:3128",
+				"http_proxy":      "http://proxy.default:3128",
+				common.HTTPSProxy: "https://proxy.default:3129",
+				"https_proxy":     "https://proxy.default:3129",
+				common.NOProxy:    "default.internal,10.96.0.0/16,10.244.0.0/16",
+				"no_proxy":        "default.internal,10.96.0.0/16,10.244.0.0/16",
+			},
+		},
+		{
+			name: "shell no proxy is preserved while docker fills http vars",
+			env: map[string]string{
+				"DOCKER_CONFIG": "/tmp/docker-config",
+				common.NOProxy:  "shell.internal",
+			},
+			want: map[string]string{
+				common.HTTPProxy:  "http://proxy.default:3128",
+				"http_proxy":      "http://proxy.default:3128",
+				common.HTTPSProxy: "https://proxy.default:3129",
+				"https_proxy":     "https://proxy.default:3129",
+				common.NOProxy:    "shell.internal,10.96.0.0/16,10.244.0.0/16",
+				"no_proxy":        "shell.internal,10.96.0.0/16,10.244.0.0/16",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			baseEnv := map[string]string{}
+			for _, name := range []string{common.HTTPProxy, common.HTTPSProxy, common.NOProxy, "http_proxy", "https_proxy", "no_proxy"} {
+				if value := tc.env[name]; value != "" {
+					baseEnv[name] = value
+				}
+			}
+			if len(baseEnv) > 0 {
+				noProxy := baseEnv[common.NOProxy]
+				if noProxy == "" {
+					noProxy = baseEnv["no_proxy"]
+				}
+				if noProxy != "" {
+					noProxy += ","
+				}
+				noProxy += cluster.Networking.ServiceSubnet + "," + cluster.Networking.PodSubnet
+				baseEnv[common.NOProxy] = noProxy
+				baseEnv["no_proxy"] = noProxy
+			}
+
+			result := mergeProxyEnvWithDockerConfig(cluster, baseEnv, dockerConfigProxyEnvs(func(key string) string {
+				return tc.env[key]
+			}, func(name string) ([]byte, error) {
+				if name != filepath.Join("/tmp/docker-config", "config.json") {
+					t.Fatalf("unexpected config path %q", name)
+				}
+				return []byte(configJSON), nil
+			}, func(string) (string, error) {
+				return "", nil
+			}))
+			assert.DeepEqual(t, tc.want, result)
+		})
+	}
+}


### PR DESCRIPTION
fixes #1175

kind was only looking at shell proxy envs. it missed Docker client proxy config from `~/.docker/config.json`, so docker node containers could miss the extra `NO_PROXY` entries kind adds for cluster traffic.

This keeps the old precedence rules too:
- if `HTTP_PROXY` or `HTTPS_PROXY` is set for kind, that still wins
- otherwise the docker provider reads client proxy config, using `DOCKER_HOST` specific entries first and `default` as fallback

How to repro:
1. write `~/.docker/config.json` with `{"proxies":{"default":{"httpProxy":"http://127.0.0.1:9999","httpsProxy":"http://127.0.0.1:9999","noProxy":"example.internal"}}}`
2. run `docker run --rm alpine:3.20 env | grep -i _proxy`
3. Docker injects those proxy vars for the container
4. run kind without `HTTP_PROXY` or `HTTPS_PROXY` in the shell
5. before this patch kind ignores that config path. after this patch it picks it up, and still appends kind `NO_PROXY` values for subnets, node names, and `.svc` names

Checks:
- `go test ./...`
- `go vet ./...`
