### PR TITLE
Render framed_picture emoji like other emojis

### DIFF
--- a/pkg/cluster/internal/providers/docker/images.go
+++ b/pkg/cluster/internal/providers/docker/images.go
@@ -37,7 +37,7 @@ func ensureNodeImages(logger log.Logger, status *cli.Status, cfg *config.Cluster
 	for _, image := range common.RequiredNodeImages(cfg).List() {
 		// prints user friendly message
 		friendlyImageName, image := sanitizeImage(image)
-		status.Start(fmt.Sprintf("Ensuring node image (%s) 🖼", friendlyImageName))
+		status.Start(fmt.Sprintf("Ensuring node image (%s) 🖼️", friendlyImageName))
 		if _, err := pullIfNotPresent(logger, image, 4); err != nil {
 			status.End(false)
 			return err

--- a/pkg/cluster/internal/providers/nerdctl/images.go
+++ b/pkg/cluster/internal/providers/nerdctl/images.go
@@ -37,7 +37,7 @@ func ensureNodeImages(logger log.Logger, status *cli.Status, cfg *config.Cluster
 	for _, image := range common.RequiredNodeImages(cfg).List() {
 		// prints user friendly message
 		friendlyImageName, image := sanitizeImage(image)
-		status.Start(fmt.Sprintf("Ensuring node image (%s) 🖼", friendlyImageName))
+		status.Start(fmt.Sprintf("Ensuring node image (%s) 🖼️", friendlyImageName))
 		if _, err := pullIfNotPresent(logger, image, 4, binaryName); err != nil {
 			status.End(false)
 			return err

--- a/pkg/cluster/internal/providers/podman/images.go
+++ b/pkg/cluster/internal/providers/podman/images.go
@@ -37,7 +37,7 @@ func ensureNodeImages(logger log.Logger, status *cli.Status, cfg *config.Cluster
 	for _, image := range common.RequiredNodeImages(cfg).List() {
 		// prints user friendly message
 		friendlyImageName, image := sanitizeImage(image)
-		status.Start(fmt.Sprintf("Ensuring node image (%s) 🖼", friendlyImageName))
+		status.Start(fmt.Sprintf("Ensuring node image (%s) 🖼️", friendlyImageName))
 		if _, err := pullIfNotPresent(logger, image, 4); err != nil {
 			status.End(false)
 			return err


### PR DESCRIPTION
Purely cosmetic change :nail_care: 

For reasons I ignore, a handful of emojis like `U+1F5BC` (FRAME WITH PICTURE) and `U+1F579` (JOYSTICK) render as a monochrome outline unless the variation selector `U+FE0F` (VS16) is appended to them.

The "JOYSTICK" emoji character printed by kind currently has this variation selector, but the "FRAME WITH PICTURE" emoji character doesn't, leading to some inconsistent visuals in certain combinations of terminal emulator + emoji font.

Below is an example in the Ghostty 1.3.1 terminal emulator + the "Noto Color Emoji" 2.051 font family:

<img width="514" height="202" alt="kind emoje outline" src="https://github.com/user-attachments/assets/cec1adf6-458e-4dac-b855-360c09a3dff4" />