### PR TITLE
docs: Update CNCF link for certified kind installer on homepage

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -83,7 +83,7 @@ See also: our own [contributor guide] and the Kubernetes [community page].
 - kind supports building Kubernetes release builds from source
   - support for make / bash or docker, in addition to pre-published builds
 - kind supports Linux, macOS and Windows
-- kind is a [CNCF certified conformant Kubernetes installer](https://landscape.cncf.io/?selected=kind)
+- kind is a [CNCF certified conformant Kubernetes installer](https://landscape.cncf.io/?group=projects-and-products&item=platform--certified-kubernetes-installer--kind)
 
 ### Code of conduct
 


### PR DESCRIPTION
The current link on the hompage to the "[CNCF certified conformant Kubernetes installer](https://landscape.cncf.io/?selected=kind)" `https://landscape.cncf.io/?selected=kind` seems to show the whole landscape without actually selecting kind.
This PR updates the link so that kind is selected. Please not that I'm not sure whether this was the intended content to be shown by the original link, so please check whether the link shows the desired page.