### PR TITLE
Enable ControlPlaneKubeletLocalMode for kubeadm 1.31 and 1.32

### DIFF
--- a/pkg/cluster/internal/kubeadm/config.go
+++ b/pkg/cluster/internal/kubeadm/config.go
@@ -697,6 +697,19 @@ func Config(data ConfigData) (config string, err error) {
 		data.KubeadmFeatureGates["IPv6DualStack"] = true
 	}
 
+	// Have control plane kubelets talk to their local apiserver instead of
+	// the load balancer, so upgrades don't violate the kubelet/apiserver
+	// version skew policy. The kubeadm gate is alpha and off by default in
+	// 1.31/1.32, on by default since 1.33, and removed in 1.36.
+	// TODO: remove this when we no longer support Kubernetes 1.32.
+	if ver.AtLeast(version.MustParseSemantic("v1.31.0")) &&
+		ver.LessThan(version.MustParseSemantic("v1.33.0")) {
+		if data.KubeadmFeatureGates == nil {
+			data.KubeadmFeatureGates = make(map[string]bool)
+		}
+		data.KubeadmFeatureGates["ControlPlaneKubeletLocalMode"] = true
+	}
+
 	// before 1.24 kind uses cgroupfs
 	// after 1.24 kind uses systemd starting in kind v0.13.0
 	// before kind v0.13.0 kubernetes 1.24 wasn't released yet

--- a/pkg/cluster/internal/kubeadm/config_test.go
+++ b/pkg/cluster/internal/kubeadm/config_test.go
@@ -64,3 +64,58 @@ func TestConfigVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigControlPlaneKubeletLocalMode(t *testing.T) {
+	cases := []struct {
+		name              string
+		kubernetesVersion string
+		expectGate        bool
+	}{
+		{
+			// The gate doesn't exist yet.
+			name:              "v1.30.0 - no gate",
+			kubernetesVersion: "v1.30.0",
+			expectGate:        false,
+		},
+		{
+			// Alpha, disabled by default: kind must enable it so
+			// control plane kubelets use the local apiserver.
+			name:              "v1.31.0 - gate enabled",
+			kubernetesVersion: "v1.31.0",
+			expectGate:        true,
+		},
+		{
+			name:              "v1.32.0 - gate enabled",
+			kubernetesVersion: "v1.32.0",
+			expectGate:        true,
+		},
+		{
+			// Beta and enabled by default since v1.33.
+			name:              "v1.33.0 - no gate",
+			kubernetesVersion: "v1.33.0",
+			expectGate:        false,
+		},
+		{
+			// The gate was removed in v1.36; setting it would be an error.
+			name:              "v1.36.0 - no gate",
+			kubernetesVersion: "v1.36.0",
+			expectGate:        false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := ConfigData{
+				KubernetesVersion: tc.kubernetesVersion,
+			}
+			cfg, err := Config(data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			hasGate := strings.Contains(cfg, "\"ControlPlaneKubeletLocalMode\": true")
+			if hasGate != tc.expectGate {
+				t.Errorf("expected ControlPlaneKubeletLocalMode gate presence to be %v, but got:\n%s", tc.expectGate, cfg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In HA clusters every kubelet, including the control plane nodes', is pointed at the external load balancer. During an upgrade a control plane node's kubelet can then talk to an older apiserver on another node. this fix is the`ControlPlaneKubeletLocalMode` feature gate, which pins control plane kubelets to their local apiserver, but it's alpha and off by default in 1.31/1.32 (on by default since 1.33, removed in 1.36) and kind never enabled it.

Enable the gate for kubeadm 1.31 and 1.32 only.

Fixes #3932