### PR TITLE
Build node images in CI if changed

### DIFF
--- a/.github/actions/build-node-image/action.yaml
+++ b/.github/actions/build-node-image/action.yaml
@@ -1,0 +1,21 @@
+name: "Build node image"
+description: "Builds a kind node image from official Kubernetes release artifacts and uploads it as an artifact. Requires kind and docker on the runner (run setup-env first)."
+runs:
+  using: "composite"
+  steps:
+    - name: Build node image from release artifacts
+      shell: bash
+      run: |
+        # Build for the same Kubernetes version the default published image targets,
+        # so this exercises the current source's node-image contents (kindnet manifest,
+        # etc.) rather than the baked-in published image. --type release downloads the
+        # official server tarball from dl.k8s.io; no Kubernetes compile.
+        ver="$(grep -oE 'kindest/node:v[0-9.]+' pkg/apis/config/defaults/image.go | head -1 | cut -d: -f2)"
+        kind build node-image --type release "$ver" --image kindest/node:pr
+        docker save kindest/node:pr -o "${RUNNER_TEMP}/node.tar"
+
+    - name: Upload node image
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: node-image
+        path: ${{ runner.temp }}/node.tar

--- a/.github/actions/load-node-image/action.yaml
+++ b/.github/actions/load-node-image/action.yaml
@@ -1,0 +1,26 @@
+name: "Load node image"
+description: "Downloads the node image artifact and loads it into the given container runtime's image store, then exports IMAGE_FLAG for kind create cluster."
+inputs:
+  provider:
+    description: "Container runtime to load the image into (docker, podman, or nerdctl)."
+    default: "docker"
+  sudo:
+    description: "Run the load command with sudo (podman/nerdctl workflows run kind under sudo)."
+    default: "false"
+runs:
+  using: "composite"
+  steps:
+    - name: Download node image
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      with:
+        name: node-image
+        path: ${{ runner.temp }}
+
+    - name: Load node image
+      shell: bash
+      run: |
+        sudo=""
+        [ "${{ inputs.sudo }}" = "true" ] && sudo="sudo"
+        $sudo ${{ inputs.provider }} load -i "${RUNNER_TEMP}/node.tar"
+        # kind create cluster reads --image from IMAGE_FLAG; empty when the build was skipped.
+        echo "IMAGE_FLAG=--image=kindest/node:pr" >> "$GITHUB_ENV"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,8 +12,39 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect build changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            build:
+              - 'pkg/build/**'
+              - 'images/**'
+
+  build-node-image:
+    name: Build node image
+    needs: changes
+    if: needs.changes.outputs.build == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/build-node-image
+
   docker:
     name: Docker
+    needs: [changes, build-node-image]
+    if: ${{ always() && needs.build-node-image.result != 'failure' && needs.build-node-image.result != 'cancelled' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
@@ -30,10 +61,15 @@ jobs:
 
       - uses: ./.github/actions/setup-env
 
+      - uses: ./.github/actions/load-node-image
+        if: needs.changes.outputs.build == 'true'
+        with:
+          provider: docker
+
       - name: Create single node cluster
         if: ${{ matrix.deployment == 'singleNode' }}
         run: |
-          cat <<EOF | /usr/local/bin/kind create cluster -v7 --wait 1m --retain --config=-
+          cat <<EOF | /usr/local/bin/kind create cluster -v7 --wait 1m --retain ${IMAGE_FLAG} --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           networking:
@@ -43,7 +79,7 @@ jobs:
       - name: Create multi node cluster
         if: ${{ matrix.deployment == 'multiNode' }}
         run: |
-          cat <<EOF | /usr/local/bin/kind create cluster -v7 --wait 1m --retain --config=-
+          cat <<EOF | /usr/local/bin/kind create cluster -v7 --wait 1m --retain ${IMAGE_FLAG} --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           networking:
@@ -57,7 +93,7 @@ jobs:
       - name: Create multi master cluster
         if: ${{ matrix.deployment == 'multiMaster' }}
         run: |
-          cat <<EOF | /usr/local/bin/kind create cluster -v7 --wait 1m --retain --config=-
+          cat <<EOF | /usr/local/bin/kind create cluster -v7 --wait 1m --retain ${IMAGE_FLAG} --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           networking:

--- a/.github/workflows/nerdctl.yaml
+++ b/.github/workflows/nerdctl.yaml
@@ -12,8 +12,39 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect build changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            build:
+              - 'pkg/build/**'
+              - 'images/**'
+
+  build-node-image:
+    name: Build node image
+    needs: changes
+    if: needs.changes.outputs.build == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/build-node-image
+
   nerdctl:
     name: Nerdctl
+    needs: [changes, build-node-image]
+    if: ${{ always() && needs.build-node-image.result != 'failure' && needs.build-node-image.result != 'cancelled' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
@@ -49,10 +80,16 @@ jobs:
           sudo ctr version
           sudo nerdctl version
 
+      - uses: ./.github/actions/load-node-image
+        if: needs.changes.outputs.build == 'true'
+        with:
+          provider: nerdctl
+          sudo: "true"
+
       - name: Create single node cluster
         if: ${{ matrix.deployment == 'singleNode' }}
         run: |
-          cat <<EOF | sudo /usr/local/bin/kind create cluster -v7 --wait 1m --retain --config=-
+          cat <<EOF | sudo /usr/local/bin/kind create cluster -v7 --wait 1m --retain ${IMAGE_FLAG} --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           networking:
@@ -62,7 +99,7 @@ jobs:
       - name: Create multi node cluster
         if: ${{ matrix.deployment == 'multiNode' }}
         run: |
-          cat <<EOF | sudo /usr/local/bin/kind create cluster -v7 --wait 1m --retain --config=-
+          cat <<EOF | sudo /usr/local/bin/kind create cluster -v7 --wait 1m --retain ${IMAGE_FLAG} --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           networking:

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -12,8 +12,39 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect build changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            build:
+              - 'pkg/build/**'
+              - 'images/**'
+
+  build-node-image:
+    name: Build node image
+    needs: changes
+    if: needs.changes.outputs.build == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/build-node-image
+
   podman:
     name: Podman
+    needs: [changes, build-node-image]
+    if: ${{ always() && needs.build-node-image.result != 'failure' && needs.build-node-image.result != 'cancelled' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
@@ -47,10 +78,16 @@ jobs:
           chmod +x ./crun
           sudo mv ./crun /usr/bin/crun
 
+      - uses: ./.github/actions/load-node-image
+        if: needs.changes.outputs.build == 'true'
+        with:
+          provider: podman
+          sudo: "true"
+
       - name: Create single node cluster
         if: ${{ matrix.deployment == 'singleNode' }}
         run: |
-          cat <<EOF | sudo KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster -v7 --wait 1m --retain --config=-
+          cat <<EOF | sudo KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster -v7 --wait 1m --retain ${IMAGE_FLAG} --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           networking:
@@ -69,7 +106,7 @@ jobs:
       - name: Create multi node cluster
         if: ${{ matrix.deployment == 'multiNode' }}
         run: |
-          cat <<EOF | sudo KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster -v7 --wait 1m --retain --config=-
+          cat <<EOF | sudo KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster -v7 --wait 1m --retain ${IMAGE_FLAG} --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           networking:

--- a/.github/workflows/vm.yaml
+++ b/.github/workflows/vm.yaml
@@ -12,8 +12,39 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect build changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            build:
+              - 'pkg/build/**'
+              - 'images/**'
+
+  build-node-image:
+    name: Build node image
+    needs: changes
+    if: needs.changes.outputs.build == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/build-node-image
+
   vm:
     name: "VM"
+    needs: [changes, build-node-image]
+    if: ${{ always() && needs.build-node-image.result != 'failure' && needs.build-node-image.result != 'cancelled' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
@@ -98,9 +129,24 @@ jobs:
           "$HELPER" "$KIND_EXPERIMENTAL_PROVIDER" info
           "$HELPER" "$KIND_EXPERIMENTAL_PROVIDER" version
 
+      # The composite load-node-image action can't be used here: the provider runs
+      # inside the Lima guest, so copy the tar in and load it with the guest's runtime.
+      - name: Download node image
+        if: needs.changes.outputs.build == 'true'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: node-image
+          path: .
+      - name: Load node image into the VM
+        if: needs.changes.outputs.build == 'true'
+        run: |
+          limactl cp node.tar default:/tmp/kind/node.tar
+          "$HELPER" "$KIND_EXPERIMENTAL_PROVIDER" load -i /tmp/kind/node.tar
+          echo "IMAGE_FLAG=--image=kindest/node:pr" >> "$GITHUB_ENV"
+
       - name: Create a cluster
         run: |
-          "$HELPER" kind create cluster -v7 --wait 10m --retain
+          "$HELPER" kind create cluster -v7 --wait 10m --retain ${IMAGE_FLAG}
 
       - name: Get Cluster status
         run: |


### PR DESCRIPTION
This updates our provider testing to build the node images if it looks like source files have changed. This allows us to validate node image changes as part of normal CI workflows.

If there are changes in `pkg/build` or `images` we will build a node image using official binaries. That image will then be loaded and used for spinning up the test cluster used as part of the CI, for each provider being tested. If nothing has changed that looks like it will impact the node image, then it just pulls and uses the default - the way things have been operating so far.