### PR TITLE
update go-based images

### DIFF
--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -20,7 +20,7 @@ package nodeimage
 The default CNI manifest and images are our own tiny kindnet
 */
 
-const kindnetdImage = "docker.io/kindest/kindnetd:v20260528-9350166c"
+const kindnetdImage = "docker.io/kindest/kindnetd:v20260820-69b56db7"
 
 var defaultCNIImages = []string{kindnetdImage}
 

--- a/pkg/build/nodeimage/const_storage.go
+++ b/pkg/build/nodeimage/const_storage.go
@@ -26,7 +26,7 @@ NOTE: we have customized it in the following ways:
 - tolerate control plane scheduling taints
 */
 
-const storageProvisionerImage = "docker.io/kindest/local-path-provisioner:v20260521-9fb22683"
+const storageProvisionerImage = "docker.io/kindest/local-path-provisioner:v20260820-69b56db7"
 const storageHelperImage = "docker.io/kindest/local-path-helper:v20260131-7181c60a"
 
 // image we need to preload

--- a/pkg/build/nodeimage/defaults.go
+++ b/pkg/build/nodeimage/defaults.go
@@ -22,4 +22,4 @@ const DefaultImage = "kindest/node:latest"
 // DefaultBaseImage is the default base image used
 // TODO: come up with a reasonable solution to digest pinning
 // https://github.com/moby/moby/issues/43188
-const DefaultBaseImage = "docker.io/kindest/base:v20260601-995e8fa5"
+const DefaultBaseImage = "docker.io/kindest/base:v20260820-69b56db7"


### PR DESCRIPTION
picks up #4239 and #4237 

NOTE: no new node image yet.