### PR TITLE
fix: improve rootless cgroup controller error message

### DIFF
--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -20,6 +20,7 @@ package create
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"al.essio.dev/pkg/shellescape"
@@ -251,7 +252,24 @@ func validateProvider(logger log.Logger, p providers.Provider) error {
 			return errors.New("running kind with rootless provider requires cgroup v2, see https://kind.sigs.k8s.io/docs/user/rootless/")
 		}
 		if !info.SupportsMemoryLimit || !info.SupportsPidsLimit || !info.SupportsCPUShares {
-			return errors.New("running kind with rootless provider requires setting systemd property \"Delegate=yes\", see https://kind.sigs.k8s.io/docs/user/rootless/")
+			var missing []string
+			if !info.SupportsMemoryLimit {
+				missing = append(missing, "memory")
+			}
+			if !info.SupportsPidsLimit {
+				missing = append(missing, "pids")
+			}
+			if !info.SupportsCPUShares {
+				missing = append(missing, "cpu")
+			}
+			return errors.Errorf(
+				"running kind with rootless provider requires cgroup controllers [%s], "+
+					"but they are not available. Possible causes: the systemd property "+
+					"\"Delegate=yes\" is not set (see https://kind.sigs.k8s.io/docs/user/rootless/), "+
+					"or the host environment is restricting available controllers "+
+					"(e.g. container runtime, LXC, or resource limits)",
+				strings.Join(missing, ", "),
+			)
 		}
 	} else if !info.Cgroup2 {
 		logger.Warn("cgroup v1 is deprecated in Kubernetes and will not be supported in a future kind release, please upgrade to cgroup v2")

--- a/site/content/docs/user/known-issues.md
+++ b/site/content/docs/user/known-issues.md
@@ -41,6 +41,7 @@ description: |-
 * [Docker Desktop for macOS and Windows](#docker-desktop-for-macos-and-windows)
 * [Older Linux Distributions](#older-linux-distributions)
 * [Failure to Create Cluster on WSL2](#failure-to-create-cluster-on-wsl2)
+* [LXC and Containerized Environments](#lxc-and-containerized-environments) (cgroup controllers may be unavailable)
 * [Local Subnet Clashes](#local-subnet-clashes)
 
 ## Troubleshooting Kind
@@ -417,6 +418,33 @@ the project relies on community support and feedback. It has been noted that the
 steps detailed in [https://github.com/spurin/wsl-cgroupsv2](https://github.com/spurin/wsl-cgroupsv2)
 have been necessary to resolve this issue.
 
+## LXC and Containerized Environments
+
+When running KIND inside an LXC container or other nested container environment,
+you may see an error like:
+
+```txt
+running kind with rootless provider requires cgroup controllers [memory, pids, cpu], but they are not available.
+```
+
+This can occur even when `Delegate=yes` is correctly configured in systemd. The
+underlying cause is that the outer host may not be making cgroup v2 controllers
+available inside the nested container. You can verify this by checking:
+
+{{< codeFromInline lang="bash" >}}
+cat /sys/fs/cgroup/cgroup.controllers
+{{< /codeFromInline >}}
+
+If the output is empty or missing expected controllers (memory, pids, cpu), the
+problem is at the host level and cannot be resolved from inside the container.
+
+This is a known limitation when the LXC host kernel uses cgroup v1 or does not
+delegate cgroup v2 controllers into the guest. Consult your host platform's
+documentation for enabling cgroup v2 controller delegation into nested
+containers.
+
+See Previous Discussion: [kind#3868]
+
 ## Local Subnet Clashes
 
 KIND creates a separate docker network named `kind` that will be configured with default IPAM settings. If you are using the default IPAM configuration in your `daemon.json` you
@@ -443,6 +471,7 @@ For more information on the Docker Engine config file check out [these docs](htt
 [kind#1326]: https://github.com/kubernetes-sigs/kind/issues/1326
 [kind#2296]: https://github.com/kubernetes-sigs/kind/issues/2296
 [kind#2411]: https://github.com/kubernetes-sigs/kind/issues/2411
+[kind#3868]: https://github.com/kubernetes-sigs/kind/issues/3868
 [moby#17666]: https://github.com/moby/moby/issues/17666
 [Docker resource lims]: https://docs.docker.com/docker-for-mac/#advanced
 [snap]: https://snapcraft.io/

--- a/site/content/docs/user/rootless.md
+++ b/site/content/docs/user/rootless.md
@@ -250,7 +250,7 @@ or
 $ systemd-run --scope --user -p "Delegate=yes" kind create cluster
 ```
 
-If you still get the error `running kind with rootless provider requires setting systemd property "Delegate=yes"` even with [host requirements](#host-requirements) configured.
+If you still get an error about missing cgroup controllers (for example, `running kind with rootless provider requires cgroup controllers [memory, pids, cpu], but they are not available.`) even with [host requirements](#host-requirements) configured, see [LXC and Containerized Environments](/docs/user/known-issues/#lxc-and-containerized-environments).
 
 ### Podman Log Driver
 


### PR DESCRIPTION
When running kind with a rootless provider inside LXC or other containerized environments, cgroup controllers may be unavailable even when "Delegate=yes" is correctly configured. The previous error message only mentioned Delegate=yes as the cause, which is misleading in these environments.

This change:

- Reports which specific controllers (memory, pids, cpu) are missing
- Lists multiple possible causes instead of asserting a single one
- Adds a known-issues documentation entry for LXC/nested environments
- Updates rootless.md to reference the new error shape

Example of the new error output:

`running kind with rootless provider requires cgroup controllers [memory, pids, cpu], but they are not available. Possible causes: the systemd property "Delegate=yes" is not set (see https://kind.sigs.k8s.io/docs/user/rootless/), or the host environment is restricting available controllers (e.g. container runtime, LXC, or resource limits)`

Related: https://github.com/kubernetes-sigs/kind/issues/3868