### PR TITLE
Clean up some old commented-out code

### DIFF
--- a/pkg/cluster/internal/loadbalancer/config.go
+++ b/pkg/cluster/internal/loadbalancer/config.go
@@ -171,11 +171,6 @@ func GenerateBootstrapCommand(clusterName, containerName string) []string {
 		ProxyConfigPathLDS,
 	)
 
-	// Create dynamic Envoy config files and start Envoy with retry,
-	// since it has an initialization phase before forwarding traffic.
-	// cmd := []string{"bash", "-c",
-	// 	fmt.Sprintf(`mkdir -p %s && echo -en '%s' > %s && touch %s && touch %s && while true; do envoy -c %s && break; sleep 1; done`, constants.ProxyConfigDir,
-	// 		envoyConfig, constants.ProxyConfigPath, constants.ProxyConfigPathCDS, constants.ProxyConfigPathLDS, constants.ProxyConfigPath)}
 	// Create dynamic Envoy config files with valid empty resources
 	emptyConfig := "resources: []"
 	return []string{"bash", "-c",


### PR DESCRIPTION
While reviewing other changes in the loadbalancer config file (#4195), noticed we had some old commented-out code that is no longer needed. This is a minor update to clean that up.