### PR TITLE
fix: default empty PortMapping protocol to TCP in SetDefaultsNode

### DIFF
--- a/pkg/internal/apis/config/default.go
+++ b/pkg/internal/apis/config/default.go
@@ -101,4 +101,10 @@ func SetDefaultsNode(obj *Node) {
 	if obj.Role == "" {
 		obj.Role = ControlPlaneRole
 	}
+
+	for i := range obj.ExtraPortMappings {
+		if obj.ExtraPortMappings[i].Protocol == "" {
+			obj.ExtraPortMappings[i].Protocol = PortMappingProtocolTCP
+		}
+	}
 }

--- a/pkg/internal/apis/config/validate_test.go
+++ b/pkg/internal/apis/config/validate_test.go
@@ -401,6 +401,26 @@ func TestNodeValidate(t *testing.T) {
 			}(),
 			ExpectErrors: 0,
 		},
+		{
+			TestName: "Duplicate host port with empty and explicit TCP protocol",
+			Node: func() Node {
+				cfg := newDefaultedNode(ControlPlaneRole)
+				cfg.ExtraPortMappings = []PortMapping{
+					{
+						ContainerPort: 80,
+						HostPort:      8080,
+					},
+					{
+						ContainerPort: 81,
+						HostPort:      8080,
+						Protocol:      PortMappingProtocolTCP,
+					},
+				}
+				SetDefaultsNode(&cfg)
+				return cfg
+			}(),
+			ExpectErrors: 1,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
When `extraPortMappings` omits `protocol` on one entry but another entry on the same `hostPort` sets it to `TCP` explicitly, `validatePortMappings` builds different map keys (`"8080/"` vs `"8080/TCP"`) and silently passes the duplicate through. At provision time all three providers (docker, podman, nerdctl) default empty protocol to TCP, so both mappings compete for the same host port and container creation fails with a bind error.

The fix defaults empty Protocol to PortMappingProtocolTCP in SetDefaultsNode, which runs before Validate(). This is the same pattern used for Image and Role in the same function, and matches what all three providers already do at provision time.