### PR TITLE
e2e-k8s.sh: fix CoreDNS forward removal for block-form Corefile

### DIFF
--- a/hack/ci/e2e-k8s.sh
+++ b/hack/ci/e2e-k8s.sh
@@ -231,6 +231,7 @@ run_tests() {
         -e '/^.*upstream$/d' \
         -e '/^.*fallthrough.*$/d' \
         -e '/^.*forward . \/etc\/resolv.conf$/d' \
+        -e '/^.*forward . \/etc\/resolv.conf {$/,/^.*}$/d' \
         -e '/^.*loop$/d' \
     )
     echo "Patched CoreDNS config:"


### PR DESCRIPTION
Fixes #4258

The IPv6 lane patches CoreDNS to run offline (k8s CI has no IPv6 connectivity), but the sed that deletes `forward . /etc/resolv.conf` is anchored to end-of-line and has not matched since kubeadm started rendering the directive as a block (`forward . /etc/resolv.conf { max_concurrent 1000 }`, v1.19+). Forwarding is silently left in the Corefile; external lookups fail with SERVFAIL after CoreDNS tries to dial the node's IPv4 resolver from an IPv6-only pod:

```
[ERROR] plugin/errors: 2 ... AAAA: dial udp 172.18.0.1:53: connect: network is unreachable
```

(observed in `ci-kubernetes-kind-conformance-parallel-ipv6` build `2095337737790951424`; the build log's "Patched CoreDNS config:" output still shows the forward block — see #4258 for full evidence and reproduction steps).

This adds a range expression that removes the block form and keeps the original single-line expression for older Corefiles:

```diff
         -e '/^.*forward . \/etc\/resolv.conf$/d' \
+        -e '/^.*forward . \/etc\/resolv.conf {$/,/^.*}$/d' \
         -e '/^.*loop$/d' \
```

Verified against both Corefile forms: the block (opening line, `max_concurrent`, closing brace) is removed, and adjacent blocks (`cache 30 { ... }`, the outer server block) are untouched.

**How to verify after merge** — once a run of the hourly `ci-kubernetes-kind-conformance-parallel-ipv6` periodic picks up the change:

```sh
JOB=ci-kubernetes-kind-conformance-parallel-ipv6
BASE=https://storage.googleapis.com/kubernetes-ci-logs/logs/$JOB
BUILD=$(curl -s $BASE/latest-build.txt)
curl -s $BASE/$BUILD/build-log.txt | sed -n '/Patched CoreDNS config:/,/loadbalance/p'
```

Expected: no `forward` in the patched Corefile, and the coredns container log artifact free of `network is unreachable` forward errors.

🤖 Generated with AI
