### PR TITLE
docs: Add install options for Arch Linux

### DIFF
--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -131,6 +131,11 @@ On Windows via Winget (https://github.com/microsoft/winget-pkgs/tree/master/mani
 winget install Kubernetes.kind
 {{< /codeFromInline >}}
 
+On Arch Linux via pacman (https://archlinux.org/packages/extra/x86_64/kind/)
+{{< codeFromInline lang="bash" >}}
+sudo pacman -Syu kind
+{{< /codeFromInline >}}
+
 ## Discovering Additional Command Options
 
 kind provides built-in help for all commands and subcommands.  


### PR DESCRIPTION
The package has now been imported into the official Arch Linux Package
Repositories so it can easily be installed via `pacman` now.
