### PR TITLE
fix local-path-provisioner helperPod toleration in const_storage.go

### DIFF
--- a/pkg/build/nodeimage/const_storage.go
+++ b/pkg/build/nodeimage/const_storage.go
@@ -204,9 +204,10 @@ data:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-        - key: node.kubernetes.io/disk-pressure
-          operator: Exists
+        - operator: Exists
           effect: NoSchedule
+        - operator: Exists
+          effect: NoExecute
       containers:
       - name: helper-pod
         image: ` + storageHelperImage + `


### PR DESCRIPTION
This change by local-storage-provisioner is quite breaking: https://github.com/rancher/local-path-provisioner/issues/487
For example, this makes it impossible to create kind clusters with multiple worker groups which have taints, where we would want to have PVCs (like a logging worker group where only opensearch should run).

IMHO I agree that it makes sense to configure this on consumer side (kind) instead of having this hardcoded in local-path-provisioner, hence this PR.

This will fix: https://github.com/kubernetes-sigs/kind/issues/4100