### PR TITLE
base image: remove LimitNOFILE=infinity from containerd.service

### DIFF
--- a/images/base/files/etc/systemd/system/containerd.service
+++ b/images/base/files/etc/systemd/system/containerd.service
@@ -20,7 +20,13 @@ RestartSec=1
 # in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
-LimitNOFILE=infinity
+# LimitNOFILE is intentionally left unset (upstream removed LimitNOFILE=infinity
+# in containerd/containerd@3ca39ef01608). Resolving to "infinity" can inherit an
+# unexpectedly large fs.nr_open value from the host/OS on newer systemd releases,
+# which containerd's child processes (i.e. containers) then also inherit unless
+# they set their own limits, causing slow startup for apps that iterate over the
+# open file descriptor range.
+# https://github.com/kubernetes-sigs/kind/issues/4244
 TasksMax=infinity
 OOMScoreAdjust=-999
 


### PR DESCRIPTION
Motivation:
Since the base image moved from Debian bookworm to trixie, node images have shipped a systemd build with the newer default behavior of unconditionally bumping the fs.nr_open sysctl to its maximum value on boot. containerd.service set LimitNOFILE=infinity, which resolves against fs.nr_open at unit start, so containerd's own NOFILE hard limit is now an extremely large number on trixie-based nodes. Any container whose spec does not set its own rlimits inherits this huge NOFILE from containerd's process limits chain (containerd -> shim -> runc -> container init). Applications that iterate the open file descriptor range at startup (e.g. wodby/varnish:6, as reported in the issue) become very slow to start as a result.

Approach:
Remove the LimitNOFILE=infinity line from containerd.service, leaving LimitNOFILE unset so systemd falls back to its own implicit default, decoupling containerd from whatever value fs.nr_open happens to be bumped to at boot. A comment is added in its place explaining the removal, referencing upstream containerd's identical fix in commit 3ca39ef01608fdd44245c0173bf071682b3bfe3c ("fix: Remove LimitNOFILE from containerd.service") and linking the issue.

Report: https://github.com/kubernetes-sigs/kind/issues/4244
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)