### PR TITLE
Bump to containerd v2.3.4 and runc v1.4.3

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -124,7 +124,7 @@ RUN eval "$(gimme "${GO_VERSION}")" \
 # stage for building containerd
 FROM go-build AS build-containerd
 ARG TARGETARCH GO_VERSION
-ARG CONTAINERD_VERSION="v2.3.1"
+ARG CONTAINERD_VERSION="v2.3.4"
 ARG CONTAINERD_CLONE_URL="https://github.com/containerd/containerd"
 # we don't build with optional snapshotters, we never select any of these
 # they're not ideal inside kind anyhow, and we save some disk space
@@ -142,7 +142,7 @@ RUN git clone --filter=tree:0 "${CONTAINERD_CLONE_URL}" /containerd \
 # stage for building runc
 FROM go-build AS build-runc
 ARG TARGETARCH GO_VERSION
-ARG RUNC_VERSION="v1.4.2"
+ARG RUNC_VERSION="v1.4.3"
 ARG RUNC_CLONE_URL="https://github.com/opencontainers/runc"
 RUN git clone --filter=tree:0 "${RUNC_CLONE_URL}" /runc \
     && cd /runc \


### PR DESCRIPTION
Picks up containerd v2.3.4 (and the runc version containerd [qualified with at that revision](https://github.com/containerd/containerd/blob/v2.3.4/script/setup/runc-version))

This includes https://github.com/containerd/containerd/pull/13454 which picks up the fix for https://github.com/kubernetes/kubernetes/issues/139132

/cc @BenTheElder 