### PR TITLE
podman: warn when rootless storage is backed by ZFS

### DIFF
--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -389,6 +389,32 @@ type podmanInfo struct {
 			Rootless bool `json:"rootless,omitempty"`
 		} `json:"security"`
 	} `json:"host"`
+	Store struct {
+		GraphDriverName string `json:"graphDriverName,omitempty"`
+		GraphStatus     struct {
+			BackingFilesystem string `json:"Backing Filesystem,omitempty"`
+		} `json:"graphStatus"`
+	} `json:"store"`
+}
+
+// zfsACLWarning returns a non-empty warning message if rootless is true and
+// the storage driver or backing filesystem is ZFS, since ZFS does not enable
+// POSIX ACLs by default and rootless podman's fuse-overlayfs snapshotter
+// requires them, which can cause node containers to fail with
+// "stat /pause: operation not supported".
+// See https://github.com/kubernetes-sigs/kind/issues/4025
+func zfsACLWarning(rootless bool, graphDriverName, backingFilesystem string) string {
+	if !rootless {
+		return ""
+	}
+	if graphDriverName != "zfs" && backingFilesystem != "zfs" {
+		return ""
+	}
+	return "Podman storage is backed by ZFS, which does not enable POSIX ACLs by default. " +
+		"With rootless Podman this can cause node containers to fail with " +
+		"\"stat /pause: operation not supported\". If cluster creation fails, try enabling ACLs " +
+		"on the backing ZFS dataset (zfs set acltype=posix <dataset>) and re-pulling the node image. " +
+		"See https://github.com/kubernetes-sigs/kind/issues/4025"
 }
 
 // info detects ProviderInfo by executing `podman info --format json`.
@@ -445,6 +471,11 @@ func info(logger log.Logger) (*providers.ProviderInfo, error) {
 		if logger != nil {
 			logger.Warn("Cgroup controller detection is not implemented for Podman. " +
 				"If you see cgroup-related errors, you might need to set systemd property \"Delegate=yes\", see https://kind.sigs.k8s.io/docs/user/rootless/")
+		}
+	}
+	if logger != nil {
+		if msg := zfsACLWarning(info.Rootless, pInfo.Store.GraphDriverName, pInfo.Store.GraphStatus.BackingFilesystem); msg != "" {
+			logger.Warn(msg)
 		}
 	}
 	return info, nil

--- a/pkg/cluster/internal/providers/podman/provider.go
+++ b/pkg/cluster/internal/providers/podman/provider.go
@@ -389,18 +389,16 @@ type podmanInfo struct {
 			Rootless bool `json:"rootless,omitempty"`
 		} `json:"security"`
 	} `json:"host"`
-	Store struct {
-		GraphDriverName string `json:"graphDriverName,omitempty"`
-		GraphStatus     struct {
-			BackingFilesystem string `json:"Backing Filesystem,omitempty"`
-		} `json:"graphStatus"`
-	} `json:"store"`
+	podmanStorageInfo
 }
 
 // zfsACLWarning returns a non-empty warning message if rootless is true and
-// the storage driver or backing filesystem is ZFS, since ZFS does not enable
-// POSIX ACLs by default and rootless podman's fuse-overlayfs snapshotter
-// requires them, which can cause node containers to fail with
+// the storage driver or backing filesystem is ZFS. `podman info` does not
+// report the ZFS dataset's acltype, so this fires even when the dataset
+// already has POSIX ACLs enabled (acltype=posix); the warning notes that it
+// can be ignored in that case. With acltype=off (ZFS's default), rootless
+// podman's fuse-overlayfs snapshotter can't expose POSIX ACLs on top of the
+// filesystem, which can cause node containers to fail with
 // "stat /pause: operation not supported".
 // See https://github.com/kubernetes-sigs/kind/issues/4025
 func zfsACLWarning(rootless bool, graphDriverName, backingFilesystem string) string {
@@ -410,10 +408,11 @@ func zfsACLWarning(rootless bool, graphDriverName, backingFilesystem string) str
 	if graphDriverName != "zfs" && backingFilesystem != "zfs" {
 		return ""
 	}
-	return "Podman storage is backed by ZFS, which does not enable POSIX ACLs by default. " +
-		"With rootless Podman this can cause node containers to fail with " +
-		"\"stat /pause: operation not supported\". If cluster creation fails, try enabling ACLs " +
-		"on the backing ZFS dataset (zfs set acltype=posix <dataset>) and re-pulling the node image. " +
+	return "Podman storage is backed by ZFS. With rootless Podman and a ZFS dataset that has " +
+		"acltype=off (ZFS's default), POSIX ACLs are unavailable and node containers can fail " +
+		"with \"stat /pause: operation not supported\". If the dataset already has " +
+		"acltype=posix set, this warning can be ignored. Otherwise, try " +
+		"\"zfs set acltype=posix <dataset>\" and re-creating the cluster. " +
 		"See https://github.com/kubernetes-sigs/kind/issues/4025"
 }
 

--- a/pkg/cluster/internal/providers/podman/provider_test.go
+++ b/pkg/cluster/internal/providers/podman/provider_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cluster/internal/providers/podman/provider_test.go
+++ b/pkg/cluster/internal/providers/podman/provider_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podman
+
+import (
+	"testing"
+)
+
+func Test_zfsACLWarning(t *testing.T) {
+	cases := []struct {
+		name              string
+		rootless          bool
+		graphDriverName   string
+		backingFilesystem string
+		wantWarning       bool
+	}{
+		{
+			name:              "rootless with zfs graph driver",
+			rootless:          true,
+			graphDriverName:   "zfs",
+			backingFilesystem: "",
+			wantWarning:       true,
+		},
+		{
+			name:              "rootless with zfs backing filesystem",
+			rootless:          true,
+			graphDriverName:   "overlay",
+			backingFilesystem: "zfs",
+			wantWarning:       true,
+		},
+		{
+			name:              "rootless with non-zfs storage",
+			rootless:          true,
+			graphDriverName:   "overlay",
+			backingFilesystem: "extfs",
+			wantWarning:       false,
+		},
+		{
+			name:              "rootful with zfs storage",
+			rootless:          false,
+			graphDriverName:   "zfs",
+			backingFilesystem: "",
+			wantWarning:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc // capture variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			msg := zfsACLWarning(tc.rootless, tc.graphDriverName, tc.backingFilesystem)
+			if tc.wantWarning && msg == "" {
+				t.Errorf("expected a warning, got none")
+			}
+			if !tc.wantWarning && msg != "" {
+				t.Errorf("expected no warning, got: %q", msg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Motivation:
Rootless podman uses fuse-overlayfs as its snapshotter. If the podman
storage graph root is backed by ZFS with acltype=off (ZFS's default),
fuse-overlayfs's attempt to expose POSIX ACLs on top of that
filesystem fails, and kind's control-plane node container can fail to
start nested containers with an error like "stat /pause: operation
not supported", eventually causing `kind create cluster` to time out
waiting for the apiserver. This was root-caused in the issue thread:
the ZFS dataset needs `acltype=posix` for rootless podman to work with
kind. Rootful podman is not affected, since it uses the kernel's
native overlayfs instead of fuse-overlayfs.

A maintainer suggested in the issue thread that an automatic warning
based on `podman info` output would be a reasonable low-effort
mitigation, in lieu of a real fix (which belongs upstream in
containerd/fuse-overlayfs).

Approach:
`pkg/cluster/internal/providers/podman/provider.go`'s `info()` already
shells out to `podman info --format json` once per provider instance
(cached on the provider) to build `ProviderInfo`, and already prints a
similar best-effort `logger.Warn` for an unrelated rootless/cgroup gap
in the same function. This change adds a `Store` field to the existing
JSON-unmarshal struct (mirroring the `podmanStorageInfo` struct
already used by `mountDevMapper` in `util.go` for the same `podman
info` output) and a small pure function, `zfsACLWarning`, that returns
a warning message when podman is rootless and either the storage
driver or backing filesystem is ZFS. If cluster creation later fails,
the user has already seen a hint on how to fix their host, without any
change to node provisioning behavior.

This does not fix the underlying failure and does not change cluster
creation behavior; the warning is only printed once, up front, and is
silent for all other configurations, including rootful podman on ZFS
and rootless podman with acltype=posix already set (kind creation
already succeeds for both of those today).

Validation:
go build ./...
go test ./pkg/cluster/internal/providers/podman/...
Both pass. Added `Test_zfsACLWarning` table test covering: rootless
with zfs storage driver, rootless with zfs backing filesystem,
rootless with a non-zfs filesystem (no warning), and rootful with zfs
storage (no warning, since rootful uses native overlayfs and is
unaffected).

Fixes #4025

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>