### PR TITLE
Handle podman 6.0.0 label change

### DIFF
--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -101,13 +101,30 @@ func (p *provider) Provision(status *cli.Status, cfg *config.Cluster) (err error
 
 // ListClusters is part of the providers.Provider interface
 func (p *provider) ListClusters() ([]string, error) {
+	// Select the format specifier for extracting the cluster label.
+	// podman 6.0.0 changed `.Labels` from a map to a slice, breaking the
+	// `index .Labels "key"` form; the `.Label "key"` specifier works on
+	// podman 5.0.0+ and across that change, but does not exist on older
+	// versions. See https://github.com/kubernetes-sigs/kind/issues/4201
+	v, err := getPodmanVersion()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check podman version")
+	}
+
+	var format string
+	if v.AtLeast(version.MustParseSemantic(labelFormatVersion)) {
+		format = fmt.Sprintf(`{{.Label "%s"}}`, clusterLabelKey)
+	} else {
+		format = fmt.Sprintf(`{{index .Labels "%s"}}`, clusterLabelKey)
+	}
+
 	cmd := exec.Command("podman",
 		"ps",
 		"-a", // show stopped nodes
 		// filter for nodes with the cluster label
 		"--filter", "label="+clusterLabelKey,
 		// format to include the cluster name
-		"--format", fmt.Sprintf(`{{index .Labels "%s"}}`, clusterLabelKey),
+		"--format", format,
 	)
 	lines, err := exec.OutputLines(cmd)
 	if err != nil {
@@ -201,7 +218,7 @@ func (p *provider) GetAPIServerEndpoint(cluster string) (string, error) {
 	// https://github.com/containers/podman/issues/8444
 	if v.AtLeast(version.MustParseSemantic("2.2.0")) &&
 		v.LessThan(version.MustParseSemantic("3.0.0")) {
-		p.logger.Warnf("WARNING: podman version %s not fully supported, please use versions 3.0.0+")
+		p.logger.Warnf("WARNING: podman version %s not fully supported, please use versions 3.0.0+", v)
 
 		cmd := exec.Command(
 			"podman", "inspect",

--- a/pkg/cluster/internal/providers/podman/util.go
+++ b/pkg/cluster/internal/providers/podman/util.go
@@ -57,6 +57,13 @@ func getPodmanVersion() (*version.Version, error) {
 
 const (
 	minSupportedVersion = "1.8.0"
+
+	// labelFormatVersion is the first podman version that supports the `.Label`
+	// format specifier for `podman ps --format`. From podman 6.0.0 onward the
+	// `.Labels` field is a slice rather than a map, which breaks the previous
+	// `index .Labels` form, so `.Label` must be used on newer podman.
+	// See https://github.com/kubernetes-sigs/kind/issues/4201
+	labelFormatVersion = "5.0.0"
 )
 
 func ensureMinVersion() error {


### PR DESCRIPTION
Podman 6.0.0 changed label format from a map to a slice. This is similar to the change we needed to handle for nerdctl in #3814. This adds version detection and handling to use Label correctly when running with older versions.

Closes: #4201 