### PR TITLE
fix: preserve external load balancer CDS/LDS configuration across container restarts

### DIFF
--- a/pkg/cluster/internal/loadbalancer/config.go
+++ b/pkg/cluster/internal/loadbalancer/config.go
@@ -178,11 +178,11 @@ func GenerateBootstrapCommand(clusterName, containerName string) []string {
 	// 		envoyConfig, constants.ProxyConfigPath, constants.ProxyConfigPathCDS, constants.ProxyConfigPathLDS, constants.ProxyConfigPath)}
 	// Create dynamic Envoy config files with valid empty resources
 	emptyConfig := "resources: []"
-  return []string{"bash", "-c",
-    fmt.Sprintf(`mkdir -p %s && echo -en '%s' > %s && { [ ! -f %s ] && echo -en '%s' > %s || true; } && { [ ! -f %s ] && echo -en '%s' > %s || true; } && while true; do envoy -c %s && break; sleep 1; done`,
-      ProxyConfigDir,
-      envoyConfig, ProxyConfigPath,
-      ProxyConfigPathCDS, emptyConfig, ProxyConfigPathCDS, // Initialize CDS only if not exists
-      ProxyConfigPathLDS, emptyConfig, ProxyConfigPathLDS, // Initialize LDS only if not exists
-      ProxyConfigPath)}
+	return []string{"bash", "-c",
+		fmt.Sprintf(`mkdir -p %s && echo -en '%s' > %s && { [ ! -f %s ] && echo -en '%s' > %s || true; } && { [ ! -f %s ] && echo -en '%s' > %s || true; } && while true; do envoy -c %s && break; sleep 1; done`,
+			ProxyConfigDir,
+			envoyConfig, ProxyConfigPath,
+			ProxyConfigPathCDS, emptyConfig, ProxyConfigPathCDS, // Initialize CDS only if not exists
+			ProxyConfigPathLDS, emptyConfig, ProxyConfigPathLDS, // Initialize LDS only if not exists
+			ProxyConfigPath)}
 }

--- a/pkg/cluster/internal/loadbalancer/config.go
+++ b/pkg/cluster/internal/loadbalancer/config.go
@@ -178,11 +178,11 @@ func GenerateBootstrapCommand(clusterName, containerName string) []string {
 	// 		envoyConfig, constants.ProxyConfigPath, constants.ProxyConfigPathCDS, constants.ProxyConfigPathLDS, constants.ProxyConfigPath)}
 	// Create dynamic Envoy config files with valid empty resources
 	emptyConfig := "resources: []"
-	return []string{"bash", "-c",
-		fmt.Sprintf(`mkdir -p %s && echo -en '%s' > %s && echo -en '%s' > %s && echo -en '%s' > %s && while true; do envoy -c %s && break; sleep 1; done`,
-			ProxyConfigDir,
-			envoyConfig, ProxyConfigPath,
-			emptyConfig, ProxyConfigPathCDS, // Initialize CDS
-			emptyConfig, ProxyConfigPathLDS, // Initialize LDS
-			ProxyConfigPath)}
+  return []string{"bash", "-c",
+    fmt.Sprintf(`mkdir -p %s && echo -en '%s' > %s && { [ ! -f %s ] && echo -en '%s' > %s || true; } && { [ ! -f %s ] && echo -en '%s' > %s || true; } && while true; do envoy -c %s && break; sleep 1; done`,
+      ProxyConfigDir,
+      envoyConfig, ProxyConfigPath,
+      ProxyConfigPathCDS, emptyConfig, ProxyConfigPathCDS, // Initialize CDS only if not exists
+      ProxyConfigPathLDS, emptyConfig, ProxyConfigPathLDS, // Initialize LDS only if not exists
+      ProxyConfigPath)}
 }


### PR DESCRIPTION
**Problem**
When the external load balancer container is restarted, the kube-apiserver becomes unreachable.

This happens because the envoy proxy starts with an empty configuration (resources: []) instead of the previously configured one, leaving it with no knowledge of the control plane endpoints.

**What this PR does**
When the envoy proxy container starts, `cds.yaml` and `lds.yaml` are unconditionally overwritten with `resources: []`, even if they already exist with valid configuration (created in [loadbalancer action](https://github.com/kubernetes-sigs/kind/blob/v0.32.0/pkg/cluster/internal/create/actions/loadbalancer/loadbalancer.go#L43)).

This causes any previously written CDS/LDS state to be lost on container restart.

This PR changes the initialization logic to only write the default `resources: []` content when the files do not already exist.

**Root cause**
In [pkg/cluster/internal/loadbalancer/config.go](https://github.com/kubernetes-sigs/kind/blob/v0.32.0/pkg/cluster/internal/loadbalancer/config.go#L182) (the function returning the container entrypoint command), the shell command used > redirects unconditionally:

```bash
echo -en 'resources: []' > /home/envoy/lds.yaml
echo -en 'resources: []' > /home/envoy/cds.yaml
```

**Fix**
Replaced with conditional writes using [ ! -f ... ] guards:
```bash
[ ! -f %s ] && echo -en '%s' > %s || true;
```

**Testing**
- Start a cluster with multiple control plane nodes
- Restart the external load balancer container
- Verify kube-api-server is served correctly