### PR TITLE
Fix terminal detection: Cygwin/MSYS support and empty NO_COLOR

### DIFF
--- a/pkg/internal/env/term.go
+++ b/pkg/internal/env/term.go
@@ -64,7 +64,7 @@ func isSmartTerminal(w io.Writer, GOOS string, lookupEnv func(string) (string, b
 
 	// Explicit request for no ANSI escape codes
 	// https://no-color.org/
-	if _, set := lookupEnv("NO_COLOR"); set {
+	if val, set := lookupEnv("NO_COLOR"); set && val != "" {
 		return false
 	}
 

--- a/pkg/internal/env/term_test.go
+++ b/pkg/internal/env/term_test.go
@@ -99,9 +99,20 @@ func TestIsSmartTerminal(t *testing.T) {
 			Writer:  &testFakeTTY{},
 		},
 		{
+			// https://no-color.org/ only disables color when NO_COLOR is
+			// set to a non-empty value.
 			Name: "tty, NO_COLOR=",
 			FakeEnv: map[string]string{
 				"NO_COLOR": "",
+			},
+			GOOS:    "linux",
+			IsSmart: true,
+			Writer:  &testFakeTTY{},
+		},
+		{
+			Name: "tty, NO_COLOR=1",
+			FakeEnv: map[string]string{
+				"NO_COLOR": "1",
 			},
 			GOOS:    "linux",
 			IsSmart: false,


### PR DESCRIPTION
Motivation:

pkg/internal/env/term.go's isSmartTerminal disabled smart-terminal/color
output whenever NO_COLOR was set to any value, including an empty
string. Per the NO_COLOR spec (https://no-color.org/), color should
only be disabled when NO_COLOR is present with a non-empty value.

Approach:

- isSmartTerminal's NO_COLOR check now requires a non-empty value
  before disabling smart-terminal features.
- Updated the table-driven test in term_test.go: the existing
  "tty, NO_COLOR=" case now expects IsSmart=true, and a new
  "tty, NO_COLOR=1" case keeps the disable path covered.

Scope note: this PR originally also proposed using
isatty.IsCygwinTerminal to detect Cygwin/MSYS terminals (e.g. Git
Bash) in IsTerminal. @BenTheElder flagged that changing Windows
terminal-detection behavior without local interactive testing on
those environments is risky, since kind's "smart" output relies on
VT escape codes for things like spinner line-rewriting that may not
render well everywhere. That's a fair concern I can't verify without
a Windows/Cygwin/MSYS environment to test in, so I've dropped that
part from this PR and kept only the NO_COLOR fix, which is narrower
and was already confirmed reasonable. The Cygwin/MSYS detection
improvement is still worth pursuing separately, ideally by someone
who can test it interactively on Windows (the original issue
reporter had expressed interest in taking it on).

Validation:

- go build ./... succeeds.
- go vet ./pkg/internal/env/... is clean.
- golangci-lint --config hack/tools/.golangci.yml run
  ./pkg/internal/env/... reports 0 issues.
- go test ./pkg/internal/env/... -v -cover passes all tests
  (91.7% coverage).
- Confirmed fail-then-pass: with only the source fix reverted (test
  change kept), "tty, NO_COLOR=" failed (expected true, got false);
  restoring the fix makes it pass.

Report: https://github.com/kubernetes-sigs/kind/issues/4256

This PR now only addresses the NO_COLOR part of #4256; the
Cygwin/MSYS detection issue described there remains open.

```release-note
Fix terminal detection: NO_COLOR is now only treated as set when it has a non-empty value, per the NO_COLOR spec.
```
