### PR TITLE
docs: document kernel keyring quota limit for rootless podman

### DIFF
--- a/site/content/docs/user/rootless.md
+++ b/site/content/docs/user/rootless.md
@@ -171,6 +171,55 @@ To increase the inotify limits, do the following:
 
 Alternatively, restart your system for these changes to take effect.
 
+### Increase Keyring Limits
+
+When using kind with rootless Podman, you may hit the following error while
+creating a cluster:
+
+```
+could not create session key: disk quota exceeded
+```
+
+This happens because the default kernel keyring limits are too low for kind's
+usage pattern. Podman creates one keyring per container, and kind nodes run via
+runc which also creates at least one keyring per container
+(see [opencontainers/runc#582](https://github.com/opencontainers/runc/pull/582)).
+The default limits (200 keys and 20000 bytes) are exhausted quickly, especially
+on Debian and Red Hat family distributions.
+
+You can list the existing keys to verify the issue with:
+
+```sh
+cat /proc/keys
+```
+
+To increase the keyring limits temporarily, run:
+
+```sh
+sudo sysctl -w kernel.keys.maxkeys=20000
+sudo sysctl -w kernel.keys.maxbytes=500000
+```
+
+To make the change persistent, create a sysctl configuration file:
+
+```sh
+cat <<EOF | sudo tee /etc/sysctl.d/01-keys.conf
+# See https://github.com/moby/moby/issues/22865
+# Default maxkeys: 200
+kernel.keys.maxkeys = 20000
+# Default maxbytes: 20000
+kernel.keys.maxbytes = 500000
+EOF
+```
+
+Then reload `sysctl` for the changes to take effect:
+
+```sh
+sudo sysctl --system
+```
+
+Alternatively, restart your system to ensure these changes take effect.
+
 ### Allow Binding to Privileged Ports
 
 If you use the `extraPortMappings` method to provide ingress to your KIND cluster, you can allow


### PR DESCRIPTION
What type of PR is this?
/kind documentation
/area docs

What this PR does / why we need it:
Documents the `could not create session key: disk quota exceeded` error that can occur when running kind with rootless Podman, and the workaround of raising the kernel keyring limits (`kernel.keys.maxkeys` / `kernel.keys.maxbytes`).

This adds a new **Increase Keyring Limits** section to the rootless docs, following the pattern of the existing `Increase PID Limits` / `Increase inotify Limits` / `Allow Binding to Privileged Ports` subsections.

Which issue(s) this PR fixes:
Closes #3806

Special notes for your reviewer:
Per the discussion on #3806 (feedback from @BenTheElder and @stmcginnis), this content belongs on the dedicated rootless page rather than the general known-issues page. The earlier attempt in #4116 placed it in known-issues.md; this PR addresses that feedback by documenting it in `site/content/docs/user/rootless.md` instead. Happy to also add a short cross-link from known-issues.md if that is preferred.

Release note:
```release-note
NONE
```