### PR TITLE
Add windows/arm64 to release binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,12 @@ mv ./kind /some-dir-in-your-PATH/kind
 On Windows:
 
 ```powershell
+# For AMD64 / x86_64
 curl.exe -Lo kind-windows-amd64.exe https://kind.sigs.k8s.io/dl/v0.32.0/kind-windows-amd64
 Move-Item .\kind-windows-amd64.exe c:\some-dir-in-your-PATH\kind.exe
+# For ARM64
+curl.exe -Lo kind-windows-arm64.exe https://kind.sigs.k8s.io/dl/v0.32.0/kind-windows-arm64
+Move-Item .\kind-windows-arm64.exe c:\some-dir-in-your-PATH\kind.exe
 
 # OR via Chocolatey (https://chocolatey.org/packages/kind)
 choco install kind

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -111,7 +111,7 @@ The script will:
 3. Build cross-platform release binaries into `bin/`:
    - `kind-linux-amd64`, `kind-linux-arm64`
    - `kind-darwin-amd64`, `kind-darwin-arm64`
-   - `kind-windows-amd64`
+   - `kind-windows-amd64`, `kind-windows-arm64`
    - `.sha256sum` file for each binary
 4. Set `versionCore = "0.32.0"` and `versionPreRelease = "alpha"`
 5. Commit with message `version v0.32.0-alpha` and tag `v0.32.0-alpha`
@@ -162,6 +162,7 @@ Go to https://github.com/kubernetes-sigs/kind/releases/new and:
    - `kind-darwin-amd64` + `kind-darwin-amd64.sha256sum`
    - `kind-darwin-arm64` + `kind-darwin-arm64.sha256sum`
    - `kind-windows-amd64` + `kind-windows-amd64.sha256sum`
+   - `kind-windows-arm64` + `kind-windows-arm64.sha256sum`
 5. Publish the release.
 
 ---

--- a/hack/release/build/cross.sh
+++ b/hack/release/build/cross.sh
@@ -41,6 +41,7 @@ else
     exit 1
 fi < <(cat <<EOF | tr '\n' '\0'
 export GOOS=windows GOARCH=amd64
+export GOOS=windows GOARCH=arm64
 export GOOS=darwin GOARCH=amd64
 export GOOS=darwin GOARCH=arm64
 export GOOS=linux GOARCH=amd64

--- a/site/content/docs/user/quick-start.md
+++ b/site/content/docs/user/quick-start.md
@@ -59,8 +59,12 @@ mv ./kind /some-dir-in-your-PATH/kind
 On Windows in [PowerShell](https://en.wikipedia.org/wiki/PowerShell):
 
 {{< codeFromInline lang="powershell" >}}
+# For AMD64 / x86_64
 curl.exe -Lo kind-windows-amd64.exe https://kind.sigs.k8s.io/dl/{{< stableVersion >}}/kind-windows-amd64
 Move-Item .\kind-windows-amd64.exe c:\some-dir-in-your-PATH\kind.exe
+# For ARM64
+curl.exe -Lo kind-windows-arm64.exe https://kind.sigs.k8s.io/dl/{{< stableVersion >}}/kind-windows-arm64
+Move-Item .\kind-windows-arm64.exe c:\some-dir-in-your-PATH\kind.exe
 {{< /codeFromInline >}}
 
 ### Installing From Source


### PR DESCRIPTION
`go install sigs.k8s.io/kind@latest` already works on Windows ARM64 (confirmed in #3999), so this adds `kind-windows-arm64` to the cross-compiled release binaries alongside the existing amd64 build, and updates the install docs (README, quick-start guide, RELEASE.md) accordingly.

Fixes #3999
