### PR TITLE
Fix index-out-of-range panic parsing docker info DriverStatus

### DIFF
--- a/pkg/cluster/internal/providers/docker/util.go
+++ b/pkg/cluster/internal/providers/docker/util.go
@@ -82,14 +82,23 @@ func mountDevMapper() bool {
 	if err := json.Unmarshal([]byte(lines[0]), &dat); err != nil {
 		return false
 	}
-	for _, item := range dat {
-		if item[0] == "Backing Filesystem" {
-			storage = strings.ToLower(item[1])
-			break
-		}
-	}
+	storage = backingFilesystem(dat)
 
 	return storage == "btrfs" || storage == "zfs" || storage == "xfs"
+}
+
+// backingFilesystem returns the lowercased "Backing Filesystem" value from
+// docker's `DriverStatus` pairs, e.g. [["Backing Filesystem","extfs"], ...].
+// DriverStatus entries are not guaranteed to have exactly 2 elements across
+// docker versions/storage drivers, so malformed entries are skipped instead
+// of indexed directly.
+func backingFilesystem(driverStatus [][]string) string {
+	for _, item := range driverStatus {
+		if len(item) == 2 && item[0] == "Backing Filesystem" {
+			return strings.ToLower(item[1])
+		}
+	}
+	return ""
 }
 
 // rootless: use fuse-overlayfs by default

--- a/pkg/cluster/internal/providers/docker/util_test.go
+++ b/pkg/cluster/internal/providers/docker/util_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import "testing"
+
+func TestBackingFilesystem(t *testing.T) {
+	cases := []struct {
+		name         string
+		driverStatus [][]string
+		want         string
+	}{
+		{
+			name: "normal docker info output",
+			driverStatus: [][]string{
+				{"Backing Filesystem", "extfs"},
+				{"Supports d_type", "true"},
+				{"Native Overlay Diff", "true"},
+			},
+			want: "extfs",
+		},
+		{
+			name: "lowercases the value",
+			driverStatus: [][]string{
+				{"Backing Filesystem", "XFS"},
+			},
+			want: "xfs",
+		},
+		{
+			name: "no matching entry",
+			driverStatus: [][]string{
+				{"Supports d_type", "true"},
+			},
+			want: "",
+		},
+		{
+			name:         "empty input",
+			driverStatus: [][]string{},
+			want:         "",
+		},
+		{
+			name: "malformed single-element entry is skipped, not indexed",
+			driverStatus: [][]string{
+				{"Backing Filesystem"},
+			},
+			want: "",
+		},
+		{
+			name: "malformed empty entry is skipped, not indexed",
+			driverStatus: [][]string{
+				{},
+				{"Backing Filesystem", "btrfs"},
+			},
+			want: "btrfs",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := backingFilesystem(tc.driverStatus); got != tc.want {
+				t.Errorf("backingFilesystem(%v) = %q, want %q", tc.driverStatus, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`mountDevMapper()` in `pkg/cluster/internal/providers/docker/util.go` parses `docker info -f '{{json .DriverStatus }}'` output into a `[][]string` and indexed `item[0]`/`item[1]` with no length check. Docker's `DriverStatus` is a list of `[key, value]` pairs, but nothing guarantees every entry has exactly 2 elements across docker versions and storage drivers the podman
provider in this same repo already had to work around an analogous "output format changed between versions" issue on its own storage-info parsing (it now unmarshals into a typed struct instead of raw arrays).

This function runs unconditionally as part of building docker run args for  every node container on every `kind create cluster` call with the docker provider (the default provider), via `commonArgs` in `provision.go`. A single malformed `DriverStatus` entry would panic the whole CLI mid cluster-creation instead of just skipping that entry.

## What this PR does

Extracts the pair-walking loop into a small pure helper, `backingFilesystem`, that skips entries without exactly 2 elements instead of indexing them directly. Extracting it into its own function was necessary to get real unit test coverage without faking the `docker info` exec call `mountDevMapper` itself isn't practical to unit test directly since it shells out to `docker`.

Adds `util_test.go` the first tests this file has ever had covering the normal case, the no-match case, and the two malformed shapes that would have panicked before this fix (single-element entry, empty entry).

## Testing

- `go test ./pkg/cluster/internal/providers/docker/...` passes.
- Confirmed the malformed-entry test cases actually reproduce the original panic: temporarily removed the length guard locally and got the exact  `index out of range [1] with length 1` panic out of `mountDevMapper`'s real code path, then restored the guard and reran green.
- `golangci-lint run` (pinned v2.11.3, repo config at   `hack/tools/.golangci.yml`) reports 0 issues on the changed package.

No associated issue found while reading the docker-provider provisioning path for real, self-contained bugs. Happy to file one if a maintainer would prefer it tracked separately.
