### PR TITLE
Detect images already loaded with the containerd image store

### DIFF
--- a/pkg/cluster/nodeutils/util.go
+++ b/pkg/cluster/nodeutils/util.go
@@ -143,6 +143,33 @@ func ImageID(n nodes.Node, image string) (string, error) {
 	return crictlOut.Status.ID, nil
 }
 
+// ImageDigest returns the digest of the target descriptor (image manifest or
+// image index) recorded by containerd on the node for the given image
+// reference, if present.
+//
+// This is distinct from ImageID: CRI identifies an image by its config digest,
+// while containerd identifies it by the digest of the target descriptor.
+// Docker reports the former as the image ID with the classic image store and
+// the latter with the containerd image store, so both are needed to reliably
+// recognize an image that is already present on the node.
+func ImageDigest(n nodes.Node, image string) (string, error) {
+	lines, err := exec.OutputLines(n.Command(
+		"ctr", "--namespace=k8s.io", "images", "ls", "name=="+image,
+	))
+	if err != nil {
+		return "", err
+	}
+	// output is a table with a header row, and at most one row for an exact
+	// name match: REF TYPE DIGEST SIZE PLATFORMS LABELS
+	for _, line := range lines[1:] {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[0] == image {
+			return fields[2], nil
+		}
+	}
+	return "", errors.Errorf("image %q not present on node %q", image, n.String())
+}
+
 // ImageTags is used to perform a reverse lookup of the ImageID to list set of available
 // RepoTags corresponding to the ImageID in question
 func ImageTags(n nodes.Node, imageID string) (map[string]bool, error) {

--- a/pkg/cmd/kind/load/docker-image/docker-image.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image.go
@@ -39,7 +39,9 @@ import (
 )
 
 type (
-	imageTagFetcher func(nodes.Node, string) (map[string]bool, error)
+	imageTagFetcher    func(nodes.Node, string) (map[string]bool, error)
+	imageIDFetcher     func(nodes.Node, string) (string, error)
+	imageDigestFetcher func(nodes.Node, string) (string, error)
 )
 
 type flagpole struct {
@@ -153,8 +155,7 @@ func runE(logger log.Logger, flags *flagpole, args []string) error {
 				}
 				continue
 			}
-			id, err := nodeutils.ImageID(node, imageName)
-			if err != nil || id != imageID {
+			if !imagePresentOnNode(node, imageName, imageID, nodeutils.ImageID, nodeutils.ImageDigest) {
 				selectedNodes[node.String()] = node
 				logger.V(0).Infof("Image: %q with ID %q not yet present on node %q, loading...", imageName, imageID, node.String())
 			}
@@ -238,6 +239,25 @@ func removeDuplicates(slice []string) []string {
 		}
 	}
 	return result
+}
+
+// imagePresentOnNode reports whether the node already holds the image content
+// identified by imageID under imageName.
+//
+// imageID comes from `docker image inspect`, which does not always report the
+// same kind of digest: the classic image store reports the image config
+// digest, while the containerd image store reports the digest of the target
+// descriptor (image manifest or image index). CRI only ever reports the config
+// digest, so comparing against it alone means images loaded from a
+// containerd-backed Docker are never recognized and get re-loaded on every
+// invocation. Containerd on the node records the target digest, so checking
+// both covers either image store.
+func imagePresentOnNode(node nodes.Node, imageName, imageID string, idFetcher imageIDFetcher, digestFetcher imageDigestFetcher) bool {
+	if id, err := idFetcher(node, imageName); err == nil && id == imageID {
+		return true
+	}
+	digest, err := digestFetcher(node, sanitizeImage(imageName))
+	return err == nil && digest == imageID
 }
 
 // checkIfImageExists makes sure we only perform the reverse lookup of the ImageID to tag map

--- a/pkg/cmd/kind/load/docker-image/docker-image_test.go
+++ b/pkg/cmd/kind/load/docker-image/docker-image_test.go
@@ -206,3 +206,80 @@ func Test_checkIfImageReTagRequired(t *testing.T) {
 		})
 	}
 }
+
+func Test_imagePresentOnNode(t *testing.T) {
+	const (
+		configDigest = "sha256:5a13d892fcdce272129e6e395d8fe5baa9532e61569c5a150e600589e81fd0a8"
+		targetDigest = "sha256:b8d31d6ecf8e6a63a9cfa29c13e45e3c00a0d7fef86f59457aa8d76a812a461f"
+	)
+	notPresent := errors.New("no such image")
+
+	tests := []struct {
+		name          string
+		imageID       string
+		nodeID        string
+		nodeIDErr     error
+		nodeDigest    string
+		nodeDigestErr error
+		want          bool
+	}{
+		{
+			// docker with the classic image store reports the config digest
+			name:       "config digest matches",
+			imageID:    configDigest,
+			nodeID:     configDigest,
+			nodeDigest: targetDigest,
+			want:       true,
+		},
+		{
+			// docker with the containerd image store reports the target digest
+			name:       "target digest matches",
+			imageID:    targetDigest,
+			nodeID:     configDigest,
+			nodeDigest: targetDigest,
+			want:       true,
+		},
+		{
+			// the tag exists on the node but points at different content
+			name:       "image on node is stale",
+			imageID:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			nodeID:     configDigest,
+			nodeDigest: targetDigest,
+			want:       false,
+		},
+		{
+			name:          "image not present on node",
+			imageID:       targetDigest,
+			nodeIDErr:     notPresent,
+			nodeDigestErr: notPresent,
+			want:          false,
+		},
+		{
+			// CRI cannot resolve a target digest, the containerd lookup still can
+			name:       "cri lookup fails but target digest matches",
+			imageID:    targetDigest,
+			nodeIDErr:  notPresent,
+			nodeDigest: targetDigest,
+			want:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// imagePresentOnNode only passes nodes.Node through to the fetchers,
+			// which are stubbed out here, so a nil node is fine
+			got := imagePresentOnNode(nil, "image1:tag1", tc.imageID,
+				func(nodes.Node, string) (string, error) {
+					return tc.nodeID, tc.nodeIDErr
+				},
+				func(nodes.Node, string) (string, error) {
+					return tc.nodeDigest, tc.nodeDigestErr
+				},
+			)
+			if got != tc.want {
+				t.Errorf("imagePresentOnNode() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4236

**What this fixes**

`docker image inspect -f '{{.Id}}'` does not always report the same kind of digest:

| Docker image store | `.Id` |
|---|---|
| classic (`overlay2`) | image **config** digest |
| containerd | digest of the **target descriptor** (manifest or index) |

`crictl inspecti` on the node only ever reports the config digest, so with the containerd image store the presence check compared two different objects and could never match. Every `kind load docker-image` re-transferred an image that was already on the node, correctly tagged and resolvable through CRI.

**Approach**

Containerd on the node records the target digest, and it matches what Docker reports with the containerd image store:

| image | host `docker .Id` | node `crictl status.id` | node `ctr images ls` DIGEST |
|---|---|---|---|
| single manifest | `b8d31d6e` | `5a13d892` | `b8d31d6e` |
| manifest list | `c510f0be` | `d54c4719` | `c510f0be` |

`imagePresentOnNode` now accepts a match on either the config digest (CRI) or the target digest (containerd). This needs no `docker info` probe or version branching, and cannot produce a false positive since both values are content-addressed digests that uniquely identify image content.

The CRI lookup is tried first, so with the classic image store the check returns on the first match exactly as before.

**Verified manually** on macOS/arm64, Docker 28.3.2 with the containerd image store:

| Case | Before | After |
|---|---|---|
| single-manifest image, repeated load | reloads every time | already present |
| manifest-list image, repeated load | reloads every time | already present |
| image rebuilt with new content, same tag | reloads | reloads |
| image not on node | loads | loads |

Unit tests cover both image stores, a stale image on the node, and absence.

**Out of scope**

`checkIfImageReTagRequired` looks up tags via `crictl inspecti <imageID>`, which also cannot resolve a target digest. Correctness is unaffected — it falls through to the check above — but the re-tag optimization is still unavailable with the containerd image store. Happy to address it here or in a follow-up, whichever you prefer.

**Note on testing**

kind's CI runs the classic image store, where this bug is not observable, so there is no e2e coverage for the fix. Let me know if adding a job with `containerd-snapshotter` enabled is worth doing.

```release-note
Fix `kind load docker-image` repeatedly reloading images that are already present on the node when Docker uses the containerd image store
```
